### PR TITLE
Allow pods to ping outside using masquerade

### DIFF
--- a/pkg/templates/node.go
+++ b/pkg/templates/node.go
@@ -180,6 +180,7 @@ storage:
           :POSTROUTING ACCEPT [0:0]
           -A POSTROUTING -p tcp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32000-65000
           -A POSTROUTING -p udp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32000-65000
+          -A POSTROUTING -p icmp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE
           COMMIT
 
     - path: /etc/sysctl.d/10-enable-icmp-redirects


### PR DESCRIPTION
We currently masquerade ourselves due to the ephemeral ports issue.
This workaround with --to-ports can be done on protocols where ports are available.

This adds another rule which takes care of icmp packets allowing the pods to ping.