### PR TITLE
Expose service and cluster CIDR in the api

### DIFF
--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -44,8 +44,10 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 	}
 
 	kluster, err := kubernikus.NewKlusterFactory().KlusterFor(v1.KlusterSpec{
-		Name:      name,
-		NodePools: nodePools,
+		Name:        name,
+		ServiceCIDR: params.Body.Spec.ServiceCIDR,
+		ClusterCIDR: params.Body.Spec.ClusterCIDR,
+		NodePools:   nodePools,
 	})
 
 	kluster.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -71,7 +71,9 @@ func clusterModelFromCRD(k *v1.Kluster) *models.Cluster {
 	return &models.Cluster{
 		Name: swag.String(k.Spec.Name),
 		Spec: models.ClusterSpec{
-			NodePools: clusterSpecNodePoolItemsFromCRD(k),
+			ServiceCIDR: k.Spec.ServiceCIDR,
+			ClusterCIDR: k.Spec.ClusterCIDR,
+			NodePools:   clusterSpecNodePoolItemsFromCRD(k),
 		},
 		Status: &models.ClusterStatus{
 			Kluster: &models.ClusterStatusKluster{

--- a/pkg/api/models/cluster.go
+++ b/pkg/api/models/cluster.go
@@ -126,15 +126,33 @@ func (m *Cluster) UnmarshalBinary(b []byte) error {
 // swagger:model ClusterSpec
 type ClusterSpec struct {
 
+	// CIDR Range for Pods in the cluster. Can not be updated.
+	// Pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+	ClusterCIDR string `json:"clusterCIDR,omitempty"`
+
 	// node pools
 	NodePools []*ClusterSpecNodePoolsItems0 `json:"nodePools"`
+
+	// CIDR Range for Services in the cluster. Can not be updated.
+	// Pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+	ServiceCIDR string `json:"serviceCIDR,omitempty"`
 }
 
 // Validate validates this cluster spec
 func (m *ClusterSpec) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateClusterCIDR(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateNodePools(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceCIDR(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -142,6 +160,19 @@ func (m *ClusterSpec) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ClusterSpec) validateClusterCIDR(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ClusterCIDR) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("spec"+"."+"clusterCIDR", "body", string(m.ClusterCIDR), `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$`); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -167,6 +198,19 @@ func (m *ClusterSpec) validateNodePools(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *ClusterSpec) validateServiceCIDR(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ServiceCIDR) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("spec"+"."+"serviceCIDR", "body", string(m.ServiceCIDR), `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$`); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/api/rest/embedded_spec.go
+++ b/pkg/api/rest/embedded_spec.go
@@ -285,6 +285,13 @@ func init() {
         "spec": {
           "type": "object",
           "properties": {
+            "clusterCIDR": {
+              "description": "CIDR Range for Pods in the cluster. Can not be updated.",
+              "type": "string",
+              "default": "198.19.0.0/16",
+              "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+              "x-nullable": false
+            },
             "nodePools": {
               "type": "array",
               "items": {
@@ -312,6 +319,13 @@ func init() {
                   }
                 }
               }
+            },
+            "serviceCIDR": {
+              "description": "CIDR Range for Services in the cluster. Can not be updated.",
+              "type": "string",
+              "default": "198.18.128.0/17",
+              "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+              "x-nullable": false
             }
           },
           "x-nullable": false

--- a/pkg/client/models/cluster.go
+++ b/pkg/client/models/cluster.go
@@ -126,15 +126,33 @@ func (m *Cluster) UnmarshalBinary(b []byte) error {
 // swagger:model ClusterSpec
 type ClusterSpec struct {
 
+	// CIDR Range for Pods in the cluster. Can not be updated.
+	// Pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+	ClusterCIDR string `json:"clusterCIDR,omitempty"`
+
 	// node pools
 	NodePools []*ClusterSpecNodePoolsItems0 `json:"nodePools"`
+
+	// CIDR Range for Services in the cluster. Can not be updated.
+	// Pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+	ServiceCIDR string `json:"serviceCIDR,omitempty"`
 }
 
 // Validate validates this cluster spec
 func (m *ClusterSpec) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateClusterCIDR(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateNodePools(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceCIDR(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -142,6 +160,19 @@ func (m *ClusterSpec) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ClusterSpec) validateClusterCIDR(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ClusterCIDR) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("spec"+"."+"clusterCIDR", "body", string(m.ClusterCIDR), `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$`); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -167,6 +198,19 @@ func (m *ClusterSpec) validateNodePools(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *ClusterSpec) validateServiceCIDR(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ServiceCIDR) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("spec"+"."+"serviceCIDR", "body", string(m.ServiceCIDR), `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$`); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cmd/kubernikus/seed/dns.go
+++ b/pkg/cmd/kubernikus/seed/dns.go
@@ -1,6 +1,8 @@
 package seed
 
 import (
+	"errors"
+
 	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/controller/ground/bootstrap/dns"
@@ -40,7 +42,6 @@ func NewKubeDNSOptions() *KubeDNSOptions {
 		repository: dns.DEFAULT_REPOSITORY,
 		version:    dns.DEFAULT_VERSION,
 		domain:     dns.DEFAULT_DOMAIN,
-		clusterIP:  dns.DEFAULT_CLUSTER_IP,
 	}
 }
 
@@ -54,6 +55,9 @@ func (o *KubeDNSOptions) BindFlags(flags *pflag.FlagSet) {
 }
 
 func (o *KubeDNSOptions) Validate(c *cobra.Command, args []string) error {
+	if o.clusterIP == "" {
+		return errors.New("--cluster-ip is required")
+	}
 	return nil
 }
 

--- a/pkg/controller/ground/bootstrap/dns/dns.go
+++ b/pkg/controller/ground/bootstrap/dns/dns.go
@@ -21,7 +21,6 @@ const (
 	DEFAULT_REPOSITORY = "gcr.io/google_containers"
 	DEFAULT_VERSION    = "1.14.5"
 	DEFAULT_DOMAIN     = "cluster.local"
-	DEFAULT_CLUSTER_IP = "198.18.254.254"
 )
 
 type DeploymentOptions struct {

--- a/swagger.yml
+++ b/swagger.yml
@@ -207,6 +207,18 @@ definitions:
         type: object
         x-nullable: false
         properties:
+          serviceCIDR:
+            x-nullable: false
+            description: CIDR Range for Services in the cluster. Can not be updated.
+            default: 198.18.128.0/17
+            type: string
+            pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
+          clusterCIDR:
+            x-nullable: false
+            description: CIDR Range for Pods in the cluster. Can not be updated.
+            default: 198.19.0.0/16
+            type: string
+            pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
           nodePools:
             type: array
             items:


### PR DESCRIPTION
This allows users to optionally specify the service and cluster cidr when creating a cluster.
It can’t be changed afterwards.
By default it will still be set to

* service CIDR: `198.18.128.0/17`
* pod CIDR: `198.19.0.0/16`

We need this so we can re-create our parent clusters to avoid routing conflicts with the child clusters.

@SchwarzM Does `kubernikusctl` need changing to support creating a cluster with different CIDRs?