### PR TITLE
Sort (and filter) flavors in metadata response

### DIFF
--- a/pkg/api/models/flavor_sorter.go
+++ b/pkg/api/models/flavor_sorter.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"sort"
+)
+
+type flavorSorter struct {
+	flavors []Flavor
+}
+
+func SortFlavors(flavors []Flavor) {
+	sort.Sort(&flavorSorter{flavors: flavors})
+}
+
+//Part of sort.Interface
+func (fs *flavorSorter) Len() int {
+	return len(fs.flavors)
+}
+
+func (fs *flavorSorter) Swap(i, j int) {
+	fs.flavors[i], fs.flavors[j] = fs.flavors[j], fs.flavors[i]
+}
+
+func (fs *flavorSorter) Less(i, j int) bool {
+	if fs.flavors[i].RAM <= fs.flavors[j].RAM {
+		return true
+	}
+	return fs.flavors[i].Vcpus < fs.flavors[i].Vcpus
+}

--- a/pkg/api/models/flavor_sorter_test.go
+++ b/pkg/api/models/flavor_sorter_test.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlavorSorter(t *testing.T) {
+
+	m1small := Flavor{ID: "m1.small", RAM: 2046, Vcpus: 2}
+	m1xsmall := Flavor{ID: "m1.xsmall", RAM: 4096, Vcpus: 2}
+	m1medium := Flavor{ID: "m1.medium", RAM: 4096, Vcpus: 4}
+	m1xmedium := Flavor{ID: "m1.xmedium", RAM: 8192, Vcpus: 4}
+
+	input := []Flavor{m1xmedium, m1medium, m1small, m1xsmall}
+
+	SortFlavors(input)
+
+	expected := []Flavor{m1small, m1xsmall, m1medium, m1xmedium}
+
+	assert.Equal(t, expected, input)
+
+}

--- a/pkg/api/models/openstack_metadata.go
+++ b/pkg/api/models/openstack_metadata.go
@@ -19,7 +19,7 @@ import (
 type OpenstackMetadata struct {
 
 	// flavors
-	Flavors []*Flavor `json:"flavors"`
+	Flavors []Flavor `json:"flavors"`
 
 	// key pairs
 	KeyPairs []*KeyPair `json:"keyPairs"`
@@ -65,24 +65,6 @@ func (m *OpenstackMetadata) validateFlavors(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Flavors) { // not required
 		return nil
-	}
-
-	for i := 0; i < len(m.Flavors); i++ {
-
-		if swag.IsZero(m.Flavors[i]) { // not required
-			continue
-		}
-
-		if m.Flavors[i] != nil {
-
-			if err := m.Flavors[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("flavors" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
 	}
 
 	return nil
@@ -196,6 +178,12 @@ type Flavor struct {
 
 	// name
 	Name string `json:"name,omitempty"`
+
+	// ram
+	RAM int64 `json:"ram"`
+
+	// vcpus
+	Vcpus int64 `json:"vcpus"`
 }
 
 // Validate validates this flavor

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -550,9 +550,16 @@ func init() {
               },
               "name": {
                 "type": "string"
+              },
+              "ram": {
+                "type": "integer"
+              },
+              "vcpus": {
+                "type": "integer"
               }
             },
-            "x-go-name": "Flavor"
+            "x-go-name": "Flavor",
+            "x-nullable": false
           }
         },
         "keyPairs": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -205,6 +205,7 @@ definitions:
       flavors:
         type: array
         items:
+          x-nullable: false
           type: object
           x-go-name: Flavor
           properties:
@@ -212,6 +213,10 @@ definitions:
               type: string
             id:
               type: string
+            ram:
+              type: integer
+            vcpus:
+              type: integer
       securityGroups:
         type: array
         items:


### PR DESCRIPTION
Flavors are now sorted by RAM and VCPUs.
Also the RAM and VCPUs are now part of the reponse.
Additionally I hardcoded the flavors list call for now to only return flavors with 2000 MB RAM or more to get rid of the tiny images that don’t work with our default coreos image

Fixes #130