### PR TITLE
Fix Broken Doc Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It allows to easily manage Kubernetes clusters that are natively integrated with
 
 More documentation can be found at:
 
-  * [blob/master/docs/](blob/master/docs/)
+  * [Kubernikus Docs](./docs/)
   
 ## Contact
 


### PR DESCRIPTION
Doesn't have to be in this syntax, but docs link is broken, so here's a fix.