### PR TITLE
Adds Kluster Deorbit Controller

### DIFF
--- a/docs/development/controllers.md
+++ b/docs/development/controllers.md
@@ -2,6 +2,37 @@ Kubernikus Controllers
 ======================
 The Kubernikus operator contains various independent controllers each one handling a different aspect of the managed kubernetes clusters.
 
+Deorbit Controller
+------------------
+
+The Kubernetes `controller-manager` runs controllers that are responsible for
+creating, updating and deleting of OpenStack resources. It auto-provisions
+Cinder volumes for Persistent Volume Claims, load balancers for services and
+routes for nodes in the cluster.  When a kluster is terminated it is desired
+that these resources are cleaned up automatically. 
+
+The problem is that the `controller-manager` only cleans up, when the
+respective resources are deleted from the cluster.
+
+This is where the `deorbiter` comes into play. It inspects the cluster and
+deletes all PVCs that are backed by Cinder, as well as all services of type
+`LoadBalancer`. Afterwards, it waits until the `controller-manager` has
+completed the clean-up.
+
+Problematic is that Cinder volumes can take a variable time until they are
+deleted. In some cases volumes might be stuck deleting indefinitely. The
+`deorbiter` watches the PVs (note: PV not PVC) in the cluster and waits for all
+of them to disappear. PVs are guarded by a finalizer and are only removed when
+the cleanup completes. The `deorbiter` retries the deletion for a configurable
+amount of time and eventually self-destructs the cluster. This might leave some
+debris in the OpenStack project. 
+
+For services Kubernetes does currently not implement the same finalizer
+concept. That means that a service is deleted immediately while the clean-up
+progresses in the background. Without double checking directly in OpenStack,
+the `deboriter` can't tell when the deletion is completed. Here we assume
+a fixed time, like 2 minutes, and hope for the best. 
+
 
 Route garbage collector
 -----------------------
@@ -11,3 +42,5 @@ The bug occasionally leaves static route entries in the cluster's OpenStack rout
 The bug is fixed in the upcoming 1.10 version of kubernetes. That means this controller is only needed for clusters <1.10.
 
 For each cluster the controller polls the corresponding OpenStack router and inspects the configured static routes. It tries to identify and remove orphaned routes to fix the clusters networking. It removes all route entries for CIDR ranges that are within the clusters CIDR range for Pods where the target/nextHop ip address can't be matched to an OpenStack compute instance.
+
+

--- a/pkg/cmd/kubernikus/operator.go
+++ b/pkg/cmd/kubernikus/operator.go
@@ -49,7 +49,7 @@ func NewOperatorOptions() *Options {
 	options.KubernikusDomain = "kluster.staging.cloud.sap"
 	options.Namespace = "kubernikus"
 	options.MetricPort = 9091
-	options.Controllers = []string{"groundctl", "launchctl", "routegc"}
+	options.Controllers = []string{"groundctl", "launchctl", "deorbiter", "routegc"}
 	return options
 }
 

--- a/pkg/controller/deorbit/controller.go
+++ b/pkg/controller/deorbit/controller.go
@@ -1,0 +1,149 @@
+package deorbit
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/base"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/metrics"
+	informers_kubernikus "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/util"
+)
+
+func init() {
+	prometheus.MustRegister(
+		metrics.DeorbitOperationsLatency,
+		metrics.DeorbitOperationsTotal,
+		metrics.DeorbitSuccessfulOperationsTotal,
+		metrics.DeorbitFailedOperationsTotal,
+	)
+}
+
+const (
+	DeorbiterFinalizer = "deorbiter"
+
+	// The longest time a single worker will be blocked, while waiting for the clean
+	// up of OpenStack resources. After this timeout, deorbiting will be queued again.
+	// It's a safeguard against having all workers hanging indefinetly and congesting
+	// the queue.
+	UnblockWorkerTimeout = 10 * time.Minute
+)
+
+type DeorbitReconciler struct {
+	config.Clients
+
+	Recorder record.EventRecorder
+	Logger   log.Logger
+
+	klusterInformer informers_kubernikus.KlusterInformer
+}
+
+func NewController(threadiness int, factories config.Factories, clients config.Clients, recorder record.EventRecorder, logger log.Logger) base.Controller {
+	logger = log.With(logger, "controller", "deorbit")
+
+	var reconciler base.Reconciler
+	reconciler = &DeorbitReconciler{clients, recorder, logger, factories.Kubernikus.Kubernikus().V1().Klusters()}
+	reconciler = &base.LoggingReconciler{reconciler, logger}
+	reconciler = &base.InstrumentingReconciler{
+		reconciler,
+		metrics.DeorbitOperationsLatency,
+		metrics.DeorbitOperationsTotal,
+		metrics.DeorbitSuccessfulOperationsTotal,
+		metrics.DeorbitFailedOperationsTotal,
+	}
+	return base.NewController(threadiness, factories, clients, reconciler, logger)
+}
+
+func (d *DeorbitReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {
+	switch kluster.Status.Phase {
+	case models.KlusterPhaseRunning:
+		return false, util.EnsureFinalizerCreated(d.Kubernikus.KubernikusV1(), d.klusterInformer.Lister(), kluster, DeorbiterFinalizer)
+	case models.KlusterPhaseTerminating:
+		if kluster.HasFinalizer(DeorbiterFinalizer) {
+			if err := d.deorbit(kluster); err != nil {
+				return false, err
+			}
+			return false, util.EnsureFinalizerRemoved(d.Kubernikus.KubernikusV1(), d.klusterInformer.Lister(), kluster, DeorbiterFinalizer)
+		}
+	}
+	return false, nil
+}
+
+func (d *DeorbitReconciler) deorbit(kluster *v1.Kluster) (err error) {
+	// The following channel is used to abort the deorbiting after a certain
+	// time. It is required because the deorbit wait-functions block indefinetly or
+	// until the stop channel is closed. This is used to unblock the workqueue.
+	done := make(chan struct{})
+
+	timer := time.NewTimer(UnblockWorkerTimeout)
+	defer timer.Stop()
+
+	go func() {
+		<-timer.C
+		d.Logger.Log("msg", "timeout waiting. unblocking the worker routine")
+		close(done)
+	}()
+
+	deorbiter, err := NewDeorbiter(kluster, done, d.Clients, d.Recorder, d.Logger)
+	if err != nil {
+		return err
+	}
+
+	err = d.doDeorbit(deorbiter)
+
+	return d.doSelfDestruct(deorbiter, err)
+}
+
+func (d *DeorbitReconciler) doDeorbit(deorbiter Deorbiter) (err error) {
+	deletedPVCs, err := deorbiter.DeletePersistentVolumeClaims()
+	if err != nil {
+		return err
+	}
+
+	deletedServices, err := deorbiter.DeleteServices()
+	if err != nil {
+		return err
+	}
+
+	if len(deletedPVCs) > 0 {
+		if err := deorbiter.WaitForPersistentVolumeCleanup(); err != nil {
+			return err
+		}
+	}
+
+	if len(deletedServices) > 0 {
+		if err := deorbiter.WaitForServiceCleanup(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DeorbitReconciler) doSelfDestruct(deorbiter Deorbiter, outer error) (err error) {
+	// If for some reason communication with the Kluster's apiserver is not possible,
+	// we retry until a timeout is reached. Then self-destruct and accept debris.
+	if errors.IsUnexpectedServerError(outer) || errors.IsServerTimeout(outer) {
+		if deorbiter.IsAPIUnavailableTimeout() {
+			err = deorbiter.SelfDestruct(APIUnavailable)
+		}
+	}
+
+	// Self-Destruct if the Kluster is stuck in deorbitting for a long time. This
+	// timeout is long enough for reaction of an operations team and alerts to fire.
+	// Keeps the chance to analyse what went wrong. Eventually this unstuckes the
+	// Kluster automatically without human interaction. It frees up the Kluster with
+	// the downside of potential debris in the customer's project.
+	if deorbiter.IsDeorbitHangingTimeout() {
+		err = deorbiter.SelfDestruct(DeorbitHanging)
+	}
+
+	return err
+}

--- a/pkg/controller/deorbit/controller_test.go
+++ b/pkg/controller/deorbit/controller_test.go
@@ -1,0 +1,77 @@
+package deorbit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+var (
+	ServerTimeout = errors.NewServerTimeout(core_v1.Resource("services"), "GET", 0)
+)
+
+func TestDeborit(testing *testing.T) {
+	reconciler := &DeorbitReconciler{}
+
+	deorbiter := &FakeDeorbiter{
+		CinderPVCCount: 3,
+		LBServiceCount: 2,
+	}
+
+	err := reconciler.doDeorbit(deorbiter)
+	err = reconciler.doSelfDestruct(deorbiter, err)
+	assert.Equal(testing, true, deorbiter.HasCalledDeletePersistentVolumeClaims)
+	assert.Equal(testing, true, deorbiter.HasCalledDeleteServices)
+	assert.Equal(testing, true, deorbiter.HasCalledWaitForPersistentVolumeCleanup)
+	assert.Equal(testing, true, deorbiter.HasCalledWaitForServiceCleanup)
+	assert.Equal(testing, false, deorbiter.HasCalledSeldDestruct)
+	assert.NoError(testing, err)
+
+	deorbiter = &FakeDeorbiter{
+		CinderPVCCount: 0,
+		LBServiceCount: 0,
+	}
+
+	err = reconciler.doDeorbit(deorbiter)
+	err = reconciler.doSelfDestruct(deorbiter, err)
+	assert.Equal(testing, true, deorbiter.HasCalledDeletePersistentVolumeClaims)
+	assert.Equal(testing, true, deorbiter.HasCalledDeleteServices)
+	assert.Equal(testing, false, deorbiter.HasCalledWaitForPersistentVolumeCleanup)
+	assert.Equal(testing, false, deorbiter.HasCalledWaitForServiceCleanup)
+	assert.Equal(testing, false, deorbiter.HasCalledSeldDestruct)
+	assert.NoError(testing, err)
+
+	deorbiter = &FakeDeorbiter{
+		CinderPVCCount: 3,
+		LBServiceCount: 2,
+		APIDown:        true,
+	}
+
+	err = reconciler.doDeorbit(deorbiter)
+	err = reconciler.doSelfDestruct(deorbiter, ServerTimeout)
+	assert.Equal(testing, true, deorbiter.HasCalledDeletePersistentVolumeClaims)
+	assert.Equal(testing, true, deorbiter.HasCalledDeleteServices)
+	assert.Equal(testing, true, deorbiter.HasCalledWaitForPersistentVolumeCleanup)
+	assert.Equal(testing, true, deorbiter.HasCalledWaitForServiceCleanup)
+	assert.Equal(testing, true, deorbiter.HasCalledSeldDestruct)
+	assert.Equal(testing, APIUnavailable, deorbiter.SelfDestructReason)
+	assert.NoError(testing, err)
+
+	deorbiter = &FakeDeorbiter{
+		CinderPVCCount: 3,
+		LBServiceCount: 2,
+		Hanging:        true,
+	}
+
+	err = reconciler.doDeorbit(deorbiter)
+	err = reconciler.doSelfDestruct(deorbiter, err)
+	assert.Equal(testing, true, deorbiter.HasCalledDeletePersistentVolumeClaims)
+	assert.Equal(testing, true, deorbiter.HasCalledDeleteServices)
+	assert.Equal(testing, true, deorbiter.HasCalledWaitForPersistentVolumeCleanup)
+	assert.Equal(testing, true, deorbiter.HasCalledWaitForServiceCleanup)
+	assert.Equal(testing, true, deorbiter.HasCalledSeldDestruct)
+	assert.Equal(testing, DeorbitHanging, deorbiter.SelfDestructReason)
+	assert.NoError(testing, err)
+}

--- a/pkg/controller/deorbit/deorbiter.go
+++ b/pkg/controller/deorbit/deorbiter.go
@@ -1,0 +1,190 @@
+package deorbit
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/metrics"
+)
+
+type SelfDestructReason string
+
+const (
+	APIUnavailable SelfDestructReason = "APIUnavailable"
+	DeorbitHanging SelfDestructReason = "DeorbitHanging"
+
+	// If the customer's apiserver is unreachable for this duration, we assume it is
+	// already decomissioned, permanently damaged or was never created successfully
+	// in the first place.
+	APIUnavailableTimeout = 2 * time.Minute
+
+	// After this duration, the deorbiter will utimately give up retrying. This will
+	// potentially leave debris in the customer's project in the form of volumes,
+	// load balancers or floating IPs.
+	DeorbitHangingTimeout = 24 * time.Hour
+
+	// As of this writing services are not yet migrated to make use of
+	// finalizers. In effect there's no feedback loop and a deleted service
+	// disappears immediately - even though the cloud provider isn't finished yet
+	// with the decomissioning of existing load balancers. We guess that it takes
+	// around this duration until the clean-up was successful.
+	ServiceDeletionGracePeriod = 2 * time.Minute
+
+	// While waiting for deletion use this interval for rechecks
+	PollInterval = 15 * time.Second
+)
+
+type Deorbiter interface {
+	DeletePersistentVolumeClaims() ([]core_v1.PersistentVolumeClaim, error)
+	DeleteServices() ([]core_v1.Service, error)
+	WaitForPersistentVolumeCleanup() error
+	WaitForServiceCleanup() error
+	SelfDestruct(SelfDestructReason) error
+	IsAPIUnavailableTimeout() bool
+	IsDeorbitHangingTimeout() bool
+}
+
+type ConcreteDeorbiter struct {
+	Kluster *v1.Kluster
+	Stop    <-chan struct{}
+	Client  kubernetes.Interface
+	Logger  log.Logger
+}
+
+func NewDeorbiter(kluster *v1.Kluster, stopCh <-chan struct{}, clients config.Clients, recorder record.EventRecorder, logger log.Logger) (Deorbiter, error) {
+	client, err := clients.Satellites.ClientFor(kluster)
+	if err != nil {
+		return nil, err
+	}
+
+	var deorbiter Deorbiter
+	deorbiter = &ConcreteDeorbiter{kluster, stopCh, client, logger}
+	deorbiter = &LoggingDeorbiter{deorbiter, logger}
+	deorbiter = &EventingDeorbiter{deorbiter, kluster, recorder}
+	deorbiter = &InstrumentingDeorbiter{
+		deorbiter,
+		metrics.DeorbitOperationsLatency,
+		metrics.DeorbitOperationsTotal,
+		metrics.DeorbitSuccessfulOperationsTotal,
+		metrics.DeorbitFailedOperationsTotal,
+	}
+
+	return deorbiter, nil
+}
+
+func (d *ConcreteDeorbiter) DeletePersistentVolumeClaims() (deleted []core_v1.PersistentVolumeClaim, err error) {
+	deleted = []core_v1.PersistentVolumeClaim{}
+
+	pvcs, err := d.Client.Core().PersistentVolumeClaims(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
+	if err != nil {
+		return deleted, err
+	}
+
+	for _, pvc := range pvcs.Items {
+		pv, err := d.Client.Core().PersistentVolumes().Get(pvc.Spec.VolumeName, meta_v1.GetOptions{})
+		if err != nil {
+			return deleted, err
+		}
+
+		if pv.Spec.Cinder == nil {
+			continue
+		}
+		deleted = append(deleted, pvc)
+
+		err = d.Client.Core().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, &meta_v1.DeleteOptions{})
+		if err != nil {
+			return deleted, err
+		}
+	}
+
+	return deleted, err
+}
+
+func (d *ConcreteDeorbiter) DeleteServices() (deleted []core_v1.Service, err error) {
+	deleted = []core_v1.Service{}
+
+	services, err := d.Client.Core().Services(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
+	if err != nil {
+		return deleted, err
+	}
+
+	for _, service := range services.Items {
+		if service.Spec.Type != "LoadBalancer" {
+			continue
+		}
+		deleted = append(deleted, service)
+
+		err = d.Client.Core().Services(service.Namespace).Delete(service.Name, &meta_v1.DeleteOptions{})
+		if err != nil {
+			return deleted, err
+		}
+	}
+
+	return deleted, err
+}
+
+func (d *ConcreteDeorbiter) WaitForPersistentVolumeCleanup() (err error) {
+	done, err := d.isPersistentVolumesCleanupFinished()
+	if err != nil {
+		return err
+	}
+
+	if done {
+		return nil
+	}
+
+	return wait.PollUntil(PollInterval, d.isPersistentVolumesCleanupFinished, d.Stop)
+}
+
+func (d *ConcreteDeorbiter) WaitForServiceCleanup() (err error) {
+	done, err := d.isServiceCleanupFinished()
+	if err != nil {
+		return err
+	}
+
+	if done {
+		return nil
+	}
+
+	return wait.PollUntil(PollInterval, d.isServiceCleanupFinished, d.Stop)
+}
+
+func (d *ConcreteDeorbiter) SelfDestruct(reason SelfDestructReason) (err error) {
+	// Self-Destruct ironically does nothing
+	return nil
+}
+
+func (d *ConcreteDeorbiter) IsAPIUnavailableTimeout() bool {
+	return d.Kluster.ObjectMeta.DeletionTimestamp.Add(APIUnavailableTimeout).Before(time.Now())
+}
+
+func (d *ConcreteDeorbiter) IsDeorbitHangingTimeout() bool {
+	return d.Kluster.ObjectMeta.DeletionTimestamp.Add(DeorbitHangingTimeout).Before(time.Now())
+}
+
+func (d *ConcreteDeorbiter) isPersistentVolumesCleanupFinished() (bool, error) {
+	pvs, err := d.Client.Core().PersistentVolumes().List(meta_v1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, pv := range pvs.Items {
+		if pv.Spec.PersistentVolumeSource.Cinder != nil {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (d *ConcreteDeorbiter) isServiceCleanupFinished() (bool, error) {
+	return d.Kluster.ObjectMeta.DeletionTimestamp.Add(ServiceDeletionGracePeriod).Before(time.Now()), nil
+}

--- a/pkg/controller/deorbit/deorbiter_test.go
+++ b/pkg/controller/deorbit/deorbiter_test.go
@@ -1,0 +1,222 @@
+package deorbit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	kubernikus_v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+)
+
+var (
+	kluster = &kubernikus_v1.Kluster{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	pvCinder0 = &core_v1.PersistentVolume{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pv-cinder0",
+		},
+		Spec: core_v1.PersistentVolumeSpec{
+			PersistentVolumeSource: core_v1.PersistentVolumeSource{
+				Cinder: &core_v1.CinderVolumeSource{
+					VolumeID: "hase",
+				},
+			},
+		},
+	}
+
+	pvCinder1 = &core_v1.PersistentVolume{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pv-cinder1",
+		},
+		Spec: core_v1.PersistentVolumeSpec{
+			PersistentVolumeSource: core_v1.PersistentVolumeSource{
+				Cinder: &core_v1.CinderVolumeSource{
+					VolumeID: "maus",
+				},
+			},
+		},
+	}
+
+	pvNFS = &core_v1.PersistentVolume{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pv-nfs",
+		},
+		Spec: core_v1.PersistentVolumeSpec{
+			PersistentVolumeSource: core_v1.PersistentVolumeSource{
+				NFS: &core_v1.NFSVolumeSource{},
+			},
+		},
+	}
+
+	pvcCinder0 = &core_v1.PersistentVolumeClaim{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pvc-cinder0",
+		},
+		Spec: core_v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-cinder0",
+		},
+	}
+
+	pvcCinder1 = &core_v1.PersistentVolumeClaim{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pvc-cinder1",
+		},
+		Spec: core_v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-cinder1",
+		},
+	}
+
+	pvcNFS = &core_v1.PersistentVolumeClaim{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pvc-nfs",
+		},
+		Spec: core_v1.PersistentVolumeClaimSpec{
+			VolumeName: "pv-nfs",
+		},
+	}
+
+	svcLB0 = &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "svc-lb0",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type: "LoadBalancer",
+		},
+	}
+
+	svcLB1 = &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "svc-lb1",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type: "LoadBalancer",
+		},
+	}
+
+	svcCIP = &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "svc-cip",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type: "ClusterIP",
+		},
+	}
+)
+
+func TestIsServiceCleanupFinished(testing *testing.T) {
+	type test_case struct {
+		message   string
+		expected  bool
+		deletedAt time.Time
+	}
+
+	for i, t := range []test_case{
+		{"true if grace period is not expired.", false, time.Now()},
+		{"true if grace period is expired.", true, time.Now().Add(-1 * ServiceDeletionGracePeriod)},
+	} {
+
+		k := kluster.DeepCopy()
+		k.DeletionTimestamp = &meta_v1.Time{t.deletedAt}
+		done := make(chan struct{})
+		client := fake.NewSimpleClientset()
+		logger := log.NewNopLogger()
+
+		deorbiter := &ConcreteDeorbiter{k, done, client, logger}
+		finished, err := deorbiter.isServiceCleanupFinished()
+
+		assert.Equal(testing, t.expected, finished, "Test %d failed: %v", i, t.message)
+		assert.NoError(testing, err, "test %d failed", i)
+	}
+}
+
+func TestIsPersistentVolumesCleanupFinished(testing *testing.T) {
+	type test struct {
+		message  string
+		expected bool
+		objects  []runtime.Object
+	}
+
+	for i, t := range []test{
+		{"false if Cinder PVs remain", false, []runtime.Object{pvCinder0}},
+		{"false if Cinder PVs remain", false, []runtime.Object{pvCinder0, pvNFS}},
+		{"true if no Cinder PVs remain", true, []runtime.Object{pvNFS}},
+		{"true if no PVs remain", true, []runtime.Object{}},
+	} {
+
+		done := make(chan struct{})
+		client := fake.NewSimpleClientset(t.objects...)
+		logger := log.NewNopLogger()
+
+		deorbiter := &ConcreteDeorbiter{kluster, done, client, logger}
+		finished, err := deorbiter.isPersistentVolumesCleanupFinished()
+
+		assert.Equal(testing, t.expected, finished, "Test %d failed: %v", i, t.message)
+		assert.NoError(testing, err, "test %d failed", i)
+	}
+}
+
+func TestDeletePersistentVolumeClaims(testing *testing.T) {
+	type test struct {
+		message   string
+		remaining int
+		deleted   int
+		objects   []runtime.Object
+	}
+
+	for i, t := range []test{
+		{"deletes all Cinder PVs", 0, 2, []runtime.Object{pvCinder0, pvCinder1, pvcCinder0, pvcCinder1}},
+		{"deletes only Cinder PVs", 1, 2, []runtime.Object{pvCinder0, pvCinder1, pvNFS, pvcCinder0, pvcCinder1, pvcNFS}},
+	} {
+
+		done := make(chan struct{})
+		client := fake.NewSimpleClientset(t.objects...)
+		logger := log.NewNopLogger()
+
+		deorbiter := &ConcreteDeorbiter{kluster, done, client, logger}
+		deleted, err := deorbiter.DeletePersistentVolumeClaims()
+		remaining, _ := client.Core().PersistentVolumeClaims(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
+
+		assert.Equal(testing, t.remaining, len(remaining.Items), "Test %d failed: %v", i, t.message)
+		assert.Equal(testing, t.deleted, len(deleted), "Test %d failed: %v", i, t.message)
+		assert.NoError(testing, err, "test %d failed", i)
+	}
+}
+
+func TestDeleteServices(testing *testing.T) {
+	type test struct {
+		message   string
+		remaining int
+		deleted   int
+		objects   []runtime.Object
+	}
+
+	for i, t := range []test{
+		{"deletes all services of type LoadBalancer", 0, 2, []runtime.Object{svcLB0, svcLB1}},
+		{"deletes only services of type LoadBalancer", 1, 2, []runtime.Object{svcCIP, svcLB0, svcLB1}},
+	} {
+
+		done := make(chan struct{})
+		client := fake.NewSimpleClientset(t.objects...)
+		logger := log.NewNopLogger()
+
+		deorbiter := &ConcreteDeorbiter{kluster, done, client, logger}
+		deleted, err := deorbiter.DeleteServices()
+		remaining, _ := client.Core().Services(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
+
+		assert.Equal(testing, t.remaining, len(remaining.Items), "Test %d failed: %v", i, t.message)
+		assert.Equal(testing, t.deleted, len(deleted), "Test %d failed: %v", i, t.message)
+		assert.NoError(testing, err, "test %d failed", i)
+	}
+}

--- a/pkg/controller/deorbit/events.go
+++ b/pkg/controller/deorbit/events.go
@@ -1,0 +1,93 @@
+package deorbit
+
+import (
+	"fmt"
+
+	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/events"
+)
+
+type EventingDeorbiter struct {
+	Deorbiter Deorbiter
+	Kluster   *v1.Kluster
+	Recorder  record.EventRecorder
+}
+
+func (d *EventingDeorbiter) DeletePersistentVolumeClaims() (deletedPVCs []core_v1.PersistentVolumeClaim, err error) {
+	deletedPVCs, err = d.Deorbiter.DeletePersistentVolumeClaims()
+
+	for i, pvc := range deletedPVCs {
+		if err == nil || i < len(deletedPVCs)-1 {
+			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.SuccessfulDeorbitPVC, "Successfully deleted persistent volume: %v", fmt.Sprintf("%v/%v", pvc.Namespace, pvc.Name))
+		} else {
+			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeWarning, events.FailedDeorbitPVC, "Failed to delete persistent volume (%v): %v", err)
+		}
+	}
+
+	return
+}
+
+func (d *EventingDeorbiter) DeleteServices() (deletedServices []core_v1.Service, err error) {
+	deletedServices, err = d.Deorbiter.DeleteServices()
+
+	for i, service := range deletedServices {
+		if err == nil || i < len(deletedServices)-1 {
+			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.SuccessfulDeorbitService, "Successfully deleted service of type LoadBalancer: %v", fmt.Sprintf("%v/%v", service.Namespace, service.Name))
+		} else {
+			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeWarning, events.FailedDeorbitService, "Failed to delete service of type LoadBalancer (%v): %v", err)
+		}
+	}
+
+	return
+}
+
+func (d *EventingDeorbiter) WaitForPersistentVolumeCleanup() (err error) {
+	d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.WaitingForDeorbitPVs, "Waiting for cleanup of Cinder volumes")
+
+	err = d.Deorbiter.WaitForPersistentVolumeCleanup()
+
+	if err == nil {
+		d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.SuccessfulDeorbitPVs, "Successfully cleaned up Cinder volumes")
+	} else {
+		d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.FailedDeorbitPVs, "Failed to clean up Cinder volumes: %v", err)
+	}
+
+	return
+}
+
+func (d *EventingDeorbiter) WaitForServiceCleanup() (err error) {
+	d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.WaitingForDeorbitLoadBalancers, "Waiting for cleanup of load balancers")
+
+	err = d.Deorbiter.WaitForServiceCleanup()
+
+	if err == nil {
+		d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.SuccessfulDeorbitLoadBalancers, "Successfully cleaned up load balancers")
+	} else {
+		d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.FailedDeorbitLoadBalancers, "Failed to clean up load balancers: %v", err)
+	}
+
+	return
+}
+
+func (d *EventingDeorbiter) SelfDestruct(reason SelfDestructReason) (err error) {
+	err = d.Deorbiter.SelfDestruct(reason)
+
+	if err == nil {
+		d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.SuccessfulDeorbitSelfDestruct, "Failed to gracefully terminate the cluster. Initiated self-destruction. There might be left-over volumes and load balancers.")
+	} else {
+		d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.FailedDeorbitSelfDestruct, "Failed to activate self-destruction. There might be left-over volumes and load balancers.", err)
+	}
+
+	return
+}
+
+func (d *EventingDeorbiter) IsAPIUnavailableTimeout() bool {
+	return d.Deorbiter.IsAPIUnavailableTimeout()
+}
+
+func (d *EventingDeorbiter) IsDeorbitHangingTimeout() bool {
+	return d.Deorbiter.IsDeorbitHangingTimeout()
+}

--- a/pkg/controller/deorbit/fake.go
+++ b/pkg/controller/deorbit/fake.go
@@ -1,0 +1,88 @@
+package deorbit
+
+import (
+	"fmt"
+
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FakeDeorbiter struct {
+	CinderPVCCount int
+	LBServiceCount int
+
+	APIDown bool
+	Hanging bool
+
+	HasCalledDeletePersistentVolumeClaims   bool
+	HasCalledDeleteServices                 bool
+	HasCalledWaitForPersistentVolumeCleanup bool
+	HasCalledWaitForServiceCleanup          bool
+	HasCalledSeldDestruct                   bool
+
+	SelfDestructReason SelfDestructReason
+}
+
+func (d *FakeDeorbiter) DeletePersistentVolumeClaims() (deleted []core_v1.PersistentVolumeClaim, err error) {
+	d.HasCalledDeletePersistentVolumeClaims = true
+
+	for i := 0; i < d.CinderPVCCount; i++ {
+		deleted = append(deleted,
+			core_v1.PersistentVolumeClaim{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: fmt.Sprintf("pvc-cinder%d", i),
+				},
+				Spec: core_v1.PersistentVolumeClaimSpec{
+					VolumeName: fmt.Sprintf("pv-cinder%d", i),
+				},
+			},
+		)
+	}
+
+	return deleted, nil
+}
+
+func (d *FakeDeorbiter) DeleteServices() (deleted []core_v1.Service, err error) {
+	d.HasCalledDeleteServices = true
+
+	for i := 0; i < d.LBServiceCount; i++ {
+		deleted = append(deleted,
+			core_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: fmt.Sprintf("svc-lb%d", i),
+				},
+				Spec: core_v1.ServiceSpec{
+					Type: "LoadBalancer",
+				},
+			},
+		)
+	}
+
+	return deleted, nil
+}
+
+func (d *FakeDeorbiter) WaitForPersistentVolumeCleanup() (err error) {
+	d.HasCalledWaitForPersistentVolumeCleanup = true
+
+	return nil
+}
+
+func (d *FakeDeorbiter) WaitForServiceCleanup() (err error) {
+	d.HasCalledWaitForServiceCleanup = true
+
+	return nil
+}
+
+func (d *FakeDeorbiter) SelfDestruct(reason SelfDestructReason) (err error) {
+	d.HasCalledSeldDestruct = true
+	d.SelfDestructReason = reason
+	return nil
+}
+
+func (d *FakeDeorbiter) IsAPIUnavailableTimeout() bool {
+	return d.APIDown
+}
+
+func (d *FakeDeorbiter) IsDeorbitHangingTimeout() bool {
+	return d.Hanging
+}

--- a/pkg/controller/deorbit/logs.go
+++ b/pkg/controller/deorbit/logs.go
@@ -1,0 +1,91 @@
+package deorbit
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+type LoggingDeorbiter struct {
+	Deorbiter Deorbiter
+	Logger    log.Logger
+}
+
+func (d *LoggingDeorbiter) DeleteServices() (deleted []core_v1.Service, err error) {
+	defer func(begin time.Time) {
+		list := make([]string, len(deleted))
+		for i, v := range deleted {
+			list[i] = fmt.Sprintf("%v/%v", v.Namespace, v.Name)
+		}
+
+		d.Logger.Log(
+			"msg", "deleted services",
+			"services", strings.Join(list, ", "),
+			"took", time.Since(begin),
+			"err", err,
+		)
+	}(time.Now())
+	return d.Deorbiter.DeleteServices()
+}
+
+func (d *LoggingDeorbiter) DeletePersistentVolumeClaims() (deleted []core_v1.PersistentVolumeClaim, err error) {
+	defer func(begin time.Time) {
+		list := make([]string, len(deleted))
+		for i, v := range deleted {
+			list[i] = fmt.Sprintf("%v/%v", v.Namespace, v.Name)
+		}
+
+		d.Logger.Log(
+			"msg", "deleted pvcs",
+			"pvcs", strings.Join(list, ", "),
+			"took", time.Since(begin),
+			"err", err,
+		)
+	}(time.Now())
+	return d.Deorbiter.DeletePersistentVolumeClaims()
+}
+
+func (d *LoggingDeorbiter) WaitForPersistentVolumeCleanup() (err error) {
+	defer func(begin time.Time) {
+		d.Logger.Log(
+			"msg", "waited for pv cleanup",
+			"took", time.Since(begin),
+			"err", err,
+		)
+	}(time.Now())
+	return d.Deorbiter.WaitForPersistentVolumeCleanup()
+}
+
+func (d *LoggingDeorbiter) WaitForServiceCleanup() (err error) {
+	defer func(begin time.Time) {
+		d.Logger.Log(
+			"msg", "waited for service cleanup",
+			"took", time.Since(begin),
+			"err", err,
+		)
+	}(time.Now())
+	return d.Deorbiter.WaitForServiceCleanup()
+}
+
+func (d *LoggingDeorbiter) SelfDestruct(reason SelfDestructReason) (err error) {
+	defer func(begin time.Time) {
+		d.Logger.Log(
+			"msg", "initiated self-destruction",
+			"reason", reason,
+			"took", time.Since(begin),
+			"err", err,
+		)
+	}(time.Now())
+	return d.Deorbiter.SelfDestruct(reason)
+}
+
+func (d *LoggingDeorbiter) IsAPIUnavailableTimeout() bool {
+	return d.Deorbiter.IsAPIUnavailableTimeout()
+}
+
+func (d *LoggingDeorbiter) IsDeorbitHangingTimeout() bool {
+	return d.Deorbiter.IsDeorbitHangingTimeout()
+}

--- a/pkg/controller/deorbit/metrics.go
+++ b/pkg/controller/deorbit/metrics.go
@@ -1,0 +1,61 @@
+package deorbit
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+type InstrumentingDeorbiter struct {
+	Deorbiter Deorbiter
+
+	Latency    *prometheus.SummaryVec
+	Total      *prometheus.CounterVec
+	Successful *prometheus.CounterVec
+	Failed     *prometheus.CounterVec
+}
+
+func (d *InstrumentingDeorbiter) DeletePersistentVolumeClaims() (deleted []core_v1.PersistentVolumeClaim, err error) {
+	defer d.instrument("DeletePersistentVolumeClaims", time.Now(), err)
+	return d.Deorbiter.DeletePersistentVolumeClaims()
+}
+
+func (d *InstrumentingDeorbiter) DeleteServices() (deleted []core_v1.Service, err error) {
+	defer d.instrument("DeleteServices", time.Now(), err)
+	return d.Deorbiter.DeleteServices()
+}
+
+func (d *InstrumentingDeorbiter) WaitForPersistentVolumeCleanup() (err error) {
+	defer d.instrument("WaitForPersistentVolumeCleanup", time.Now(), err)
+	return d.Deorbiter.WaitForPersistentVolumeCleanup()
+}
+
+func (d *InstrumentingDeorbiter) WaitForServiceCleanup() (err error) {
+	defer d.instrument("WaitForServiceCleanup", time.Now(), err)
+	return d.Deorbiter.WaitForServiceCleanup()
+}
+
+func (d *InstrumentingDeorbiter) SelfDestruct(reason SelfDestructReason) (err error) {
+	defer d.instrument("SelfDestruct", time.Now(), err)
+	return d.Deorbiter.SelfDestruct(reason)
+}
+
+func (d *InstrumentingDeorbiter) instrument(method string, begin time.Time, err error) {
+	d.Latency.With(prometheus.Labels{"method": method}).Observe(time.Since(begin).Seconds())
+	d.Total.With(prometheus.Labels{"method": method}).Add(1)
+
+	if err != nil {
+		d.Failed.With(prometheus.Labels{"method": method}).Add(1)
+	} else {
+		d.Successful.With(prometheus.Labels{"method": method}).Add(1)
+	}
+}
+
+func (d *InstrumentingDeorbiter) IsAPIUnavailableTimeout() bool {
+	return d.Deorbiter.IsAPIUnavailableTimeout()
+}
+
+func (d *InstrumentingDeorbiter) IsDeorbitHangingTimeout() bool {
+	return d.Deorbiter.IsDeorbitHangingTimeout()
+}

--- a/pkg/controller/events/event.go
+++ b/pkg/controller/events/event.go
@@ -1,8 +1,20 @@
 package events
 
 const (
-	FailedCreateNode     = "FailedCreateNode"
-	FailedDeleteNode     = "FailedDeleteNode"
-	SuccessfulCreateNode = "SuccessfulCreateNode"
-	SuccessfulDeleteNode = "SuccessfulDeleteNode"
+	FailedCreateNode               = "FailedCreateNode"
+	FailedDeleteNode               = "FailedDeleteNode"
+	FailedDeorbitLoadBalancers     = "FailedDeorbitLoadBalancers"
+	FailedDeorbitPVC               = "FailedDeorbitPVC"
+	FailedDeorbitPVs               = "FailedDeorbitPVs"
+	FailedDeorbitSelfDestruct      = "FailedDeorbitSelfDestruct"
+	FailedDeorbitService           = "FailedDeorbitService"
+	SuccessfulCreateNode           = "SuccessfulCreateNode"
+	SuccessfulDeleteNode           = "SuccessfulDeleteNode"
+	SuccessfulDeorbitLoadBalancers = "SuccessfulDeorbitLoadBalancers"
+	SuccessfulDeorbitPVC           = "SuccessfulDeorbitPVC"
+	SuccessfulDeorbitPVs           = "SuccessfulDeorbitPVs"
+	SuccessfulDeorbitSelfDestruct  = "SuccessfulDeorbitSelfDestruct"
+	SuccessfulDeorbitService       = "SuccessfulDeorbitService"
+	WaitingForDeorbitLoadBalancers = "WaitingForDeorbitLoadBalancers"
+	WaitingForDeorbitPVs           = "WaitingForDeorbitPVs"
 )

--- a/pkg/controller/metrics/deorbit.go
+++ b/pkg/controller/metrics/deorbit.go
@@ -1,0 +1,36 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var DeorbitOperationsLatency = prometheus.NewSummaryVec(
+	prometheus.SummaryOpts{
+		Namespace: "kubernikus",
+		Subsystem: "deorbit",
+		Name:      "operation_latency_seconds",
+		Help:      "Total duration of reconciliation in microseconds.",
+	},
+	[]string{"method"})
+
+var DeorbitOperationsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "kubernikus",
+		Subsystem: "deorbit",
+		Name:      "operation_total",
+		Help:      "Number of operations."},
+	[]string{"method"})
+
+var DeorbitSuccessfulOperationsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "kubernikus",
+		Subsystem: "deorbit",
+		Name:      "successful_operation_total",
+		Help:      "Number of successful operations."},
+	[]string{"method"})
+
+var DeorbitFailedOperationsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "kubernikus",
+		Subsystem: "deorbit",
+		Name:      "failed_operation_total",
+		Help:      "Number of failed operations."},
+	[]string{"method"})

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/client/kubernikus"
 	"github.com/sapcc/kubernikus/pkg/client/openstack"
 	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/deorbit"
 	"github.com/sapcc/kubernikus/pkg/controller/launch"
 	"github.com/sapcc/kubernikus/pkg/controller/routegc"
 	kubernikus_informers "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions"
@@ -158,6 +159,8 @@ func NewKubernikusOperator(options *KubernikusOperatorOptions, logger log.Logger
 			o.Config.Kubernikus.Controllers["launchctl"] = launch.NewController(1, o.Factories, o.Clients, recorder, logger)
 		case "routegc":
 			o.Config.Kubernikus.Controllers["routegc"] = routegc.New(60*time.Second, o.Factories.Kubernikus.Kubernikus().V1().Klusters(), o.Clients.Openstack, logger)
+		case "deorbiter":
+			o.Config.Kubernikus.Controllers["deorbiter"] = deorbit.NewController(10, o.Factories, o.Clients, recorder, logger)
 		}
 	}
 


### PR DESCRIPTION
This adds a controller that does a sequenced decomissioning of Klusters. Fixes #45.

For an initial version the most pressing issue is that the Kluster's ControllerManager is just being terminated. This doesn't give the Kubernetes controllers enough time to remove remaining OpenStack resources. Therefore, trash just keeps on collecting in the user's project. 

To make matters worse, manual clean-up is not straight forward:

* Load Balancers require a whole deletion sequence
* Volumes take a non-trivial amount of time to actually detach/delete
* Identifying which LBs/Volumes belong to the kluster or other resources in the project is not always possible
* If multi-kluster support per project becomes a reality, it will be next to impossible for the user to distinguish which resource belongs to which cluster.

Given that, my approach in this PR:

1. Delete all Services of `type=LoadBalancer`
2. Delete all PVCs
3. Wait until everything is deleted

It turns out step 3 is tricky. Deleting services happens asynchronously. The actual observable resources are deleted immediately. While the controller-manager in the background keeps cached retry-loops active. This is not observable from the outside. See: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/service/service_controller.go#L801

We could check the resources in Openstack and continue once they are gone. It's not easy to figure out what belongs to a kluster and to the project though. 

Currently, i'm approaching this by adding a wait period. For Klusters without LBs and Volumes, 1min seems sufficient for the RouteController. For LBs we wait for 2minutes. Deletion might happen sequentially and that needs to be increased dynamically.