### PR TITLE
caches cors preflight request for 10 min

### DIFF
--- a/pkg/api/rest/configure_kubernikus.go
+++ b/pkg/api/rest/configure_kubernikus.go
@@ -86,6 +86,7 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedHeaders: []string{"X-Auth-Token", "Content-Type", "Accept"},
 		AllowedMethods: []string{"GET", "HEAD", "POST", "DELETE", "PUT"},
+		MaxAge: 600,
 	})
 	return gmiddleware.LoggingHandler(os.Stdout, handlers.RootHandler(c.Handler(handler)))
 }


### PR DESCRIPTION
Cache the result of the preflight request for 10 minutes so the browser doesn't do a preflight request every time. This'll speed up the api calls since it won't do two requests every time.