### PR TITLE
removes glog 

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -65,7 +65,14 @@ func main() {
 		Namespace: namespace,
 		Logger:    logger,
 	}
-	rt.Kubernikus, rt.Kubernetes = rest.NewKubeClients()
+	rt.Kubernikus, rt.Kubernetes, err = rest.NewKubeClients(logger)
+	if err != nil {
+		logger.Log(
+			"msg", "failed to create kubernetes clients",
+			"err", err)
+		os.Exit(1)
+	}
+
 	if err := rest.Configure(api, rt); err != nil {
 		logger.Log(
 			"msg", "failed to configure API server",

--- a/pkg/api/auth/authorizer.go
+++ b/pkg/api/auth/authorizer.go
@@ -58,7 +58,7 @@ func NewOsloPolicyAuthorizer(document *loads.Document, rules map[string]string) 
 			//Add this once go-openapi/spec includes this fix: https://github.com/go-openapi/spec/pull/40
 			//secSchemes := document.Analyzer.SecurityDefinitionsFor(operation)
 			//if _, ok := rules[operation.ID]; !ok && len(secSchemes) > 0 {
-			//  glog.Errorf("No policy found for %s. The api route will not be accessible", operation.ID)
+			//  logger.Log("msg", "policy not found. The api route will not be accessible", "operation", operation.ID)
 			//}
 		}
 	}

--- a/pkg/client/helm/client.go
+++ b/pkg/client/helm/client.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/golang/glog"
+	"github.com/go-kit/kit/log"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/helm/pkg/helm"
@@ -13,7 +13,8 @@ import (
 	"github.com/sapcc/kubernikus/pkg/client/helm/portforwarder"
 )
 
-func NewClient(kubeClient kubernetes.Interface, kubeConfig *rest.Config) (*helm.Client, error) {
+func NewClient(kubeClient kubernetes.Interface, kubeConfig *rest.Config, logger log.Logger) (*helm.Client, error) {
+	logger = log.With(logger, "client", "helm")
 
 	tillerHost := os.Getenv("TILLER_DEPLOY_SERVICE_HOST")
 	if tillerHost == "" {
@@ -26,7 +27,9 @@ func NewClient(kubeClient kubernetes.Interface, kubeConfig *rest.Config) (*helm.
 	tillerHost = fmt.Sprintf("%s:%s", tillerHost, tillerPort)
 
 	if _, err := rest.InClusterConfig(); err != nil {
-		glog.V(2).Info("We are not running inside the cluster. Creating tunnel to tiller pod.")
+		logger.Log(
+			"msg", "We are not running inside the cluster. Creating tunnel to tiller pod.",
+			"v", 2)
 		tunnel, err := portforwarder.New("kube-system", kubeClient, kubeConfig)
 		if err != nil {
 			return nil, err
@@ -35,7 +38,10 @@ func NewClient(kubeClient kubernetes.Interface, kubeConfig *rest.Config) (*helm.
 		client := helm.NewClient(helm.Host(tillerHost))
 		//Lets see how this goes: We close the tunnel as soon as the client is GC'ed.
 		runtime.SetFinalizer(client, func(_ *helm.Client) {
-			glog.V(2).Info("Tearing Down tunnel to tiller at %s", tillerHost)
+			logger.Log(
+				"msg", "trearing down tunnel to tiller",
+				"host", tillerHost,
+				"v", 2)
 			tunnel.Close()
 		})
 		return client, nil

--- a/pkg/client/openstack/client.go
+++ b/pkg/client/openstack/client.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/golang/glog"
+	"github.com/go-kit/kit/log"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -49,6 +49,8 @@ type client struct {
 
 	domainNameToID sync.Map
 	roleNameToID   sync.Map
+
+	Logger log.Logger
 }
 
 type Client interface {
@@ -165,7 +167,7 @@ func (r *StateExt) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func NewClient(secrets typedv1.SecretInterface, klusterEvents cache.SharedIndexInformer, authURL, username, password, domain, project, projectDomain string) Client {
+func NewClient(secrets typedv1.SecretInterface, klusterEvents cache.SharedIndexInformer, authURL, username, password, domain, project, projectDomain string, logger log.Logger) Client {
 
 	c := &client{
 		authURL:           authURL,
@@ -175,12 +177,16 @@ func NewClient(secrets typedv1.SecretInterface, klusterEvents cache.SharedIndexI
 		authProject:       project,
 		authProjectDomain: projectDomain,
 		secrets:           secrets,
+		Logger:            log.With(logger, "client", "openstack"),
 	}
 
 	klusterEvents.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			if kluster, ok := obj.(*kubernikus_v1.Kluster); ok {
-				glog.V(5).Infof("Deleting shared openstack client for kluster %s", kluster.Name)
+				c.Logger.Log(
+					"msg", "deleting shared openstack client",
+					"kluster", kluster.Name,
+					"v", 5)
 				c.klusterClients.Delete(kluster.GetUID())
 			}
 		},
@@ -248,7 +254,13 @@ func (c *client) klusterClientFor(kluster *kubernikus_v1.Kluster) (*gophercloud.
 		},
 	}
 
-	glog.V(5).Infof("AuthOptions: %#v", authOptions)
+	c.Logger.Log(
+		"msg", "using authOptions from secret",
+		"identity_endpoint", authOptions.IdentityEndpoint,
+		"username", authOptions.Username,
+		"domain_name", authOptions.DomainName,
+		"project_id", authOptions.Scope.ProjectID,
+		"v", 5)
 
 	err = openstack.AuthenticateV3(provider, authOptions, gophercloud.EndpointOpts{})
 	if err != nil {
@@ -526,7 +538,6 @@ func (c *client) GetNodes(kluster *kubernikus_v1.Kluster, pool *models.NodePool)
 	err = servers.List(client, opts).EachPage(func(page pagination.Page) (bool, error) {
 		nodes, err = ExtractServers(page)
 		if err != nil {
-			glog.V(5).Infof("Couldn't extract server %v", err)
 			return false, err
 		}
 
@@ -539,7 +550,22 @@ func (c *client) GetNodes(kluster *kubernikus_v1.Kluster, pool *models.NodePool)
 	return nodes, nil
 }
 
-func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePool, userData []byte) (string, error) {
+func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePool, userData []byte) (id string, err error) {
+	var name string
+
+	defer func() {
+		c.Logger.Log(
+			"msg", "created node",
+			"kluster", kluster.Name,
+			"project", kluster.Account(),
+			"name", name,
+			"id", id,
+			"v", 5,
+			"err", err)
+	}()
+
+	name = v1.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", kluster.Spec.Name, pool.Name))
+
 	provider, err := c.klusterClientFor(kluster)
 	if err != nil {
 		return "", err
@@ -550,8 +576,7 @@ func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePoo
 		return "", err
 	}
 
-	name := v1.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", kluster.Spec.Name, pool.Name))
-	glog.V(5).Infof("Creating node %v", name)
+	name = v1.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", kluster.Spec.Name, pool.Name))
 
 	server, err := servers.Create(client, compute.CreateOpts{
 		CreateOpts: servers.CreateOpts{
@@ -566,13 +591,23 @@ func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePoo
 	}).Extract()
 
 	if err != nil {
-		glog.V(5).Infof("Couldn't create node %v: %v", name, err)
 		return "", err
 	}
+
 	return server.ID, nil
 }
 
-func (c *client) DeleteNode(kluster *kubernikus_v1.Kluster, ID string) error {
+func (c *client) DeleteNode(kluster *kubernikus_v1.Kluster, ID string) (err error) {
+	defer func() {
+		c.Logger.Log(
+			"msg", "deleted node",
+			"kluster", kluster.Name,
+			"project", kluster.Account(),
+			"id", ID,
+			"v", 5,
+			"err", err)
+	}()
+
 	provider, err := c.klusterClientFor(kluster)
 	if err != nil {
 		return err
@@ -585,7 +620,6 @@ func (c *client) DeleteNode(kluster *kubernikus_v1.Kluster, ID string) error {
 
 	err = servers.Delete(client, ID).ExtractErr()
 	if err != nil {
-		glog.V(5).Infof("Couldn't delete node %v: %v", kluster.Name, err)
 		return err
 	}
 

--- a/pkg/cmd/kubernikus/certificates.go
+++ b/pkg/cmd/kubernikus/certificates.go
@@ -1,12 +1,21 @@
 package kubernikus
 
 import (
+	"os"
+
+	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/certificates"
+	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
 func NewCertificatesCommand() *cobra.Command {
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = logutil.NewTrailingNilFilter(logger)
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", Caller(3))
+
 	c := &cobra.Command{
 		Use:   "certificates",
 		Short: "Debug certificates",
@@ -15,7 +24,7 @@ func NewCertificatesCommand() *cobra.Command {
 	c.AddCommand(
 		certificates.NewFilesCommand(),
 		certificates.NewPlainCommand(),
-		certificates.NewSignCommand(),
+		certificates.NewSignCommand(logger),
 	)
 
 	return c

--- a/pkg/cmd/kubernikus/certificates/sign.go
+++ b/pkg/cmd/kubernikus/certificates/sign.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/ghodss/yaml"
+	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,8 +18,8 @@ import (
 	"github.com/sapcc/kubernikus/pkg/util"
 )
 
-func NewSignCommand() *cobra.Command {
-	o := NewSignOptions()
+func NewSignCommand(logger log.Logger) *cobra.Command {
+	o := NewSignOptions(logger)
 
 	c := &cobra.Command{
 		Use:   "sign KLUSTER",
@@ -41,14 +42,17 @@ type SignOptions struct {
 	CA           string
 	Organization string
 	ApiURL       string
+
+	Logger log.Logger
 }
 
-func NewSignOptions() *SignOptions {
+func NewSignOptions(logger log.Logger) *SignOptions {
 	return &SignOptions{
 		Namespace:    "kubernikus",
 		CA:           "apiserver-clients-ca",
 		CN:           os.Getenv("USER"),
 		Organization: "system:masters",
+		Logger:       logger,
 	}
 }
 
@@ -81,7 +85,7 @@ func (o *SignOptions) Complete(args []string) error {
 }
 
 func (o *SignOptions) Run(c *cobra.Command) error {
-	client, err := kubernetes.NewClient(o.KubeConfig, "")
+	client, err := kubernetes.NewClient(o.KubeConfig, "", o.Logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/kubernikus/seed.go
+++ b/pkg/cmd/kubernikus/seed.go
@@ -1,19 +1,28 @@
 package kubernikus
 
 import (
+	"os"
+
+	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/seed"
+	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
 func NewSeedCommand() *cobra.Command {
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = logutil.NewTrailingNilFilter(logger)
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", Caller(3))
+
 	c := &cobra.Command{
 		Use:   "seed",
 		Short: "Seed stuff",
 	}
 
 	c.AddCommand(
-		seed.NewKubeDNSCommand(),
+		seed.NewKubeDNSCommand(logger),
 	)
 
 	return c

--- a/pkg/cmd/kubernikus/seed/dns.go
+++ b/pkg/cmd/kubernikus/seed/dns.go
@@ -3,6 +3,7 @@ package seed
 import (
 	"errors"
 
+	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -11,8 +12,8 @@ import (
 	"github.com/sapcc/kubernikus/pkg/controller/ground/bootstrap/dns"
 )
 
-func NewKubeDNSCommand() *cobra.Command {
-	o := NewKubeDNSOptions()
+func NewKubeDNSCommand(logger log.Logger) *cobra.Command {
+	o := NewKubeDNSOptions(logger)
 
 	c := &cobra.Command{
 		Use:   "dns",
@@ -36,13 +37,16 @@ type KubeDNSOptions struct {
 	version    string
 	domain     string
 	clusterIP  string
+
+	Logger log.Logger
 }
 
-func NewKubeDNSOptions() *KubeDNSOptions {
+func NewKubeDNSOptions(logger log.Logger) *KubeDNSOptions {
 	return &KubeDNSOptions{
 		repository: dns.DEFAULT_REPOSITORY,
 		version:    dns.DEFAULT_VERSION,
 		domain:     dns.DEFAULT_DOMAIN,
+		Logger:     logger,
 	}
 }
 
@@ -67,7 +71,7 @@ func (o *KubeDNSOptions) Complete(args []string) error {
 }
 
 func (o *KubeDNSOptions) Run(c *cobra.Command) error {
-	client, err := kubernetes.NewClient(o.kubeConfig, o.context)
+	client, err := kubernetes.NewClient(o.kubeConfig, o.context, o.Logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/wormhole/server.go
+++ b/pkg/cmd/wormhole/server.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/golang/glog"
+	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -16,8 +16,8 @@ import (
 	"github.com/sapcc/kubernikus/pkg/wormhole"
 )
 
-func NewServerCommand() *cobra.Command {
-	o := NewServerOptions()
+func NewServerCommand(logger log.Logger) *cobra.Command {
+	o := NewServerOptions(log.With(logger, "wormhole", "server"))
 
 	c := &cobra.Command{
 		Use:   "server",
@@ -38,8 +38,10 @@ type ServerOptions struct {
 	wormhole.ServerOptions
 }
 
-func NewServerOptions() *ServerOptions {
-	return &ServerOptions{}
+func NewServerOptions(logger log.Logger) *ServerOptions {
+	o := &ServerOptions{}
+	o.Logger = logger
+	return o
 }
 
 func (o *ServerOptions) BindFlags(flags *pflag.FlagSet) {
@@ -76,7 +78,7 @@ func (o *ServerOptions) Run(c *cobra.Command) error {
 	go server.Run(stop, wg)
 
 	<-sigs // Wait for signals (this hangs until a signal arrives)
-	glog.Info("Shutting down...")
+	o.Logger.Log("msg", "Shutting down...")
 	close(stop) // Tell goroutines to stop themselves
 	wg.Wait()   // Wait for all to be stopped
 

--- a/pkg/cmd/wormhole/wormhole.go
+++ b/pkg/cmd/wormhole/wormhole.go
@@ -2,11 +2,21 @@ package wormhole
 
 import (
 	"flag"
+	"os"
 
+	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
+
+	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus"
+	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
 func NewCommand(name string) *cobra.Command {
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = logutil.NewTrailingNilFilter(logger)
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", kubernikus.Caller(3))
+
 	c := &cobra.Command{
 		Use:   name,
 		Short: "Wormhole as a Service",
@@ -14,8 +24,8 @@ func NewCommand(name string) *cobra.Command {
 	}
 
 	c.AddCommand(
-		NewServerCommand(),
-		NewClientCommand(),
+		NewServerCommand(logger),
+		NewClientCommand(logger),
 	)
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 

--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -108,7 +108,7 @@ func (cpm *ConcretePoolManager) CreateNode() (id string, err error) {
 		return "", err
 	}
 
-	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, secret)
+	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, secret, cpm.Logger)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -180,8 +180,12 @@ func init() {
 	)
 }
 
-func ExposeMetrics(metricPort int, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
-	glog.Infof("Exposing metrics on localhost:%v/metrics ", metricPort)
+func ExposeMetrics(host string, metricPort int, stopCh <-chan struct{}, wg *sync.WaitGroup, logger log.Logger) error {
+	logger.Log(
+		"msg", "Exposing metrics",
+		"host", host,
+		"port", metricPort,
+		"path", "/metrics")
 	defer wg.Done()
 	wg.Add(1)
 	for {
@@ -191,7 +195,7 @@ func ExposeMetrics(metricPort int, stopCh <-chan struct{}, wg *sync.WaitGroup) e
 		default:
 			http.Handle("/metrics", promhttp.Handler())
 			return http.ListenAndServe(
-				fmt.Sprintf("0.0.0.0:%v", metricPort),
+				fmt.Sprintf("%v:%v", host, metricPort),
 				nil,
 			)
 		}

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -9,7 +9,8 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/coreos/container-linux-config-transpiler/config"
 	"github.com/coreos/container-linux-config-transpiler/config/platform"
-	"github.com/golang/glog"
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/go-kit/kit/log"
 	"k8s.io/client-go/pkg/api/v1"
 
 	kubernikusv1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
@@ -35,8 +36,7 @@ var Ignition = &ignition{
 	},
 }
 
-func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, secret *v1.Secret) ([]byte, error) {
-
+func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, secret *v1.Secret, logger log.Logger) ([]byte, error) {
 	for _, field := range i.requiredNodeSecrets {
 		if _, ok := secret.Data[field]; !ok {
 			return nil, fmt.Errorf("Field %s missing in secret", field)
@@ -90,18 +90,28 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, secret *v1.Secret
 		KubernikusImageTag:                 version.GitCommit,
 	}
 
+	var dataOut []byte
 	var buffer bytes.Buffer
+	var report report.Report
+
+	defer func() {
+		logger.Log(
+			"msg", "ignition debug",
+			"data", data,
+			"yaml", string(buffer.Bytes()),
+			"json", string(dataOut),
+			"report", report.String(),
+			"v", 6,
+			"err", err)
+	}()
+
 	err = tmpl.Execute(&buffer, data)
 	if err != nil {
 		return nil, err
 	}
 
-	glog.V(6).Infof("IgnitionData: %v", data)
-	glog.V(6).Infof("IgnitionYAML: %v", string(buffer.Bytes()))
-
 	ignitionConfig, ast, report := config.Parse(buffer.Bytes())
 	if len(report.Entries) > 0 {
-		glog.V(2).Infof("Something odd while transpiling ignition file: %v", report.String())
 		if report.IsFatal() {
 			return nil, fmt.Errorf("Couldn't transpile ignition file: %v", report.String())
 		}
@@ -109,17 +119,13 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, secret *v1.Secret
 
 	ignitionConfig2_0, report := config.ConvertAs2_0(ignitionConfig, platform.OpenStackMetadata, ast)
 	if len(report.Entries) > 0 {
-		glog.V(2).Infof("Something odd while convertion ignition config: %v", report.String())
 		if report.IsFatal() {
 			return nil, fmt.Errorf("Couldn't convert ignition config: %v", report.String())
 		}
 	}
 
-	var dataOut []byte
 	dataOut, err = json.MarshalIndent(&ignitionConfig2_0, "", "  ")
 	dataOut = append(dataOut, '\n')
-
-	glog.V(6).Infof("IgnitionJSON: %v", string(dataOut))
 
 	if err != nil {
 		return nil, err

--- a/pkg/templates/ignition_test.go
+++ b/pkg/templates/ignition_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
@@ -42,6 +43,6 @@ func TestGenerateNode(t *testing.T) {
 		ObjectMeta: kluster.ObjectMeta,
 		Data:       secretData,
 	}
-	_, err := Ignition.GenerateNode(&kluster, &secret)
+	_, err := Ignition.GenerateNode(&kluster, &secret, log.NewNopLogger())
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This commit removes all glog references in favor of the structured
logging approach using go-kit/log.

There is plenty room for improvement. The intention here is to rid glog
without introducing to many bugs.

`kubernikusctl` is left to use glog as the main intent of logging here
is human consumption on the cli without an intermediate log retrieval
system. Also, there's tight integration with k8s clients that log using
glog anyway.

The log output is not yet completely clean and 100% structured logging,
because of the informer framwork being uncooperative. We could get rid
of that using a higher default log threshold instead of the default
`INFO`. That exercise is left for another time.