### PR TITLE
Masquerading in static firewall deployment

### DIFF
--- a/pkg/templates/node.go
+++ b/pkg/templates/node.go
@@ -169,6 +169,7 @@ networkd:
 storage:
   files:
     - path: /var/lib/iptables/rules-save
+      filesystem: root
       mode: 0644
       contents:
         inline: |-

--- a/pkg/templates/node.go
+++ b/pkg/templates/node.go
@@ -15,6 +15,8 @@ locksmith:
 
 systemd:
   units:
+    - name: iptables-restore.service
+      enable: true
     - name: ccloud-metadata.service
       contents: |
         [Unit]
@@ -79,7 +81,7 @@ systemd:
           --cluster-dns={{ .ClusterDNSAddress }} \
           --cluster-domain={{ .ClusterDomain }} \
           --client-ca-file=/etc/kubernetes/certs/kubelet-clients-ca.pem \
-          --non-masquerade-cidr={{ .ClusterCIDR }} \
+          --non-masquerade-cidr=0.0.0.0/0 \
           --anonymous-auth=false
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always
@@ -166,6 +168,18 @@ networkd:
 
 storage:
   files:
+    - path: /var/lib/iptables/rules-save
+      mode: 0644
+      contents:
+        inline: |-
+          *nat
+          :PREROUTING ACCEPT [0:0]
+          :INPUT ACCEPT [0:0]
+          :OUTPUT ACCEPT [0:0]
+          :POSTROUTING ACCEPT [0:0]
+          -A POSTROUTING -p tcp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32000-65000
+          -A POSTROUTING -p udp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32000-65000
+          COMMIT
     - path: /etc/sysctl.d/10-enable-icmp-redirects
       filesystem: root
       mode: 0644


### PR DESCRIPTION
The static firewall currently allows ingress traffic on default ephemeral ports.
If masquerade has a port collision it will by default choose a port from 1024-32000 which is
outside the default ephemeral port range.

Thus the answer packet is never reaching our system.

We disable the non-masquerade-cidr which disables all masquerading and insert our own rules for masquerading which adheres to the correct port range.
