### PR TITLE
WIP: Refactor nanny/route gc to run in the operator

### DIFF
--- a/Dockerfile.nanny
+++ b/Dockerfile.nanny
@@ -1,9 +1,6 @@
-FROM golang:1.9.2-alpine3.6 as builder
-WORKDIR /go/src/github.com/sapcc/kubernikus/
-RUN apk add --no-cache make
-COPY . .
-ARG VERSION
-RUN make bin/linux/nanny
+ARG VERSION=latest
+
+FROM sapcc/kubernikus-binaries:$VERSION as kubernikus-binaries
 
 FROM alpine:3.6 as nanny
 MAINTAINER "Fabian Ruff <fabian.ruff@sap.com>"
@@ -11,6 +8,6 @@ RUN apk add --no-cache curl
 RUN curl -Lo /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
 	&& chmod +x /bin/dumb-init \
 	&& dumb-init -V
-COPY --from=builder /go/src/github.com/sapcc/kubernikus/bin/linux/nanny /usr/local/bin/
+COPY --from=kubernikus-binaries /nanny /usr/local/bin/
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["nanny"]

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ build:
 	docker build $(BUILD_ARGS) -t sapcc/kubernikusctl:$(VERSION)                                                             ./contrib/kubernikusctl
 	docker build $(BUILD_ARGS) -t sapcc/kubernikus-docs:$(VERSION)         -f Dockerfile.kubernikus-docs .
 	docker build $(BUILD_ARGS) -t sapcc/kubernikus:$(VERSION)              -f Dockerfile .
+	docker build $(BUILD_ARGS) -t sapcc/kubernikus-nanny:$(VERSION)        -f Dockerfile.nanny .
 
 pull:
 	docker pull sapcc/kubernikus-docs-builder:latest
@@ -52,6 +53,7 @@ pull:
 
 tag:
 	docker tag sapcc/kubernikus:$(VERSION)         sapcc/kubernikus:latest
+	docker tag sapcc/kubernikus-nanny:$(VERSION)   sapcc/kubernikus-nanny:latest
 	docker tag sapcc/kubernikusctl:$(VERSION)      sapcc/kubernikusctl:latest
 	docker tag sapcc/kubernikus-kubectl:$(VERSION) sapcc/kubernikus-kubectl:latest
 
@@ -62,6 +64,8 @@ push:
 	docker push sapcc/kubernikusctl:latest
 	docker push sapcc/kubernikus-kubectl:$(VERSION)
 	docker push sapcc/kubernikus-kubectl:latest
+	docker push sapcc/kubernikus-nanny:$(VERSION)
+	docker push sapcc/kubernikus-nanny:latest
 
 gh-pages:
 	docker run --name gh-pages sapcc/kubernikus-docs:$(VERSION) /bin/true

--- a/charts/kube-master/templates/nanny.yaml
+++ b/charts/kube-master/templates/nanny.yaml
@@ -1,0 +1,40 @@
+{{/* vim: set filetype=gotexttmpl: */ -}}
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: {{ include "master.fullname" . }}-nanny
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  replicas: 1 
+  selector:
+    matchLabels:
+      app: {{ include "master.fullname" . }}-nanny
+  template:
+    metadata:
+      labels:
+        app: {{ include "master.fullname" . }}-nanny
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: nanny 
+          image: "{{ .Values.nanny.image.repository }}:{{ .Values.nanny.image.tag }}"
+          args:
+            - nanny
+            - --auth-url={{ .Values.openstack.authURL }}
+            - --auth-username={{ .Values.openstack.username }}
+            - --auth-domain={{ .Values.openstack.domainName }}
+            - --router-id={{ .Values.openstack.routerID }}
+            - --cluster-cidr={{ .Values.clusterCIDR  }}
+          env:
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "master.fullname" . }}
+                  key: openstack-password
+          resources:
+{{ toYaml .Values.nanny.resources | indent 12 }}

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -63,4 +63,17 @@ scheduler:
       cpu: 500m
       memory: 512Mi
 
+nanny:
+  image:
+    repository: sapcc/kubernikus-nanny 
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 revisionHistoryLimit: 3

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -182,7 +182,7 @@ func (op *GroundControl) handler(key string) error {
 				}
 			}
 			glog.V(5).Infof("%d of %d pods ready for kluster %s", podsReady, len(pods), key)
-			if podsReady == 4 {
+			if podsReady == 5 {
 				clientset, err := op.Clients.Satellites.ClientFor(kluster)
 				if err != nil {
 					return err

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -40,6 +40,16 @@ type apiValues struct {
 	WormholeHost  string `yaml:"wormholeHost,omitempty"`
 }
 
+type nannyValues struct {
+	Image containerImage `yaml:"repository,omitempty"`
+}
+
+type containerImage struct {
+	Repository string `yaml:"repository,omitempty"`
+	Tag        string `yaml:"tag,omitempty"`
+	PullPolicy string `yaml:"pullPolicy,omitempty"`
+}
+
 type kubernikusHelmValues struct {
 	Openstack        openstackValues   `yaml:"openstack,omitempty"`
 	Certs            map[string]string `yaml:"certs,omitempty"`
@@ -50,6 +60,7 @@ type kubernikusHelmValues struct {
 	Version          string            `yaml:"version,omitempty"`
 	Etcd             etcdValues        `yaml:"etcd,omitempty"`
 	Api              apiValues         `yaml:"api,omitempty"`
+	Nanny            nannyValues       `yaml:"nanny,omitempty"`
 }
 
 func KlusterToHelmValues(kluster *v1.Kluster, openstack *OpenstackOptions, certificates map[string]string, bootstrapToken string, accessMode string) ([]byte, error) {
@@ -88,6 +99,11 @@ func KlusterToHelmValues(kluster *v1.Kluster, openstack *OpenstackOptions, certi
 		Api: apiValues{
 			ApiserverHost: apiserverURL.Hostname(),
 			WormholeHost:  wormholeURL.Hostname(),
+		},
+		Nanny: nannyValues{
+			Image: containerImage{
+				Tag: kluster.Status.Version,
+			},
 		},
 	}
 


### PR DESCRIPTION
Instead of deploying a separate binary for each kluster we decided to have this run centrally in the operator to make it easier to ship manage the lifecycle of the nanny components