### PR TITLE
Add leveled logging

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	kitLog "github.com/go-kit/kit/log"
-	"github.com/go-stack/stack"
 	"github.com/spf13/pflag"
 
 	apipkg "github.com/sapcc/kubernikus/pkg/api"
@@ -92,8 +90,4 @@ func main() {
 		os.Exit(1)
 	}
 
-}
-
-func Caller(depth int) kitLog.Valuer {
-	return func() interface{} { return fmt.Sprintf("%+v", stack.Caller(depth)) }
 }

--- a/cmd/kubernikus/main.go
+++ b/cmd/kubernikus/main.go
@@ -1,17 +1,18 @@
 package main
 
 import (
+	goflag "flag"
 	"os"
 	"path/filepath"
-
-	"github.com/golang/glog"
 
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus"
 )
 
 func main() {
-	defer glog.Flush()
+	if f := goflag.Lookup("logtostderr"); f != nil {
+		f.Value.Set("true") // log to stderr by default
+	}
 
 	baseName := filepath.Base(os.Args[0])
 

--- a/cmd/kubernikusctl/main.go
+++ b/cmd/kubernikusctl/main.go
@@ -1,23 +1,20 @@
 package main
 
 import (
-	"flag"
+	goflag "flag"
 	"os"
 	"path/filepath"
-
-	"github.com/golang/glog"
 
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl"
 )
 
 func main() {
-	defer glog.Flush()
-
-	baseName := filepath.Base(os.Args[0])
-	if f := flag.Lookup("logtostderr"); f != nil {
+	if f := goflag.Lookup("logtostderr"); f != nil {
 		f.Value.Set("true")
 	}
+
+	baseName := filepath.Base(os.Args[0])
 
 	err := kubernikusctl.NewCommand(baseName).Execute()
 	cmd.CheckError(err)

--- a/cmd/nanny/main.go
+++ b/cmd/nanny/main.go
@@ -5,14 +5,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
-
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/cmd/nanny"
 )
 
 func main() {
-	defer glog.Flush()
 	if f := goflag.Lookup("logtostderr"); f != nil {
 		f.Value.Set("true") // log to stderr by default
 	}

--- a/cmd/wormhole/main.go
+++ b/cmd/wormhole/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"flag"
+	goflag "flag"
 	"os"
 	"path/filepath"
-
-	"github.com/golang/glog"
 
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/cmd/wormhole"
 )
 
 func main() {
-	defer glog.Flush()
-	if f := flag.Lookup("logtostderr"); f != nil {
+	if f := goflag.Lookup("logtostderr"); f != nil {
 		f.Value.Set("true") // log to stderr by default
 	}
 

--- a/pkg/cmd/kubernikus/certificates.go
+++ b/pkg/cmd/kubernikus/certificates.go
@@ -1,20 +1,12 @@
 package kubernikus
 
 import (
-	"os"
-
-	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/certificates"
-	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
 func NewCertificatesCommand() *cobra.Command {
-	var logger log.Logger
-	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = logutil.NewTrailingNilFilter(logger)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", Caller(3))
 
 	c := &cobra.Command{
 		Use:   "certificates",
@@ -24,7 +16,7 @@ func NewCertificatesCommand() *cobra.Command {
 	c.AddCommand(
 		certificates.NewFilesCommand(),
 		certificates.NewPlainCommand(),
-		certificates.NewSignCommand(logger),
+		certificates.NewSignCommand(),
 	)
 
 	return c

--- a/pkg/cmd/kubernikus/certificates/sign.go
+++ b/pkg/cmd/kubernikus/certificates/sign.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/ghodss/yaml"
-	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,10 +15,11 @@ import (
 	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/util"
+	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
-func NewSignCommand(logger log.Logger) *cobra.Command {
-	o := NewSignOptions(logger)
+func NewSignCommand() *cobra.Command {
+	o := NewSignOptions()
 
 	c := &cobra.Command{
 		Use:   "sign KLUSTER",
@@ -42,17 +42,14 @@ type SignOptions struct {
 	CA           string
 	Organization string
 	ApiURL       string
-
-	Logger log.Logger
 }
 
-func NewSignOptions(logger log.Logger) *SignOptions {
+func NewSignOptions() *SignOptions {
 	return &SignOptions{
 		Namespace:    "kubernikus",
 		CA:           "apiserver-clients-ca",
 		CN:           os.Getenv("USER"),
 		Organization: "system:masters",
-		Logger:       logger,
 	}
 }
 
@@ -85,7 +82,8 @@ func (o *SignOptions) Complete(args []string) error {
 }
 
 func (o *SignOptions) Run(c *cobra.Command) error {
-	client, err := kubernetes.NewClient(o.KubeConfig, "", o.Logger)
+	logger := logutil.NewLogger(c.Flags())
+	client, err := kubernetes.NewClient(o.KubeConfig, "", logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/kubernikus/operator.go
+++ b/pkg/cmd/kubernikus/operator.go
@@ -2,7 +2,6 @@ package kubernikus
 
 import (
 	"errors"
-	goflag "flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -22,10 +21,6 @@ import (
 
 func NewOperatorCommand() *cobra.Command {
 	o := NewOperatorOptions()
-
-	if f := goflag.Lookup("logtostderr"); f != nil {
-		f.Value.Set("true") // log to stderr by default
-	}
 
 	c := &cobra.Command{
 		Use:   "operator",
@@ -91,10 +86,8 @@ func (o *Options) Complete(args []string) error {
 }
 
 func (o *Options) Run(c *cobra.Command) error {
-	var logger log.Logger
-	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = logutil.NewTrailingNilFilter(logger)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", Caller(3))
+
+	logger := logutil.NewLogger(c.Flags())
 
 	sigs := make(chan os.Signal, 1)
 	stop := make(chan struct{})

--- a/pkg/cmd/kubernikus/operator.go
+++ b/pkg/cmd/kubernikus/operator.go
@@ -2,14 +2,11 @@ package kubernikus
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-stack/stack"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -108,8 +105,4 @@ func (o *Options) Run(c *cobra.Command) error {
 	wg.Wait()   // Wait for all to be stopped
 
 	return nil
-}
-
-func Caller(depth int) log.Valuer {
-	return func() interface{} { return fmt.Sprintf("%+v", stack.Caller(depth)) }
 }

--- a/pkg/cmd/kubernikus/seed.go
+++ b/pkg/cmd/kubernikus/seed.go
@@ -1,20 +1,12 @@
 package kubernikus
 
 import (
-	"os"
-
-	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus/seed"
-	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
 func NewSeedCommand() *cobra.Command {
-	var logger log.Logger
-	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = logutil.NewTrailingNilFilter(logger)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", Caller(3))
 
 	c := &cobra.Command{
 		Use:   "seed",
@@ -22,7 +14,7 @@ func NewSeedCommand() *cobra.Command {
 	}
 
 	c.AddCommand(
-		seed.NewKubeDNSCommand(logger),
+		seed.NewKubeDNSCommand(),
 	)
 
 	return c

--- a/pkg/cmd/kubernikus/seed/dns.go
+++ b/pkg/cmd/kubernikus/seed/dns.go
@@ -3,17 +3,17 @@ package seed
 import (
 	"errors"
 
-	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	"github.com/sapcc/kubernikus/pkg/controller/ground/bootstrap/dns"
+	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
-func NewKubeDNSCommand(logger log.Logger) *cobra.Command {
-	o := NewKubeDNSOptions(logger)
+func NewKubeDNSCommand() *cobra.Command {
+	o := NewKubeDNSOptions()
 
 	c := &cobra.Command{
 		Use:   "dns",
@@ -37,16 +37,13 @@ type KubeDNSOptions struct {
 	version    string
 	domain     string
 	clusterIP  string
-
-	Logger log.Logger
 }
 
-func NewKubeDNSOptions(logger log.Logger) *KubeDNSOptions {
+func NewKubeDNSOptions() *KubeDNSOptions {
 	return &KubeDNSOptions{
 		repository: dns.DEFAULT_REPOSITORY,
 		version:    dns.DEFAULT_VERSION,
 		domain:     dns.DEFAULT_DOMAIN,
-		Logger:     logger,
 	}
 }
 
@@ -71,7 +68,8 @@ func (o *KubeDNSOptions) Complete(args []string) error {
 }
 
 func (o *KubeDNSOptions) Run(c *cobra.Command) error {
-	client, err := kubernetes.NewClient(o.kubeConfig, o.context, o.Logger)
+	logger := logutil.NewLogger(c.Flags())
+	client, err := kubernetes.NewClient(o.kubeConfig, o.context, logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/nanny/nanny.go
+++ b/pkg/cmd/nanny/nanny.go
@@ -3,10 +3,8 @@ package nanny
 import (
 	"flag"
 	"net"
-	"os"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -26,7 +24,7 @@ func NewCommand(name string) *cobra.Command {
 			if err := cmd.Validate(o, c, args); err != nil {
 				return err
 			}
-			return run(o)
+			return o.Run(c)
 		},
 	}
 	o.BindFlags(c.Flags())
@@ -66,11 +64,8 @@ func (o *Options) BindFlags(flags *pflag.FlagSet) {
 	flags.DurationVar(&o.SyncPeriod, "sync-period", o.SyncPeriod, "How often should the sync handler run.")
 }
 
-func run(o *Options) error {
-	var logger log.Logger
-	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = logutil.NewTrailingNilFilter(logger)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+func (o *Options) Run(c *cobra.Command) error {
+	logger := logutil.NewLogger(c.Flags())
 
 	group := cmd.Runner()
 	authOpts := tokens.AuthOptions{

--- a/pkg/cmd/wormhole/server.go
+++ b/pkg/cmd/wormhole/server.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/sapcc/kubernikus/pkg/cmd"
 	logutil "github.com/sapcc/kubernikus/pkg/util/log"
-	"github.com/sapcc/kubernikus/pkg/wormhole"
+	"github.com/sapcc/kubernikus/pkg/wormhole/server"
 )
 
 func NewServerCommand() *cobra.Command {
@@ -35,7 +35,7 @@ func NewServerCommand() *cobra.Command {
 }
 
 type ServerOptions struct {
-	wormhole.ServerOptions
+	server.Options
 }
 
 func NewServerOptions() *ServerOptions {
@@ -70,7 +70,7 @@ func (o *ServerOptions) Run(c *cobra.Command) error {
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM) // Push signals into channel
 	wg := &sync.WaitGroup{}                            // Goroutines can add themselves to this to be waited on
 
-	server, err := wormhole.NewServer(&o.ServerOptions)
+	server, err := server.New(&o.Options)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize server: %s", err)
 	}

--- a/pkg/cmd/wormhole/server.go
+++ b/pkg/cmd/wormhole/server.go
@@ -8,16 +8,16 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/sapcc/kubernikus/pkg/cmd"
+	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 	"github.com/sapcc/kubernikus/pkg/wormhole"
 )
 
-func NewServerCommand(logger log.Logger) *cobra.Command {
-	o := NewServerOptions(log.With(logger, "wormhole", "server"))
+func NewServerCommand() *cobra.Command {
+	o := NewServerOptions()
 
 	c := &cobra.Command{
 		Use:   "server",
@@ -38,9 +38,8 @@ type ServerOptions struct {
 	wormhole.ServerOptions
 }
 
-func NewServerOptions(logger log.Logger) *ServerOptions {
+func NewServerOptions() *ServerOptions {
 	o := &ServerOptions{}
-	o.Logger = logger
 	return o
 }
 
@@ -65,6 +64,7 @@ func (o *ServerOptions) Complete(args []string) error {
 }
 
 func (o *ServerOptions) Run(c *cobra.Command) error {
+	o.Logger = logutil.NewLogger(c.Flags())
 	sigs := make(chan os.Signal, 1)
 	stop := make(chan struct{})
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM) // Push signals into channel

--- a/pkg/cmd/wormhole/wormhole.go
+++ b/pkg/cmd/wormhole/wormhole.go
@@ -2,20 +2,11 @@ package wormhole
 
 import (
 	"flag"
-	"os"
 
-	"github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
-
-	"github.com/sapcc/kubernikus/pkg/cmd/kubernikus"
-	logutil "github.com/sapcc/kubernikus/pkg/util/log"
 )
 
 func NewCommand(name string) *cobra.Command {
-	var logger log.Logger
-	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = logutil.NewTrailingNilFilter(logger)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", kubernikus.Caller(3))
 
 	c := &cobra.Command{
 		Use:   name,
@@ -24,8 +15,8 @@ func NewCommand(name string) *cobra.Command {
 	}
 
 	c.AddCommand(
-		NewServerCommand(logger),
-		NewClientCommand(logger),
+		NewServerCommand(),
+		NewClientCommand(),
 	)
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 

--- a/pkg/util/log/levelfilter.go
+++ b/pkg/util/log/levelfilter.go
@@ -1,0 +1,36 @@
+package log
+
+import (
+	"errors"
+
+	kitlog "github.com/go-kit/kit/log"
+)
+
+type levelFilter struct {
+	threshold int
+	next      kitlog.Logger
+}
+
+var levelKey interface{} = "v"
+
+// NewLevelFilter filters log messages based on a level key.
+// It discards log messages
+func NewLevelFilter(level int, logger kitlog.Logger) kitlog.Logger {
+	return &levelFilter{threshold: level, next: logger}
+}
+
+func (l levelFilter) Log(keyvals ...interface{}) error {
+	for i := len(keyvals) - 2; i >= 0; i -= 2 {
+		if keyvals[i] == levelKey {
+			if lvl, ok := keyvals[i+1].(int); ok {
+				if lvl <= l.threshold {
+					l.next.Log(keyvals...)
+				}
+				return nil // filter log message
+			}
+			return errors.New("Level value is not of expected type (int)")
+		}
+	}
+	//ALways log lines without a level
+	return l.next.Log(keyvals...)
+}

--- a/pkg/util/log/levelfilter_test.go
+++ b/pkg/util/log/levelfilter_test.go
@@ -1,0 +1,36 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelFilter(t *testing.T) {
+	var buf bytes.Buffer
+	logger := kitlog.NewLogfmtLogger(&buf)
+	logger = NewLevelFilter(2, logger)
+	assert.NoError(t, logger.Log("key", "val"))
+	assert.Equal(t, "key=val\n", buf.String())
+
+	buf.Reset()
+	assert.NoError(t, logger.Log("v", 2))
+	assert.Equal(t, "v=2\n", buf.String())
+
+	buf.Reset()
+	assert.NoError(t, logger.Log("v", 3))
+	assert.Equal(t, "", buf.String())
+
+	buf.Reset()
+	assert.NoError(t, logger.Log("key", "val", "v", 3))
+	assert.Equal(t, "", buf.String())
+
+	buf.Reset()
+	assert.NoError(t, logger.Log("key", "val", "v", 3, "key2", "val2"))
+	assert.Equal(t, "", buf.String())
+
+	assert.Error(t, logger.Log("v", "noint"))
+
+}

--- a/pkg/util/log/logging.go
+++ b/pkg/util/log/logging.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	kitLog "github.com/go-kit/kit/log"
+	"github.com/go-stack/stack"
+	"github.com/spf13/pflag"
+)
+
+func NewLogger(flags *pflag.FlagSet) kitLog.Logger {
+	//for now we piggyback on the --v flag defined by glog.
+	level := 0
+	if v := flags.Lookup("v"); v != nil {
+		level, _ = strconv.Atoi(v.Value.String())
+	}
+	fmt.Println("Logging with level ", level)
+
+	var logger kitLog.Logger
+	logger = kitLog.NewLogfmtLogger(kitLog.NewSyncWriter(os.Stderr))
+	logger = NewTrailingNilFilter(logger)
+	logger = NewLevelFilter(level, logger)
+	logger = kitLog.With(logger, "ts", kitLog.DefaultTimestampUTC, "caller", Caller(3))
+
+	return logger
+
+}
+
+func Caller(depth int) kitLog.Valuer {
+	return func() interface{} { return fmt.Sprintf("%+v", stack.Caller(depth)) }
+}

--- a/pkg/wormhole/server.go
+++ b/pkg/wormhole/server.go
@@ -22,8 +22,6 @@ type ServerOptions struct {
 	Context     string
 	ServiceCIDR string
 	server.TunnelOptions
-
-	Logger log.Logger
 }
 
 type Server struct {
@@ -37,9 +35,6 @@ type Server struct {
 
 func NewServer(options *ServerOptions) (*Server, error) {
 	s := &Server{Logger: log.With(options.Logger, "wormhole", "server")}
-	if options.TunnelOptions.Logger == nil {
-		options.TunnelOptions.Logger = options.Logger
-	}
 
 	client, err := kube.NewClient(options.KubeConfig, options.Context, options.Logger)
 	if err != nil {

--- a/pkg/wormhole/server/options.go
+++ b/pkg/wormhole/server/options.go
@@ -1,0 +1,17 @@
+package server
+
+import "github.com/go-kit/kit/log"
+
+type Options struct {
+	Logger log.Logger
+
+	//Used by the controller
+	KubeConfig  string
+	Context     string
+	ServiceCIDR string
+
+	//Used by the tunnel
+	ClientCA    string
+	Certificate string
+	PrivateKey  string
+}

--- a/pkg/wormhole/server/server.go
+++ b/pkg/wormhole/server/server.go
@@ -1,4 +1,4 @@
-package wormhole
+package server
 
 import (
 	"sync"
@@ -10,31 +10,23 @@ import (
 
 	kube "github.com/sapcc/kubernikus/pkg/client/kubernetes"
 	"github.com/sapcc/kubernikus/pkg/version"
-	"github.com/sapcc/kubernikus/pkg/wormhole/server"
 )
 
 const (
 	DEFAULT_RECONCILIATION = 5 * time.Minute
 )
 
-type ServerOptions struct {
-	KubeConfig  string
-	Context     string
-	ServiceCIDR string
-	server.TunnelOptions
-}
-
 type Server struct {
 	factory    informers.SharedInformerFactory
 	client     kubernetes.Interface
-	controller *server.Controller
-	tunnel     *server.Tunnel
+	controller *Controller
+	tunnel     *Tunnel
 
-	Logger log.Logger
+	logger log.Logger
 }
 
-func NewServer(options *ServerOptions) (*Server, error) {
-	s := &Server{Logger: log.With(options.Logger, "wormhole", "server")}
+func New(options *Options) (*Server, error) {
+	s := &Server{logger: log.With(options.Logger, "wormhole", "server")}
 
 	client, err := kube.NewClient(options.KubeConfig, options.Context, options.Logger)
 	if err != nil {
@@ -43,27 +35,27 @@ func NewServer(options *ServerOptions) (*Server, error) {
 
 	s.client = client
 	s.factory = informers.NewSharedInformerFactory(s.client, DEFAULT_RECONCILIATION)
-	s.tunnel, err = server.NewTunnel(&options.TunnelOptions)
+	s.tunnel, err = NewTunnel(options)
 	if err != nil {
 		return nil, err
 	}
-	s.controller = server.NewController(s.factory.Core().V1().Nodes(), options.ServiceCIDR, s.tunnel.Server, options.Logger)
+	s.controller = NewController(s.factory.Core().V1().Nodes(), options.ServiceCIDR, s.tunnel.Server, options.Logger)
 
 	return s, nil
 }
 
 func (s *Server) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
-	s.Logger.Log(
-		"msg", "powering up wormhole generator",
+	s.logger.Log(
+		"msg", "Starting wormhole server",
 		"version", version.GitCommit,
 	)
 
-	kube.WaitForServer(s.client, stopCh, s.Logger)
+	kube.WaitForServer(s.client, stopCh, s.logger)
 
 	s.factory.Start(stopCh)
 	s.factory.WaitForCacheSync(stopCh)
 
-	s.Logger.Log(
+	s.logger.Log(
 		"msg", "Cache primed. Ready for Action!",
 	)
 

--- a/pkg/wormhole/server/tunnel.go
+++ b/pkg/wormhole/server/tunnel.go
@@ -18,15 +18,7 @@ type Tunnel struct {
 	Logger log.Logger
 }
 
-type TunnelOptions struct {
-	ClientCA    string
-	Certificate string
-	PrivateKey  string
-
-	Logger log.Logger
-}
-
-func NewTunnel(options *TunnelOptions) (*Tunnel, error) {
+func NewTunnel(options *Options) (*Tunnel, error) {
 	logger := log.With(options.Logger, "wormhole", "tunnel")
 
 	var listener net.Listener


### PR DESCRIPTION
I reused the `—v` flag for glog to set the desired log level. By default we only log messages with no level or level 0.
For the flag processing to work I had to move the logger creation into the cobra commands `Run` functions because otherwise I can’t access the flag without hussle.

I moved the logging setup to logutil.NewLogger() to that we can reuse that function in all binaries.