### PR TITLE
Request-ID Tracing

### DIFF
--- a/pkg/api/handlers/get_openstack_metadata.go
+++ b/pkg/api/handlers/get_openstack_metadata.go
@@ -30,7 +30,7 @@ func (d *getOpenstackMetadata) Handle(params operations.GetOpenstackMetadataPara
 		},
 	}
 
-	client, err := scoped.NewClient(authOptions, d.Logger)
+	client, err := scoped.NewClient(authOptions, getTracingLogger(params.HTTPRequest))
 	if err != nil {
 		return NewErrorResponse(&operations.GetOpenstackMetadataDefault{}, 500, err.Error())
 	}

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
+	kitlog "github.com/go-kit/kit/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -51,4 +53,12 @@ func klusterFromCRD(k *v1.Kluster) *models.Kluster {
 		Spec:   k.Spec,
 		Status: k.Status,
 	}
+}
+
+func getTracingLogger(request *http.Request) kitlog.Logger {
+	logger, ok := request.Context().Value("logger").(kitlog.Logger)
+	if !ok {
+		logger = kitlog.NewNopLogger()
+	}
+	return logger
 }

--- a/pkg/api/rest/configure.go
+++ b/pkg/api/rest/configure.go
@@ -81,6 +81,10 @@ func setupGlobalMiddleware(handler http.Handler, rt *apipkg.Runtime) http.Handle
 		MaxAge:         600,
 	}).Handler
 
+	requestIDHandler := func(next http.Handler) http.Handler {
+		return logutil.RequestIDHandler(next)
+	}
+
 	loggingHandler := func(next http.Handler) http.Handler {
 		return logutil.LoggingHandler(rt.Logger, next)
 	}
@@ -99,5 +103,5 @@ func setupGlobalMiddleware(handler http.Handler, rt *apipkg.Runtime) http.Handle
 		})
 	}
 
-	return alice.New(loggingHandler, handlers.RootHandler, redocHandler, staticHandler, corsHandler).Then(handler)
+	return alice.New(requestIDHandler, loggingHandler, handlers.RootHandler, redocHandler, staticHandler, corsHandler).Then(handler)
 }

--- a/pkg/util/log/gophercloud.go
+++ b/pkg/util/log/gophercloud.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -41,6 +42,10 @@ func (lrt *loggingRoundTripper) RoundTrip(request *http.Request) (response *http
 			keyvals = append(keyvals,
 				"status", response.StatusCode,
 				"openstack_id", strings.Join(requestIds(response), ","))
+		}
+
+		if id := request.Context().Value(KubernikusRequestID); id != nil {
+			keyvals = append(keyvals, "id", fmt.Sprintf("%s", id))
 		}
 
 		keyvals = append(keyvals,


### PR DESCRIPTION
This adds a middleware that generates a UUID on each incoming API request. For a poor-man's tracing this `id` is passed as value in a request specific logger.

