### PR TITLE
phase transition summary

### DIFF
--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -192,6 +192,7 @@ func (op *GroundControl) handler(key string) error {
 				if err := op.updatePhase(kluster, models.KlusterPhaseRunning, ""); err != nil {
 					glog.Errorf("Failed to update status of kluster %s:%s", kluster.GetName(), err)
 				}
+				metrics.SetMetricBootDurationSummary(kluster.GetCreationTimestamp().Time, time.Now())
 				glog.Infof("Kluster %s is ready!", kluster.GetName())
 			}
 		case models.KlusterPhaseTerminating:


### PR DESCRIPTION
Wanted something like [this](https://github.com/sapcc/kubernikus/compare/phasesum?expand=1#diff-9bc930f31cf0708f07b8d78355750f5cR47) @BugRoger?
`kubernikus_kluster_phase_duration{from_phase="Creating",to_phase="Running",quantile="0.99"} 10.00000009`