### PR TITLE
Nginx ingress

### DIFF
--- a/charts/kubernikus-system/charts/nginx-ingress/.helmignore
+++ b/charts/kubernikus-system/charts/nginx-ingress/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/kubernikus-system/charts/nginx-ingress/Chart.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/Chart.yaml
@@ -1,0 +1,3 @@
+description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
+name: nginx-ingress
+version: 0.9.0-beta.17

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/NOTES.txt
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/NOTES.txt
@@ -1,0 +1,64 @@
+The nginx-ingress controller has been installed.
+
+{{- if contains "NodePort" .Values.controller.service.type }}
+Get the application URL by running these commands:
+
+{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
+  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
+{{- else }}
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "controller.fullname" . }})
+{{- end }}
+{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
+  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
+{{- else }}
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "controller.fullname" . }})
+{{- end }}
+  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
+
+  echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
+  echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
+{{- else if contains "LoadBalancer" .Values.controller.service.type }}
+It may take a few minutes for the LoadBalancer IP to be available.
+You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "controller.fullname" . }}'
+{{- else if contains "ClusterIP"  .Values.controller.service.type }}
+Get the application URL by running these commands:
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:8080 to access your application."
+{{- end }}
+
+An example Ingress that makes use of the controller:
+
+  apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    annotations:
+      kubernetes.io/ingress.class: nginx
+    name: example
+    namespace: foo
+  spec:
+    rules:
+      - host: www.example.com
+        http:
+          paths:
+            - backend:
+                serviceName: exampleService
+                servicePort: 80
+              path: /
+    # This section is only required if TLS is to be enabled for the Ingress
+    tls:
+        - hosts:
+            - www.example.com
+          secretName: example-tls
+
+If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
+
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: example-tls
+    namespace: foo
+  data:
+    tls.crt: <base64 encoded cert>
+    tls.key: <base64 encoded key>
+  type: kubernetes.io/tls

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "controller.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Construct the path for the publish-service.
+
+By convention this will simply use the <namesapce>/<controller-name> to match the name of the
+service generated.
+
+Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
+
+*/}}
+{{- define "controller.publishServicePath" -}}
+{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "controller.fullname" .) -}}
+{{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
+{{- print $servicePath | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified default backend name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "defaultBackend.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/clusterrole.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+{{- if and .Values.controller.scope.enabled .Values.controller.scope.namespace }}
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - "{{ .Values.controller.scope.namespace }}"
+    verbs:
+      - get
+{{- end }}
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+{{- end -}}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}
+data:
+  enable-vts-status: "{{ .Values.controller.stats.enabled }}"
+  custom-http-errors: 404,500
+{{- if .Values.controller.config }}
+{{ toYaml .Values.controller.config | indent 2 }}
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -1,0 +1,138 @@
+{{- if eq .Values.controller.kind "DaemonSet" }}
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}
+spec:
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
+    {{- if .Values.controller.podAnnotations }}
+{{ toYaml .Values.controller.podAnnotations | indent 8}}
+    {{- end }}
+      labels:
+        app: {{ template "name" . }}
+        component: "{{ .Values.controller.name }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.controller.name }}
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ template "controller.publishServicePath" . }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --election-id={{ .Values.controller.electionID }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --configmap={{ .Release.Namespace }}/{{ template "controller.fullname" . }}
+          {{- else }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "controller.fullname" . }}
+          {{- end }}
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-tcp
+          {{- end }}
+          {{- if .Values.udp }}
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-udp
+          {{- end }}
+          {{- if .Values.controller.scope.enabled }}
+            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+          {{- end }}
+          {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          {{- if .Values.controller.stats.enabled }}
+            - name: stats
+              containerPort: 18080
+              protocol: TCP
+          {{- end }}
+          {{- range $key, $value := .Values.tcp }}
+            - name: "{{ $key }}-tcp"
+              containerPort: {{ $key }}
+              protocol: TCP
+          {{- end }}
+          {{- range $key, $value := .Values.udp }}
+            - name: "{{ $key }}-udp"
+              containerPort: {{ $key }}
+              protocol: UDP
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+          resources:
+{{ toYaml .Values.controller.resources | indent 12 }}
+      {{- if .Values.controller.stats.enabled }}
+        - name: {{ template "name" . }}-{{ .Values.statsExporter.name }}
+          image: "{{ .Values.statsExporter.image.repository }}:{{ .Values.statsExporter.image.tag }}"
+          imagePullPolicy: "{{ .Values.statsExporter.image.pullPolicy }}"
+          env:
+            - name: METRICS_ADDR
+              value: ":9913"
+            - name: METRICS_ENDPOINT
+              value: "{{ .Values.statsExporter.endpoint }}"
+            - name: METRICS_NS
+              value: "{{ .Values.statsExporter.metricsNamespace }}"
+            - name: NGINX_STATUS
+              value: "{{ .Values.statsExporter.statusPage }}"
+          ports:
+            - name: metrics
+              containerPort: 9913
+              protocol: TCP
+          resources:
+{{ toYaml .Values.statsExporter.resources | indent 12 }}
+      {{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
+    {{- if .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      terminationGracePeriodSeconds: 60
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -1,0 +1,139 @@
+{{- if eq .Values.controller.kind "Deployment" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}
+spec:
+  replicas: {{ .Values.controller.replicaCount }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
+      {{- if .Values.controller.podAnnotations }}
+{{ toYaml .Values.controller.podAnnotations | indent 8}}
+      {{- end }}
+      labels:
+        app: {{ template "name" . }}
+        component: "{{ .Values.controller.name }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.controller.name }}
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ template "controller.publishServicePath" . }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --election-id={{ .Values.controller.electionID }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
+          {{- end }}
+          {{- if (contains "0.9" .Values.controller.image.tag) }}
+            - --configmap={{ .Release.Namespace }}/{{ template "controller.fullname" . }}
+          {{- else }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "controller.fullname" . }}
+          {{- end }}
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-tcp
+          {{- end }}
+          {{- if .Values.udp }}
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "fullname" . }}-udp
+          {{- end }}
+          {{- if .Values.controller.scope.enabled }}
+            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+          {{- end }}
+          {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          {{- if .Values.controller.stats.enabled }}
+            - name: stats
+              containerPort: 18080
+              protocol: TCP
+          {{- end }}
+          {{- range $key, $value := .Values.tcp }}
+            - name: "{{ $key }}-tcp"
+              containerPort: {{ $key }}
+              protocol: TCP
+          {{- end }}
+          {{- range $key, $value := .Values.udp }}
+            - name: "{{ $key }}-udp"
+              containerPort: {{ $key }}
+              protocol: UDP
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+          resources:
+{{ toYaml .Values.controller.resources | indent 12 }}
+      {{- if .Values.controller.stats.enabled }}
+        - name: {{ template "name" . }}-{{ .Values.statsExporter.name }}
+          image: "{{ .Values.statsExporter.image.repository }}:{{ .Values.statsExporter.image.tag }}"
+          imagePullPolicy: "{{ .Values.statsExporter.image.pullPolicy }}"
+          env:
+            - name: METRICS_ADDR
+              value: ":9913"
+            - name: METRICS_ENDPOINT
+              value: "{{ .Values.statsExporter.endpoint }}"
+            - name: METRICS_NS
+              value: "{{ .Values.statsExporter.metricsNamespace }}"
+            - name: NGINX_STATUS
+              value: "{{ .Values.statsExporter.statusPage }}"
+          ports:
+            - name: metrics
+              containerPort: 9913
+              protocol: TCP
+          resources:
+{{ toYaml .Values.statsExporter.resources | indent 12 }}
+      {{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
+    {{- if .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      terminationGracePeriodSeconds: 60
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-metrics-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.controller.stats.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.statsExporter.service.annotations }}
+  annotations:
+{{ toYaml .Values.statsExporter.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}-metrics
+spec:
+  clusterIP: "{{ .Values.statsExporter.service.clusterIP }}"
+{{- if .Values.statsExporter.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.statsExporter.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.statsExporter.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.statsExporter.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.statsExporter.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.statsExporter.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.statsExporter.service.servicePort }}
+      targetPort: 9913
+  selector:
+    app: {{ template "name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.statsExporter.service.type }}"
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-service.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.service.annotations }}
+  annotations:
+{{ toYaml .Values.controller.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}
+spec:
+  clusterIP: "{{ .Values.controller.service.clusterIP }}"
+{{- if .Values.controller.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- if and (ge .Capabilities.KubeVersion.Minor "7") (.Values.controller.service.externalTrafficPolicy) }}
+  externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
+{{- end }}
+{{- if and (ge .Capabilities.KubeVersion.Minor "7") (.Values.controller.service.healthCheckNodePort) }}
+  healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
+      {{- end }}
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
+      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
+      {{- end }}
+  {{- range $key, $value := .Values.tcp }}
+    - name: "{{ $key }}-tcp"
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: {{ $key }}
+  {{- end }}
+  {{- range $key, $value := .Values.udp }}
+    - name: "{{ $key }}-udp"
+      port: {{ $key }}
+      protocol: UDP
+      targetPort: {{ $key }}
+  {{- end }}
+  selector:
+    app: {{ template "name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.service.type }}"

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-stats-service.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-stats-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.controller.stats.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.stats.service.annotations }}
+  annotations:
+{{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}-stats
+spec:
+  clusterIP: "{{ .Values.controller.stats.service.clusterIP }}"
+{{- if .Values.controller.stats.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.stats.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.stats.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.stats.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.stats.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.stats.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: stats
+      port: {{ .Values.controller.stats.service.servicePort }}
+      targetPort: 18080
+  selector:
+    app: {{ template "name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.stats.service.type }}"
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.defaultBackend.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "defaultBackend.fullname" . }}
+spec:
+  replicas: {{ .Values.defaultBackend.replicaCount }}
+  template:
+    metadata:
+    {{- if .Values.defaultBackend.podAnnotations }}
+      annotations:
+{{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: {{ template "name" . }}
+        component: "{{ .Values.defaultBackend.name }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.defaultBackend.name }}
+          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+          imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
+          args:
+          {{- range $key, $value := .Values.defaultBackend.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+{{ toYaml .Values.defaultBackend.resources | indent 12 }}
+    {{- if .Values.defaultBackend.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.tolerations }}
+      tolerations:
+{{ toYaml .Values.defaultBackend.tolerations | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: 60
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/default-backend-service.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/default-backend-service.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.defaultBackend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.defaultBackend.service.annotations }}
+  annotations:
+{{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "defaultBackend.fullname" . }}
+spec:
+  clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+{{- if .Values.defaultBackend.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.defaultBackend.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.defaultBackend.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.defaultBackend.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - port: {{ .Values.defaultBackend.service.servicePort }}
+      targetPort: 8080
+  selector:
+    app: {{ template "name" . }}
+    component: "{{ .Values.defaultBackend.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.defaultBackend.service.type }}"
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/role.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/role.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - pods
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - {{ .Values.controller.electionID }}-{{ .Values.controller.ingressClass }}
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - update
+{{- end -}}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/rolebinding.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/serviceaccount.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/tcp-configmap.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/tcp-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.tcp }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-tcp
+data:
+{{ toYaml .Values.tcp | indent 2 }}
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/templates/udp-configmap.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/udp-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.udp }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-udp
+data:
+{{ toYaml .Values.udp | indent 2 }}
+{{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/values.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/values.yaml
@@ -1,0 +1,245 @@
+## nginx configuration
+## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md
+##
+controller:
+  name: controller
+  image:
+    repository: sapcc/nginx-ingress-controller
+    tag: "0.9.0-beta.17"
+    pullPolicy: IfNotPresent
+
+  config: {}
+
+  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
+  # is merged
+  hostNetwork: false
+
+  ## Required only if defaultBackend.enabled = false
+  ## Must be <namespace>/<service_name>
+  ##
+  defaultBackendService: ""
+
+  ## Optionally specify the secret name for default SSL certificate
+  ## Must be <namespace>/<secret_name>
+  ##
+  defaultSSLCertificate: ""
+
+  ## Election ID to use for status update
+  ##
+  electionID: ingress-controller-leader
+
+  ## Name of the ingress class to route through this controller
+  ##
+  ingressClass: nginx
+
+  ## Allows customization of the external service
+  ## the ingress will be bound to via DNS
+  publishService:
+    enabled: false
+    ## Allows overriding of the publish service to bind to
+    ## Must be <namespace>/<service_name>
+    ##
+    pathOverride: ""
+
+  ## Limit the scope of the controller
+  ##
+  scope:
+    enabled: false
+    namespace: "" # defaults to .Release.Namespace
+
+  extraArgs: {}
+
+  ## DaemonSet or Deployment
+  ##
+  kind: Deployment
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #- key: "key"
+  #  operator: "Equal|Exists"
+  #  value: "value"
+  #  effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for controller pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to controller pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 64Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 64Mi
+
+  service:
+    annotations: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the controller services are available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+
+    ## Set external traffic policy to: "Local" to preserve source IP on
+    ## providers supporting it
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    externalTrafficPolicy: ""
+
+    healthCheckNodePort: 0
+
+    targetPorts:
+      http: 80
+      https: 443
+
+    type: LoadBalancer
+
+    # type: NodePort
+    # nodePorts:
+    #   http: 32080
+    #   https: 32443
+    nodePorts:
+      http: ""
+      https: ""
+
+  stats:
+    enabled: true
+
+    service:
+      annotations: {}
+      clusterIP: ""
+
+      ## List of IP addresses at which the stats service is available
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ##
+      externalIPs: []
+
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 18080
+      type: ClusterIP
+
+## Default 404 backend
+##
+defaultBackend:
+
+  ## If false, controller.defaultBackendService must be provided
+  ##
+  enabled: true
+
+  name: default-backend
+  image:
+    repository: sapcc/custombackend
+    tag: "0.1"
+    pullPolicy: IfNotPresent
+
+  extraArgs: {}
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #- key: "key"
+  #  operator: "Equal|Exists"
+  #  value: "value"
+  #  effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for default backend pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to default backend pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 20Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 20Mi
+
+  service:
+    annotations: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the default backend service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 80
+    type: ClusterIP
+
+## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
+rbac:
+  create: false
+  serviceAccountName: default
+
+## If controller.stats.enabled = true, Prometheus metrics will be exported
+## Ref: https://github.com/hnlq715/nginx-vts-exporter
+##
+statsExporter:
+  name: stats-exporter
+  image:
+    repository: sophos/nginx-vts-exporter
+    tag: v0.6
+    pullPolicy: IfNotPresent
+
+  endpoint: /metrics
+  extraArgs: {}
+  metricsNamespace: nginx
+  statusPage: http://localhost:18080/nginx_status/format/json
+
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 20Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 20Mi
+
+  service:
+    annotations: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the stats-exporter service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 9913
+    type: ClusterIP
+
+# TCP service key:value pairs
+# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
+##
+tcp: {}
+  # 8080: "default/example-tcp-svc:9000"
+
+# UDP service key:value pairs
+# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
+##
+udp: {}
+  # 53: "kube-system/kube-dns:53"

--- a/charts/kubernikus-system/requirements.lock
+++ b/charts/kubernikus-system/requirements.lock
@@ -1,12 +1,9 @@
 dependencies:
-- name: nginx-ingress
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.8.7
 - name: vice-president
   repository: file://vendor/vice-president
   version: 0.1.0
-- name: vice-president
+- name: kube-state-metrics
   repository: file://vendor/kube-state-metrics
-  version: v1.1.0
-digest: sha256:2d30a7ec6b565829bd90e18a07d4bf0304a7acdeb90fc3d3d2691077a632515c
-generated: 2017-11-15T07:39:35.640467826-08:00
+  version: 1.1.0
+digest: sha256:45d1e310d136361d9866df4b71f601b20637b11c9c83414d9c5c06a6a9c2d2d8
+generated: 2017-11-22T21:12:11.587623413-08:00

--- a/charts/kubernikus-system/requirements.yaml
+++ b/charts/kubernikus-system/requirements.yaml
@@ -1,11 +1,7 @@
 dependencies:
-  - name: nginx-ingress
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 0.8.7
-    condition: nginx-ingress.enabled
   - name: vice-president 
     repository: file://vendor/vice-president
     version: 0.1.0
-  - name: vice-president
+  - name: kube-state-metrics
     repository: file://vendor/kube-state-metrics
     version: 1.1.0


### PR DESCRIPTION
we want the ingress custom backend is already deployed in the admin cluster in the kubernikus control plane. 
official helm chart for nginx-ingress as base but with custom backend that also knows json. fixes #80.

Initially I wanted to use it as a dependency but override the image of the custom backend, but that doesn't seem to work. 
