### PR TITLE
enforce holy import trinity using goimports

### DIFF
--- a/Dockerfile.kubernikus-binaries
+++ b/Dockerfile.kubernikus-binaries
@@ -1,6 +1,7 @@
 FROM golang:1.9.2-alpine3.6 as builder
 WORKDIR /go/src/github.com/sapcc/kubernikus/
-RUN apk add --no-cache make
+RUN apk add --no-cache make git
+RUN  go get golang.org/x/tools/cmd/goimports
 COPY . .
 ARG VERSION
 RUN make all

--- a/pkg/api/auth/authorizer.go
+++ b/pkg/api/auth/authorizer.go
@@ -12,8 +12,9 @@ import (
 	"github.com/go-openapi/loads"
 	runtime "github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware/denco"
-	"github.com/sapcc/kubernikus/pkg/api/models"
 	flag "github.com/spf13/pflag"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
 )
 
 var (

--- a/pkg/api/auth/authorizer_test.go
+++ b/pkg/api/auth/authorizer_test.go
@@ -4,9 +4,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/spec"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthorizer(t *testing.T) {

--- a/pkg/api/handlers/errors.go
+++ b/pkg/api/handlers/errors.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 )
 

--- a/pkg/api/handlers/get_cluster_events.go
+++ b/pkg/api/handlers/get_cluster_events.go
@@ -3,10 +3,11 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewGetClusterEvents(rt *api.Runtime) operations.GetClusterEventsHandler {

--- a/pkg/api/handlers/get_cluster_info.go
+++ b/pkg/api/handlers/get_cluster_info.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"

--- a/pkg/api/handlers/get_cluster_info_test.go
+++ b/pkg/api/handlers/get_cluster_info_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
 )
 
 func TestKubernikusctlDownloadLinks(t *testing.T) {

--- a/pkg/api/handlers/get_openstack_metadata.go
+++ b/pkg/api/handlers/get_openstack_metadata.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"

--- a/pkg/api/handlers/info.go
+++ b/pkg/api/handlers/info.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"

--- a/pkg/api/handlers/list_api_versions.go
+++ b/pkg/api/handlers/list_api_versions.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"

--- a/pkg/api/handlers/list_clusters.go
+++ b/pkg/api/handlers/list_clusters.go
@@ -2,10 +2,11 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewListClusters(rt *api.Runtime) operations.ListClustersHandler {

--- a/pkg/api/handlers/show_cluster.go
+++ b/pkg/api/handlers/show_cluster.go
@@ -2,11 +2,12 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewShowCluster(rt *api.Runtime) operations.ShowClusterHandler {

--- a/pkg/api/handlers/terminate_cluster.go
+++ b/pkg/api/handlers/terminate_cluster.go
@@ -2,13 +2,14 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTerminateCluster(rt *api.Runtime) operations.TerminateClusterHandler {

--- a/pkg/api/handlers/update_cluster.go
+++ b/pkg/api/handlers/update_cluster.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func NewUpdateCluster(rt *api.Runtime) operations.UpdateClusterHandler {

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -1,15 +1,16 @@
 package handlers
 
 import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/spec"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	kubernikusv1 "github.com/sapcc/kubernikus/pkg/generated/clientset/typed/kubernikus/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-
-	"fmt"
-	"strings"
 )
 
 var (

--- a/pkg/api/models/kluster_print.go
+++ b/pkg/api/models/kluster_print.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/sapcc/kubernikus/pkg/cmd/printers"
 )
 

--- a/pkg/api/runtime.go
+++ b/pkg/api/runtime.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"github.com/go-kit/kit/log"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/sapcc/kubernikus/pkg/generated/clientset"
-	"k8s.io/client-go/kubernetes"
 )
 
 type Runtime struct {

--- a/pkg/client/openstack/scoped/client.go
+++ b/pkg/client/openstack/scoped/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/gophercloud/pagination"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/client/openstack/util"
 	utillog "github.com/sapcc/kubernikus/pkg/util/log"

--- a/pkg/cmd/kubernikus/certificates.go
+++ b/pkg/cmd/kubernikus/certificates.go
@@ -1,8 +1,9 @@
 package kubernikus
 
 import (
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/certificates"
 	"github.com/spf13/cobra"
+
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/certificates"
 )
 
 func NewCertificatesCommand() *cobra.Command {

--- a/pkg/cmd/kubernikus/certificates/files.go
+++ b/pkg/cmd/kubernikus/certificates/files.go
@@ -3,13 +3,13 @@ package certificates
 import (
 	"errors"
 
-	"github.com/sapcc/kubernikus/pkg/api/models"
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus"
-	"github.com/sapcc/kubernikus/pkg/util"
-
-	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus"
+	"github.com/sapcc/kubernikus/pkg/cmd"
+	"github.com/sapcc/kubernikus/pkg/util"
 )
 
 func NewFilesCommand() *cobra.Command {

--- a/pkg/cmd/kubernikus/certificates/plain.go
+++ b/pkg/cmd/kubernikus/certificates/plain.go
@@ -3,12 +3,12 @@ package certificates
 import (
 	"errors"
 
+	"github.com/spf13/cobra"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus"
-	"github.com/sapcc/kubernikus/pkg/util"
-
 	"github.com/sapcc/kubernikus/pkg/cmd"
-	"github.com/spf13/cobra"
+	"github.com/sapcc/kubernikus/pkg/util"
 )
 
 func NewPlainCommand() *cobra.Command {

--- a/pkg/cmd/kubernikus/certificates/sign.go
+++ b/pkg/cmd/kubernikus/certificates/sign.go
@@ -7,13 +7,14 @@ import (
 	"os"
 
 	"github.com/ghodss/yaml"
-	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
-	"github.com/sapcc/kubernikus/pkg/cmd"
-	"github.com/sapcc/kubernikus/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
+	"github.com/sapcc/kubernikus/pkg/cmd"
+	"github.com/sapcc/kubernikus/pkg/util"
 )
 
 func NewSignCommand() *cobra.Command {

--- a/pkg/cmd/kubernikus/helm.go
+++ b/pkg/cmd/kubernikus/helm.go
@@ -6,13 +6,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus"
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/util"
 	"github.com/sapcc/kubernikus/pkg/util/helm"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func NewHelmCommand() *cobra.Command {

--- a/pkg/cmd/kubernikus/seed.go
+++ b/pkg/cmd/kubernikus/seed.go
@@ -1,8 +1,9 @@
 package kubernikus
 
 import (
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/seed"
 	"github.com/spf13/cobra"
+
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/seed"
 )
 
 func NewSeedCommand() *cobra.Command {

--- a/pkg/cmd/kubernikus/seed/dns.go
+++ b/pkg/cmd/kubernikus/seed/dns.go
@@ -3,11 +3,12 @@ package seed
 import (
 	"errors"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/controller/ground/bootstrap/dns"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func NewKubeDNSCommand() *cobra.Command {

--- a/pkg/cmd/kubernikusctl/auth.go
+++ b/pkg/cmd/kubernikusctl/auth.go
@@ -1,8 +1,9 @@
 package kubernikusctl
 
 import (
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/auth"
 	"github.com/spf13/cobra"
+
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/auth"
 )
 
 func NewAuthCommand() *cobra.Command {

--- a/pkg/cmd/kubernikusctl/auth/init.go
+++ b/pkg/cmd/kubernikusctl/auth/init.go
@@ -9,11 +9,12 @@ import (
 	"github.com/howeyc/gopass"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 )
 
 type InitOptions struct {

--- a/pkg/cmd/kubernikusctl/auth/refresh.go
+++ b/pkg/cmd/kubernikusctl/auth/refresh.go
@@ -12,12 +12,13 @@ import (
 	"github.com/howeyc/gopass"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
-	"github.com/sapcc/kubernikus/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
+	"github.com/sapcc/kubernikus/pkg/util"
 )
 
 type RefreshOptions struct {

--- a/pkg/cmd/kubernikusctl/create.go
+++ b/pkg/cmd/kubernikusctl/create.go
@@ -1,9 +1,10 @@
 package kubernikusctl
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/create"
-	"github.com/spf13/cobra"
 )
 
 func createRun(c *cobra.Command, args []string) {

--- a/pkg/cmd/kubernikusctl/get.go
+++ b/pkg/cmd/kubernikusctl/get.go
@@ -1,9 +1,10 @@
 package kubernikusctl
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/get"
-	"github.com/spf13/cobra"
 )
 
 func getRun(c *cobra.Command, args []string) {

--- a/pkg/cmd/kubernikusctl/get/cluster.go
+++ b/pkg/cmd/kubernikusctl/get/cluster.go
@@ -3,9 +3,10 @@ package get
 import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/cmd/printers"
-	"github.com/spf13/cobra"
 )
 
 func (o *GetOptions) NewClusterCommand() *cobra.Command {

--- a/pkg/cmd/kubernikusctl/get/common.go
+++ b/pkg/cmd/kubernikusctl/get/common.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"github.com/sapcc/kubernikus/pkg/cmd"
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/sapcc/kubernikus/pkg/cmd"
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 )
 
 type GetOptions struct {

--- a/pkg/cmd/wormhole/client.go
+++ b/pkg/cmd/wormhole/client.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/databus23/guttle"
 	"github.com/golang/glog"
-	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/sapcc/kubernikus/pkg/cmd"
 )
 
 func NewClientCommand() *cobra.Command {

--- a/pkg/cmd/wormhole/server.go
+++ b/pkg/cmd/wormhole/server.go
@@ -9,10 +9,11 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	"github.com/sapcc/kubernikus/pkg/cmd"
-	"github.com/sapcc/kubernikus/pkg/wormhole"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/sapcc/kubernikus/pkg/cmd"
+	"github.com/sapcc/kubernikus/pkg/wormhole"
 )
 
 func NewServerCommand() *cobra.Command {

--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
 )
 
 const (

--- a/pkg/controller/base/instrumenting.go
+++ b/pkg/controller/base/instrumenting.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 

--- a/pkg/controller/base/logging.go
+++ b/pkg/controller/base/logging.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -3,14 +3,14 @@ package config
 import (
 	"sync"
 
-	kube "github.com/sapcc/kubernikus/pkg/client/kubernetes"
-	kubernikus_clientset "github.com/sapcc/kubernikus/pkg/generated/clientset"
-	kubernikus_informers "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions"
 	kubernetes_informers "k8s.io/client-go/informers"
 	kubernetes_clientset "k8s.io/client-go/kubernetes"
-
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
 	"k8s.io/helm/pkg/helm"
+
+	kube "github.com/sapcc/kubernikus/pkg/client/kubernetes"
+	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	kubernikus_clientset "github.com/sapcc/kubernikus/pkg/generated/clientset"
+	kubernikus_informers "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions"
 )
 
 type Controller interface {

--- a/pkg/controller/ground/bootstrap.go
+++ b/pkg/controller/ground/bootstrap.go
@@ -3,12 +3,13 @@ package ground
 import (
 	"fmt"
 
-	"github.com/sapcc/kubernikus/pkg/controller/ground/bootstrap/dns"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	storage "k8s.io/client-go/pkg/apis/storage/v1"
+
+	"github.com/sapcc/kubernikus/pkg/controller/ground/bootstrap/dns"
 
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 )
 

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
 )
 
 func TestMetrics(t *testing.T) {

--- a/pkg/controller/routegc/controller.go
+++ b/pkg/controller/routegc/controller.go
@@ -11,8 +11,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/pagination"
-	"github.com/sapcc/kubernikus/pkg/version"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/sapcc/kubernikus/pkg/version"
 )
 
 type RouteGarbageCollector struct {

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/kennygrant/sanitize"
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-
 	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 
 const (

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -4,8 +4,9 @@ import (
 	"log"
 	"net/url"
 
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 
 type OpenstackOptions struct {

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -14,10 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilexec "k8s.io/utils/exec"
 
-	utilversion "github.com/sapcc/kubernikus/pkg/util/version"
 	"golang.org/x/sys/unix"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	utilversion "github.com/sapcc/kubernikus/pkg/util/version"
 )
 
 type RulePosition string

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"time"
 
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 
 var DoesNotExist = errors.New("The object was not found in the cache")

--- a/pkg/wormhole/server/controller.go
+++ b/pkg/wormhole/server/controller.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/databus23/guttle"
 	"github.com/golang/glog"
-	"github.com/sapcc/kubernikus/pkg/util/iptables"
 	"k8s.io/apimachinery/pkg/util/wait"
 	informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	utilexec "k8s.io/utils/exec"
+
+	"github.com/sapcc/kubernikus/pkg/util/iptables"
 )
 
 const (

--- a/test/gofmt.sh
+++ b/test/gofmt.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
+set -eo pipefail
 
-if [ -n "$(gofmt -l $@)" ]; then
+VIOLATING_FILES=$(goimports -local github.com/sapcc/kubernikus -l $@ | sed /generated/d)
+if [ -n "$VIOLATING_FILES" ]; then
   echo "Go code is not formatted:"
-  gofmt -d $@ 
+  goimports -e -d $@
   exit 1
 fi


### PR DESCRIPTION
This PR changes our `gofmt` check to
`goimports -local github.com/sapcc/kubernikus`.

This causes the tests to fail if imports are not ordered in the following way:
```
stdlib
[empty line]
external deps
[empty line]
kubernikus internal deps
````

I purposly excluded the generated files from this check to avoid confusion when we regenerate stuff.

I added y'all as reviewers because I want everyone to be aware of this change.