### PR TITLE
fix default backend and use it only for 502,503,504

### DIFF
--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ template "controller.fullname" . }}
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
-  custom-http-errors: 404,500
+  custom-http-errors: {{.Values.defaultBackend.custom_http_errors}}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
 {{- end }}

--- a/charts/kubernikus-system/charts/nginx-ingress/values.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/values.yaml
@@ -143,8 +143,10 @@ defaultBackend:
   name: default-backend
   image:
     repository: sapcc/custombackend
-    tag: "0.1"
+    tag: "0.3"
     pullPolicy: IfNotPresent
+
+  custom_http_errors: 502,503,504
 
   extraArgs: {}
 


### PR DESCRIPTION
The `out of range error` happend [here](https://github.com/kubernetes/ingress-nginx/blob/master/images/custom-error-pages/main.go#L64). Added a check before.
Also just use the default backend for `502,503,504`.
Issue https://github.com/sapcc/kubernikus/issues/133 /cc @databus23 
