### PR TITLE
implements structured logging for apiserver

### DIFF
--- a/pkg/api/handlers/get_openstack_metadata.go
+++ b/pkg/api/handlers/get_openstack_metadata.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	"github.com/sapcc/kubernikus/pkg/client/openstack/scoped"
 )
 
 func NewGetOpenstackMetadata(rt *api.Runtime) operations.GetOpenstackMetadataHandler {
@@ -29,7 +29,7 @@ func (d *getOpenstackMetadata) Handle(params operations.GetOpenstackMetadataPara
 		},
 	}
 
-	client, err := openstack.NewScopedClient(authOptions)
+	client, err := scoped.NewClient(authOptions, d.Logger)
 	if err != nil {
 		return NewErrorResponse(&operations.GetOpenstackMetadataDefault{}, 500, err.Error())
 	}

--- a/pkg/api/rest/api_test.go
+++ b/pkg/api/rest/api_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	kitlog "github.com/go-kit/kit/log"
 	errors "github.com/go-openapi/errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,7 @@ func createTestHandler(t *testing.T) (http.Handler, *apipkg.Runtime) {
 		Namespace:  NAMESPACE,
 		Kubernikus: kubernikusfake.NewSimpleClientset(),
 		Kubernetes: fake.NewSimpleClientset(),
+		Logger:     kitlog.NewNopLogger(),
 	}
 	if err := Configure(api, rt); err != nil {
 		t.Fatal(err)

--- a/pkg/api/rest/configure_kubernikus.go
+++ b/pkg/api/rest/configure_kubernikus.go
@@ -3,16 +3,9 @@ package rest
 import (
 	"crypto/tls"
 	"net/http"
-	"os"
-	"strings"
 
-	"github.com/go-openapi/runtime/middleware"
-	gmiddleware "github.com/gorilla/handlers"
-	"github.com/justinas/alice"
-	"github.com/rs/cors"
 	graceful "github.com/tylerb/graceful"
 
-	"github.com/sapcc/kubernikus/pkg/api/handlers"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
 )
 
@@ -25,8 +18,9 @@ func configureFlags(api *operations.KubernikusAPI) {
 }
 
 func configureAPI(api *operations.KubernikusAPI) http.Handler {
-
-	return setupGlobalMiddleware(api.Serve(setupMiddlewares))
+	return api.Serve(func(handler http.Handler) http.Handler {
+		return handler
+	})
 }
 
 // The TLS configuration before HTTPS server starts.
@@ -39,39 +33,4 @@ func configureTLS(tlsConfig *tls.Config) {
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"
 func configureServer(s *graceful.Server, scheme, addr string) {
-}
-
-// The middleware configuration is for the handler executors. These do not apply to the swagger.json document.
-// The middleware executes after routing but before authentication, binding and validation
-func setupMiddlewares(handler http.Handler) http.Handler {
-	return handler
-}
-
-// The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
-// So this is a good place to plug in a panic handling middleware, logging and metrics
-func setupGlobalMiddleware(handler http.Handler) http.Handler {
-	corsHandler := cors.New(cors.Options{
-		AllowedHeaders: []string{"X-Auth-Token", "Content-Type", "Accept"},
-		AllowedMethods: []string{"GET", "HEAD", "POST", "DELETE", "PUT"},
-		MaxAge:         600,
-	}).Handler
-
-	loggingHandler := func(next http.Handler) http.Handler {
-		return gmiddleware.LoggingHandler(os.Stdout, next)
-	}
-	redocHandler := func(next http.Handler) http.Handler {
-		return middleware.Redoc(middleware.RedocOpts{Path: "swagger"}, next)
-	}
-
-	return alice.New(loggingHandler, handlers.RootHandler, redocHandler, StaticFiles, corsHandler).Then(handler)
-}
-
-func StaticFiles(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/docs") {
-			http.StripPrefix("/docs", http.FileServer(http.Dir("static/docs"))).ServeHTTP(rw, r)
-			return
-		}
-		next.ServeHTTP(rw, r)
-	})
 }

--- a/pkg/api/runtime.go
+++ b/pkg/api/runtime.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"github.com/go-kit/kit/log"
+
 	"github.com/sapcc/kubernikus/pkg/generated/clientset"
 	"k8s.io/client-go/kubernetes"
 )
@@ -9,4 +11,5 @@ type Runtime struct {
 	Kubernikus clientset.Interface
 	Kubernetes kubernetes.Interface
 	Namespace  string
+	Logger     log.Logger
 }

--- a/pkg/client/openstack/scoped/logging.go
+++ b/pkg/client/openstack/scoped/logging.go
@@ -1,0 +1,48 @@
+package scoped
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
+)
+
+type LoggingClient struct {
+	Client Client
+	Logger log.Logger
+}
+
+func (c LoggingClient) GetMetadata() (metadata *models.OpenstackMetadata, err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "fetched metadata",
+			"flavors", len(metadata.Flavors),
+			"keypairs", len(metadata.KeyPairs),
+			"routers", len(metadata.Routers),
+			"security_groups", len(metadata.SecurityGroups),
+			"took", time.Since(begin),
+			"v", 1,
+			"err", err,
+		)
+	}(time.Now())
+
+	return c.Client.GetMetadata()
+}
+
+func (c LoggingClient) Authenticate(authOptions *tokens.AuthOptions) (err error) {
+	defer func(begin time.Time) {
+		v := 2
+		if err != nil {
+			v = 0
+		}
+		c.Logger.Log(
+			"msg", "authenticated",
+			"took", time.Since(begin),
+			"v", v,
+			"err", err,
+		)
+	}(time.Now())
+	return c.Client.Authenticate(authOptions)
+}

--- a/pkg/client/openstack/util/factory.go
+++ b/pkg/client/openstack/util/factory.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+type AuthenticatedClient struct {
+	providerClient *gophercloud.ProviderClient
+	NetworkClient  *gophercloud.ServiceClient
+	ComputeClient  *gophercloud.ServiceClient
+	IdentityClient *gophercloud.ServiceClient
+}

--- a/pkg/util/log/authlogger.go
+++ b/pkg/util/log/authlogger.go
@@ -1,0 +1,69 @@
+package log
+
+import (
+	"fmt"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+)
+
+func NewAuthLogger(logger kitlog.Logger, authOptions *tokens.AuthOptions) kitlog.Logger {
+	if project := getProject(authOptions); project != "" {
+		logger = kitlog.With(logger, "project", project)
+	}
+
+	if authMethod := getAuthMethod(authOptions); authMethod != "" {
+		logger = kitlog.With(logger, "auth", authMethod)
+	}
+
+	if principal := getPrincipal(authOptions); principal != "" {
+		logger = kitlog.With(logger, "principal", principal)
+	}
+	return logger
+}
+
+func getProject(authOptions *tokens.AuthOptions) string {
+	if authOptions.Scope.ProjectID != "" {
+		return authOptions.Scope.ProjectID
+	}
+
+	domain := ""
+	if authOptions.Scope.DomainID != "" {
+		domain = authOptions.Scope.DomainID
+	} else {
+		domain = authOptions.Scope.DomainName
+	}
+
+	return fmt.Sprintf("%s/%s", domain, authOptions.Scope.ProjectName)
+}
+
+func getAuthMethod(authOptions *tokens.AuthOptions) string {
+	if authOptions.TokenID != "" {
+		return "token"
+	}
+
+	if authOptions.Password != "" {
+		return "password"
+	}
+
+	return ""
+}
+
+func getPrincipal(authOptions *tokens.AuthOptions) string {
+	if authOptions.TokenID != "" {
+		return ""
+	}
+
+	if authOptions.UserID != "" {
+		return authOptions.UserID
+	}
+
+	domain := ""
+	if authOptions.DomainID != "" {
+		domain = authOptions.DomainID
+	} else {
+		domain = authOptions.DomainName
+	}
+
+	return fmt.Sprintf("%s/%s", domain, authOptions.Username)
+}

--- a/pkg/util/log/gophercloud.go
+++ b/pkg/util/log/gophercloud.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+)
+
+func NewLoggingProviderClient(endpoint string, logger kitlog.Logger) (*gophercloud.ProviderClient, error) {
+	providerClient, err := openstack.NewClient(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := providerClient.HTTPClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	providerClient.HTTPClient.Transport = &loggingRoundTripper{
+		transport,
+		kitlog.With(logger, "api", "egress"),
+	}
+
+	return providerClient, err
+}
+
+type loggingRoundTripper struct {
+	rt     http.RoundTripper
+	Logger kitlog.Logger
+}
+
+func (lrt *loggingRoundTripper) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	defer func(begin time.Time) {
+		keyvals := make([]interface{}, 0, 6)
+
+		if response != nil {
+			keyvals = append(keyvals,
+				"status", response.StatusCode,
+				"openstack_id", strings.Join(requestIds(response), ","))
+		}
+
+		keyvals = append(keyvals,
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+
+		log(lrt.Logger, request, keyvals...)
+	}(time.Now())
+
+	return lrt.rt.RoundTrip(request)
+}
+
+func requestIds(response *http.Response) []string {
+	ids := []string{}
+
+	if id := response.Header.Get("X-Openstack-Request-ID"); id != "" {
+		ids = append(ids, id)
+	}
+
+	if id := response.Header.Get("X-Compute-Request-ID"); id != "" {
+		ids = append(ids, id)
+	}
+
+	return ids
+}

--- a/pkg/util/log/middleware.go
+++ b/pkg/util/log/middleware.go
@@ -1,0 +1,165 @@
+package log
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	kitlog "github.com/go-kit/kit/log"
+)
+
+func LoggingHandler(logger kitlog.Logger, next http.Handler) http.Handler {
+	logger = kitlog.With(logger, "api", "ingress")
+	return http.HandlerFunc(func(rw http.ResponseWriter, request *http.Request) {
+		wrapper := makeWrapper(rw)
+
+		defer func(begin time.Time) {
+			log(logger, request,
+				"status", wrapper.Status(),
+				"size", wrapper.Size(),
+				"took", time.Since(begin))
+		}(time.Now())
+
+		next.ServeHTTP(wrapper, request)
+	})
+}
+
+func log(logger kitlog.Logger, request *http.Request, extra ...interface{}) {
+	var keyvals []interface{}
+
+	source_ip, _, err := net.SplitHostPort(request.RemoteAddr)
+	if err != nil {
+		source_ip = request.RemoteAddr
+	}
+
+	if source_ip != "" {
+		keyvals = append(keyvals, "source_ip", source_ip)
+	}
+
+	keyvals = append(keyvals, "method", request.Method)
+
+	host, host_port, err := net.SplitHostPort(request.Host)
+	if err == nil {
+		if host != "" {
+			keyvals = append(keyvals,
+				"host", host)
+		}
+		if host_port != "" {
+			keyvals = append(keyvals,
+				"port", host_port)
+		}
+	}
+
+	keyvals = append(keyvals, "path", request.URL.EscapedPath())
+
+	for i, k := range request.URL.Query() {
+		keyvals = append(keyvals, i, strings.Join(k, ","))
+	}
+
+	keyvals = append(keyvals, "user_agent", request.UserAgent())
+	keyvals = append(keyvals, extra...)
+	logger.Log(keyvals...)
+}
+
+// this stuff is copied from gorilla
+
+func makeWrapper(w http.ResponseWriter) loggingResponseWriter {
+	var logger loggingResponseWriter = &responseLogger{w: w, status: http.StatusOK}
+	if _, ok := w.(http.Hijacker); ok {
+		logger = &hijackLogger{responseLogger{w: w, status: http.StatusOK}}
+	}
+	h, ok1 := logger.(http.Hijacker)
+	c, ok2 := w.(http.CloseNotifier)
+	if ok1 && ok2 {
+		return hijackCloseNotifier{logger, h, c}
+	}
+	if ok2 {
+		return &closeNotifyWriter{logger, c}
+	}
+	return logger
+}
+
+type hijackLogger struct {
+	responseLogger
+}
+
+func (l *hijackLogger) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h := l.responseLogger.w.(http.Hijacker)
+	conn, rw, err := h.Hijack()
+	if err == nil && l.responseLogger.status == 0 {
+		// The status will be StatusSwitchingProtocols if there was no error and
+		// WriteHeader has not been called yet
+		l.responseLogger.status = http.StatusSwitchingProtocols
+	}
+	return conn, rw, err
+}
+
+type closeNotifyWriter struct {
+	loggingResponseWriter
+	http.CloseNotifier
+}
+
+type hijackCloseNotifier struct {
+	loggingResponseWriter
+	http.Hijacker
+	http.CloseNotifier
+}
+
+type loggingResponseWriter interface {
+	commonLoggingResponseWriter
+	http.Pusher
+}
+
+type commonLoggingResponseWriter interface {
+	http.ResponseWriter
+	http.Flusher
+	Status() int
+	Size() int
+}
+
+type responseLogger struct {
+	w      http.ResponseWriter
+	status int
+	size   int
+}
+
+func (l *responseLogger) Header() http.Header {
+	return l.w.Header()
+}
+
+func (l *responseLogger) Write(b []byte) (int, error) {
+	size, err := l.w.Write(b)
+	l.size += size
+	return size, err
+}
+
+func (l *responseLogger) WriteHeader(s int) {
+	l.w.WriteHeader(s)
+	l.status = s
+}
+
+func (l *responseLogger) Status() int {
+	return l.status
+}
+
+func (l *responseLogger) Size() int {
+	return l.size
+}
+
+func (l *responseLogger) Flush() {
+	f, ok := l.w.(http.Flusher)
+	if ok {
+		f.Flush()
+	}
+}
+
+func (l *responseLogger) Push(target string, opts *http.PushOptions) error {
+	p, ok := l.w.(http.Pusher)
+	if !ok {
+		return fmt.Errorf("responseLogger does not implement http.Pusher")
+	}
+	return p.Push(target, opts)
+}


### PR DESCRIPTION
```
api | ts=2017-12-07T17:37:00.746191096Z caller=github.com/sapcc/kubernikus/pkg/api/rest/configure.go:31 msg="Serving kubernikus at http://127.0.0.1:5100"
api | ts=2017-12-07T17:37:03.981714807Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=POST host=identity-3.eu-nl-1.cloud.sap path=/v3/auth/tokens status=201 size=12081 id=req-df05b676-9c98-4043-91d1-e3d251ffc1f2 took=174.10291ms v=2
api | ts=2017-12-07T17:37:03.994440467Z caller=github.com/sapcc/kubernikus/pkg/client/openstack/scoped/logging.go:35 project=5d725ddf97664a16b011e8a8dd75772b auth=token msg=authenticated took=187.137236ms v=2
api | ts=2017-12-07T17:37:04.229706102Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=network-3.eu-nl-1.cloud.sap path=/v2.0/routers status=200 size=-1 id=req-e23dfbde-12a7-4df1-98ac-7920bc3a2e8b took=235.173194ms v=2
api | ts=2017-12-07T17:37:04.432480469Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=network-3.eu-nl-1.cloud.sap path=/v2.0/ports device_id=21adab1b-b8ae-4d44-8a1f-fcb0f3258d01 device_owner=network:router_interface status=200 size=-1 id=req-b4d47b35-cce8-4b83-b8af-73b7e41f10de took=202.045165ms v=2
api | ts=2017-12-07T17:37:04.621683785Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=network-3.eu-nl-1.cloud.sap path=/v2.0/networks/48317f3c-13ae-4300-9101-353125b9aa9e status=200 size=-1 id=req-7f529b64-0ed5-4707-af7d-80ebc656fbd7 took=188.319113ms v=2
api | ts=2017-12-07T17:37:04.809404826Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=network-3.eu-nl-1.cloud.sap path=/v2.0/networks/48317f3c-13ae-4300-9101-353125b9aa9e status=200 size=-1 id=req-5cd86e08-2e50-443a-95ac-449a95d829b6 took=187.269636ms v=2
api | ts=2017-12-07T17:37:05.007636259Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=network-3.eu-nl-1.cloud.sap path=/v2.0/subnets/dbef5f63-0df6-4438-8979-dd0c1fbb99ab status=200 size=-1 id=req-746e5d27-87f1-436e-ab9e-3c5c82bee1ee took=197.773135ms v=2
api | ts=2017-12-07T17:37:05.165771023Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=compute-3.eu-nl-1.cloud.sap path=/v2/5d725ddf97664a16b011e8a8dd75772b/os-keypairs status=200 size=-1 id=req-a0d66208-84ba-45c0-8753-072d9bb30e04 took=157.759571ms v=2
api | ts=2017-12-07T17:37:05.401391954Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=compute-3.eu-nl-1.cloud.sap path=/v2/5d725ddf97664a16b011e8a8dd75772b/os-security-groups status=200 size=-1 id=req-83144cb9-b7e4-4399-aacb-cfb17be5ab5f took=235.225408ms v=2
api | ts=2017-12-07T17:37:05.571716528Z caller=github.com/sapcc/kubernikus/pkg/util/log/gophercloud.go:52 project=5d725ddf97664a16b011e8a8dd75772b auth=token method=GET host=compute-3.eu-nl-1.cloud.sap path=/v2/5d725ddf97664a16b011e8a8dd75772b/flavors/detail status=200 size=-1 id=req-8745a964-a133-48b9-90dc-433b886ddda1 took=169.489954ms v=2
api | ts=2017-12-07T17:37:05.57490622Z caller=github.com/sapcc/kubernikus/pkg/client/openstack/scoped/logging.go:19 project=5d725ddf97664a16b011e8a8dd75772b auth=token msg="fetched metadata" flavors=20 keypairs=1 routers=1 security_groups=1 took=1.580461341s
api | ts=2017-12-07T17:37:05.57524819Z caller=github.com/sapcc/kubernikus/pkg/util/log/middleware.go:36 method=GET host=127.0.0.1 path=/api/v1/openstack/metadata status=200 size=1035 took=2.029857786s v=1
```