### PR TITLE
Specify security groups by id when creating servers

### DIFF
--- a/pkg/api/models/openstack_spec.go
+++ b/pkg/api/models/openstack_spec.go
@@ -27,6 +27,9 @@ type OpenstackSpec struct {
 
 	// router ID
 	RouterID string `json:"routerID,omitempty"`
+
+	// security group ID
+	SecurityGroupID string `json:"securityGroupID,omitempty"`
 }
 
 // Validate validates this openstack spec

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -642,6 +642,9 @@ func init() {
         },
         "routerID": {
           "type": "string"
+        },
+        "securityGroupID": {
+          "type": "string"
         }
       },
       "x-nullable": false

--- a/pkg/client/openstack/compute/create_options.go
+++ b/pkg/client/openstack/compute/create_options.go
@@ -1,0 +1,32 @@
+package compute
+
+import (
+	"errors"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+type CreateOpts struct {
+	servers.CreateOpts
+}
+
+func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
+	data, err := opts.CreateOpts.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := data["server"]; !ok {
+		return nil, errors.New("Expected field `server` not found")
+	}
+
+	serverData, ok := data["server"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("Field `server` not of expected type")
+	}
+	securityGroups := make([]map[string]interface{}, len(opts.SecurityGroups))
+	for i, groupID := range opts.SecurityGroups {
+		securityGroups[i] = map[string]interface{}{"id": groupID}
+	}
+	serverData["security_groups"] = securityGroups
+	return data, nil
+}

--- a/pkg/client/openstack/compute/create_options_test.go
+++ b/pkg/client/openstack/compute/create_options_test.go
@@ -1,0 +1,27 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateOpts(t *testing.T) {
+	opts := CreateOpts{
+		CreateOpts: servers.CreateOpts{
+			Name:           "nase",
+			FlavorRef:      "flavor",
+			SecurityGroups: []string{"id1", "id2"},
+		}}
+
+	data, err := opts.ToServerCreateMap()
+	assert.NoError(t, err)
+	serverData := data["server"].(map[string]interface{})
+	expected := []map[string]interface{}{
+		map[string]interface{}{"id": opts.SecurityGroups[0]},
+		map[string]interface{}{"id": opts.SecurityGroups[1]},
+	}
+	assert.Equal(t, expected, serverData["security_groups"])
+	assert.Equal(t, opts.Name, serverData["name"])
+}

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -141,6 +141,11 @@ func (op *GroundControl) handler(key string) error {
 		metrics.SetMetricKlusterInfo(kluster.GetNamespace(), kluster.GetName(), kluster.Status.Version, kluster.Spec.Openstack.ProjectID, kluster.GetAnnotations(), kluster.GetLabels())
 		metrics.SetMetricKlusterStatusPhase(kluster.GetName(), kluster.Status.Phase)
 
+		//TODO: remove ASAP, this is just a poor mans migration, adding the sec group id to existing klusters
+		if err := op.ensureSecurityGroupID(kluster); err != nil {
+			op.Recorder.Eventf(kluster, api_v1.EventTypeWarning, ConfigurationError, "Failed to add default security grop id to kluster: %s", err)
+		}
+
 		switch phase := kluster.Status.Phase; phase {
 		case models.KlusterPhasePending:
 			{
@@ -477,8 +482,38 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		}
 	}
 
+	if securityGroupID := copy.Spec.Openstack.SecurityGroupID; securityGroupID != "" {
+		//TODO: Validate that the securitygroup id exists
+
+	} else {
+		id, err := op.Clients.Openstack.GetSecurityGroupID(kluster.Account(), "default")
+		if err != nil {
+			return fmt.Errorf("Failed to get id for default securitygroup in project %s: %s", err, kluster.Account())
+		}
+		glog.V(5).Infof("[%v] Setting SecurityGroupID to %v", kluster.Name, copy.Spec.Openstack.SecurityGroupID)
+		copy.Spec.Openstack.SecurityGroupID = id
+	}
+
 	_, err = op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Update(copy)
 	return err
+}
+
+//TODO: remove this after it has been deployed once everywhere, this is a poor mans migration
+func (op *GroundControl) ensureSecurityGroupID(kluster *v1.Kluster) error {
+	if kluster.Spec.Openstack.SecurityGroupID == "" {
+		copy, err := op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Get(kluster.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		id, err := op.Clients.Openstack.GetSecurityGroupID(kluster.Account(), "default")
+		if err != nil {
+			return fmt.Errorf("Failed to get id for default securitygroup in project %s: %s", err, kluster.Account())
+		}
+		copy.Spec.Openstack.SecurityGroupID = id
+		_, err = op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Update(copy)
+		return err
+	}
+	return nil
 }
 
 func (op *GroundControl) podAdd(obj interface{}) {

--- a/swagger.yml
+++ b/swagger.yml
@@ -370,6 +370,8 @@ definitions:
       lbSubnetID:
         x-go-name: LBSubnetID
         type: string
+      securityGroupID:
+        type: string
   NodePool:
     x-nullable: false
     type: object

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/doc.go
@@ -1,0 +1,58 @@
+/*
+Package groups provides information and interaction with Security Groups
+for the OpenStack Networking service.
+
+Example to List Security Groups
+
+	listOpts := groups.ListOpts{
+		TenantID: "966b3c7d36a24facaf20b7e458bf2192",
+	}
+
+	allPages, err := groups.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allGroups, err := groups.ExtractGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, group := range allGroups {
+		fmt.Printf("%+v\n", group)
+	}
+
+Example to Create a Security Group
+
+	createOpts := groups.CreateOpts{
+		Name:        "group_name",
+		Description: "A Security Group",
+	}
+
+	group, err := groups.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Security Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+
+	updateOpts := groups.UpdateOpts{
+		Name: "new_name",
+	}
+
+	group, err := groups.Update(networkClient, groupID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := groups.Delete(networkClient, groupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package groups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
@@ -1,0 +1,151 @@
+package groups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the group attributes you want to see returned. SortKey allows you to
+// sort by a particular network attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID       string `q:"id"`
+	Name     string `q:"name"`
+	TenantID string `q:"tenant_id"`
+	Limit    int    `q:"limit"`
+	Marker   string `q:"marker"`
+	SortKey  string `q:"sort_key"`
+	SortDir  string `q:"sort_dir"`
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// security groups. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+	q, err := gophercloud.BuildQueryString(&opts)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	u := rootURL(c) + q.String()
+	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return SecGroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSecGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new security group.
+type CreateOpts struct {
+	// Human-readable name for the Security Group. Does not have to be unique.
+	Name string `json:"name" required:"true"`
+
+	// The UUID of the tenant who owns the Group. Only administrative users
+	// can specify a tenant UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// Describes the security group.
+	Description string `json:"description,omitempty"`
+}
+
+// ToSecGroupCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToSecGroupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "security_group")
+}
+
+// Create is an operation which provisions a new security group with default
+// security group rules for the IPv4 and IPv6 ether types.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSecGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSecGroupUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update an existing security
+// group.
+type UpdateOpts struct {
+	// Human-readable name for the Security Group. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Describes the security group.
+	Description string `json:"description,omitempty"`
+}
+
+// ToSecGroupUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "security_group")
+}
+
+// Update is an operation which updates an existing security group.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToSecGroupUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get retrieves a particular security group based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// Delete will permanently delete a particular security group based on its
+// unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a security group's ID,
+// given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, ListOpts{}).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractGroups(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "security group"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "security group"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -1,0 +1,102 @@
+package groups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// SecGroup represents a container for security group rules.
+type SecGroup struct {
+	// The UUID for the security group.
+	ID string
+
+	// Human-readable name for the security group. Might not be unique.
+	// Cannot be named "default" as that is automatically created for a tenant.
+	Name string
+
+	// The security group description.
+	Description string
+
+	// A slice of security group rules that dictate the permitted behaviour for
+	// traffic entering and leaving the group.
+	Rules []rules.SecGroupRule `json:"security_group_rules"`
+
+	// Owner of the security group.
+	TenantID string `json:"tenant_id"`
+}
+
+// SecGroupPage is the page returned by a pager when traversing over a
+// collection of security groups.
+type SecGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of security groups has
+// reached the end of a page and the pager seeks to traverse over a new one. In
+// order to do this, it needs to construct the next page's URL.
+func (r SecGroupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"security_groups_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a SecGroupPage struct is empty.
+func (r SecGroupPage) IsEmpty() (bool, error) {
+	is, err := ExtractGroups(r)
+	return len(is) == 0, err
+}
+
+// ExtractGroups accepts a Page struct, specifically a SecGroupPage struct,
+// and extracts the elements into a slice of SecGroup structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractGroups(r pagination.Page) ([]SecGroup, error) {
+	var s struct {
+		SecGroups []SecGroup `json:"security_groups"`
+	}
+	err := (r.(SecGroupPage)).ExtractInto(&s)
+	return s.SecGroups, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a security group.
+func (r commonResult) Extract() (*SecGroup, error) {
+	var s struct {
+		SecGroup *SecGroup `json:"security_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.SecGroup, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SecGroup.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a SecGroup.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SecGroup.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/urls.go
@@ -1,0 +1,13 @@
+package groups
+
+import "github.com/gophercloud/gophercloud"
+
+const rootPath = "security-groups"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/doc.go
@@ -1,0 +1,50 @@
+/*
+Package rules provides information and interaction with Security Group Rules
+for the OpenStack Networking service.
+
+Example to List Security Groups Rules
+
+	listOpts := rules.ListOpts{
+		Protocol: "tcp",
+	}
+
+	allPages, err := rules.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRules, err := rules.ExtractRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rule := range allRules {
+		fmt.Printf("%+v\n", rule)
+	}
+
+Example to Create a Security Group Rule
+
+	createOpts := rules.CreateOpts{
+		Direction:     "ingress",
+		PortRangeMin:  80,
+		EtherType:     rules.EtherType4,
+		PortRangeMax:  80,
+		Protocol:      "tcp",
+		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
+		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
+	}
+
+	rule, err := rules.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group Rule
+
+	ruleID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := rules.Delete(networkClient, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package rules

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -1,0 +1,154 @@
+package rules
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the security group rule attributes you want to see returned. SortKey allows
+// you to sort by a particular network attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Direction      string `q:"direction"`
+	EtherType      string `q:"ethertype"`
+	ID             string `q:"id"`
+	PortRangeMax   int    `q:"port_range_max"`
+	PortRangeMin   int    `q:"port_range_min"`
+	Protocol       string `q:"protocol"`
+	RemoteGroupID  string `q:"remote_group_id"`
+	RemoteIPPrefix string `q:"remote_ip_prefix"`
+	SecGroupID     string `q:"security_group_id"`
+	TenantID       string `q:"tenant_id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// security group rules. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+	q, err := gophercloud.BuildQueryString(&opts)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	u := rootURL(c) + q.String()
+	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return SecGroupRulePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type RuleDirection string
+type RuleProtocol string
+type RuleEtherType string
+
+// Constants useful for CreateOpts
+const (
+	DirIngress        RuleDirection = "ingress"
+	DirEgress         RuleDirection = "egress"
+	EtherType4        RuleEtherType = "IPv4"
+	EtherType6        RuleEtherType = "IPv6"
+	ProtocolAH        RuleProtocol  = "ah"
+	ProtocolDCCP      RuleProtocol  = "dccp"
+	ProtocolEGP       RuleProtocol  = "egp"
+	ProtocolESP       RuleProtocol  = "esp"
+	ProtocolGRE       RuleProtocol  = "gre"
+	ProtocolICMP      RuleProtocol  = "icmp"
+	ProtocolIGMP      RuleProtocol  = "igmp"
+	ProtocolIPv6Encap RuleProtocol  = "ipv6-encap"
+	ProtocolIPv6Frag  RuleProtocol  = "ipv6-frag"
+	ProtocolIPv6ICMP  RuleProtocol  = "ipv6-icmp"
+	ProtocolIPv6NoNxt RuleProtocol  = "ipv6-nonxt"
+	ProtocolIPv6Opts  RuleProtocol  = "ipv6-opts"
+	ProtocolIPv6Route RuleProtocol  = "ipv6-route"
+	ProtocolOSPF      RuleProtocol  = "ospf"
+	ProtocolPGM       RuleProtocol  = "pgm"
+	ProtocolRSVP      RuleProtocol  = "rsvp"
+	ProtocolSCTP      RuleProtocol  = "sctp"
+	ProtocolTCP       RuleProtocol  = "tcp"
+	ProtocolUDP       RuleProtocol  = "udp"
+	ProtocolUDPLite   RuleProtocol  = "udplite"
+	ProtocolVRRP      RuleProtocol  = "vrrp"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSecGroupRuleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new security group
+// rule.
+type CreateOpts struct {
+	// Must be either "ingress" or "egress": the direction in which the security
+	// group rule is applied.
+	Direction RuleDirection `json:"direction" required:"true"`
+
+	// Must be "IPv4" or "IPv6", and addresses represented in CIDR must match the
+	// ingress or egress rules.
+	EtherType RuleEtherType `json:"ethertype" required:"true"`
+
+	// The security group ID to associate with this security group rule.
+	SecGroupID string `json:"security_group_id" required:"true"`
+
+	// The maximum port number in the range that is matched by the security group
+	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
+	// the protocol is ICMP, this value must be an ICMP type.
+	PortRangeMax int `json:"port_range_max,omitempty"`
+
+	// The minimum port number in the range that is matched by the security group
+	// rule. If the protocol is TCP or UDP, this value must be less than or equal
+	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
+	// value must be an ICMP type.
+	PortRangeMin int `json:"port_range_min,omitempty"`
+
+	// The protocol that is matched by the security group rule. Valid values are
+	// "tcp", "udp", "icmp" or an empty string.
+	Protocol RuleProtocol `json:"protocol,omitempty"`
+
+	// The remote group ID to be associated with this security group rule. You can
+	// specify either RemoteGroupID or RemoteIPPrefix.
+	RemoteGroupID string `json:"remote_group_id,omitempty"`
+
+	// The remote IP prefix to be associated with this security group rule. You can
+	// specify either RemoteGroupID or RemoteIPPrefix. This attribute matches the
+	// specified IP prefix as the source IP address of the IP packet.
+	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
+
+	// The UUID of the tenant who owns the Rule. Only administrative users
+	// can specify a tenant UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
+// ToSecGroupRuleCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToSecGroupRuleCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "security_group_rule")
+}
+
+// Create is an operation which adds a new security group rule and associates it
+// with an existing security group (whose ID is specified in CreateOpts).
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSecGroupRuleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular security group rule based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// Delete will permanently delete a particular security group rule based on its
+// unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -1,0 +1,121 @@
+package rules
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// SecGroupRule represents a rule to dictate the behaviour of incoming or
+// outgoing traffic for a particular security group.
+type SecGroupRule struct {
+	// The UUID for this security group rule.
+	ID string
+
+	// The direction in which the security group rule is applied. The only values
+	// allowed are "ingress" or "egress". For a compute instance, an ingress
+	// security group rule is applied to incoming (ingress) traffic for that
+	// instance. An egress rule is applied to traffic leaving the instance.
+	Direction string
+
+	// Must be IPv4 or IPv6, and addresses represented in CIDR must match the
+	// ingress or egress rules.
+	EtherType string `json:"ethertype"`
+
+	// The security group ID to associate with this security group rule.
+	SecGroupID string `json:"security_group_id"`
+
+	// The minimum port number in the range that is matched by the security group
+	// rule. If the protocol is TCP or UDP, this value must be less than or equal
+	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
+	// value must be an ICMP type.
+	PortRangeMin int `json:"port_range_min"`
+
+	// The maximum port number in the range that is matched by the security group
+	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
+	// the protocol is ICMP, this value must be an ICMP type.
+	PortRangeMax int `json:"port_range_max"`
+
+	// The protocol that is matched by the security group rule. Valid values are
+	// "tcp", "udp", "icmp" or an empty string.
+	Protocol string
+
+	// The remote group ID to be associated with this security group rule. You
+	// can specify either RemoteGroupID or RemoteIPPrefix.
+	RemoteGroupID string `json:"remote_group_id"`
+
+	// The remote IP prefix to be associated with this security group rule. You
+	// can specify either RemoteGroupID or RemoteIPPrefix . This attribute
+	// matches the specified IP prefix as the source IP address of the IP packet.
+	RemoteIPPrefix string `json:"remote_ip_prefix"`
+
+	// The owner of this security group rule.
+	TenantID string `json:"tenant_id"`
+}
+
+// SecGroupRulePage is the page returned by a pager when traversing over a
+// collection of security group rules.
+type SecGroupRulePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of security group rules has
+// reached the end of a page and the pager seeks to traverse over a new one. In
+// order to do this, it needs to construct the next page's URL.
+func (r SecGroupRulePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"security_group_rules_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a SecGroupRulePage struct is empty.
+func (r SecGroupRulePage) IsEmpty() (bool, error) {
+	is, err := ExtractRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractRules accepts a Page struct, specifically a SecGroupRulePage struct,
+// and extracts the elements into a slice of SecGroupRule structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractRules(r pagination.Page) ([]SecGroupRule, error) {
+	var s struct {
+		SecGroupRules []SecGroupRule `json:"security_group_rules"`
+	}
+	err := (r.(SecGroupRulePage)).ExtractInto(&s)
+	return s.SecGroupRules, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a security rule.
+func (r commonResult) Extract() (*SecGroupRule, error) {
+	var s struct {
+		SecGroupRule *SecGroupRule `json:"security_group_rule"`
+	}
+	err := r.ExtractInto(&s)
+	return s.SecGroupRule, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SecGroupRule.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SecGroupRule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/urls.go
@@ -1,0 +1,13 @@
+package rules
+
+import "github.com/gophercloud/gophercloud"
+
+const rootPath = "security-group-rules"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}


### PR DESCRIPTION
This PR adds a field `SecurityGroupID` to the kluster spec.
If its not specified the auto discovery fills in the `id` of the `default` security group.
This id is then used when creating instances (e.g. by launchctl).

I added a poor mans migration into the `groundctl` reconciliation to retrofit existing clusters with the `id` of the projects `default` security group.
I will remove this hack in a subsequent commit once it has been deployed everywhere (and all clusters have the security group set)