### PR TITLE
Fixes Failing LivelinessProbe for Ingress

### DIFF
--- a/charts/kubernikus-system/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/kubernikus-system/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -74,7 +74,7 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             timeoutSeconds: 1
           ports:
             - name: http


### PR DESCRIPTION
The nginx-ingress controller initalization seems to take longer than 10s
now. The LivelinessProbe kicks in and destroys the ingress before it
manages to fully start up.

This commit increases the timeout to 60s but the error might be related
to the following log:

```
ssl.go:185] unexpected error generating SSL certificate with full chain: Get http://ss.symcb.com/ss.crt: dial tcp: i/o timeout
```

This error seems to be blocking for ~5s. Afterwards the
ingress-controller takes a few seconds to generate the `nginx.conf` and
reload. Takes longer than 10s now.

```
I0108 12:30:45.788794       7 launch.go:128]
Name:       NGINX
Release:    0.9.0-beta.17
Build:      git-baa6bcb0
Repository: https://github.com/kubernetes/ingress-nginx
I0108 12:30:45.788832       7 launch.go:131] Watching for ingress class: nginx
I0108 12:30:45.789234       7 launch.go:307] Creating API client for https://192.168.128.1:443
I0108 12:30:45.820092       7 launch.go:319] Running in Kubernetes Cluster version v1.7 (v1.7.5+coreos.0) - git (clean) commit 070d238cd2ec359928548e486a9171b498573181 - platform linux/amd64
I0108 12:30:45.827792       7 launch.go:155] validated kubernikus-system/kubernikus-system-nginx-ingress-default-backend as the default backend
I0108 12:30:45.844031       7 nginx.go:174] starting NGINX process...
I0108 12:30:45.844210       7 controller.go:1262] starting Ingress controller
I0108 12:30:45.923382       7 listers.go:76] ignoring add for ingress gnsreg-3e10d3d57d1843c88f686672f970fcf5 based on annotation kubernetes.io/ingress.class with value k8sniff
I0108 12:30:45.923644       7 listers.go:76] ignoring add for ingress test-6d24c4eac0fa4846b89611439ab6b481 based on annotation kubernetes.io/ingress.class with value k8sniff
I0108 12:30:45.923705       7 listers.go:76] ignoring add for ingress test7-865184580ead46918860656eb2aff11e based on annotation kubernetes.io/ingress.class with value k8sniff
I0108 12:30:45.923853       7 event.go:218] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"kubernikus-system", Name:"kubernikus-api", UID:"5cd1c4a9-c871-11e7-b055-0a58644401ca", APIVersion:"extensions", ResourceVersion:"1197128", FieldPath:""}): type: 'Normal' reason: 'CREATE' Ingress kubernikus-system/kubernikus-api
I0108 12:30:51.482096       7 controller.go:1270] running initial sync of secrets
I0108 12:30:51.482164       7 controller.go:1276] ignoring add for ingress test7-865184580ead46918860656eb2aff11e based on annotation kubernetes.io/ingress.class with value k8sniff
E0108 12:31:21.483830       7 ssl.go:185] unexpected error generating SSL certificate with full chain: Get http://ss.symcb.com/ss.crt: dial tcp: i/o timeout
I0108 12:31:21.483883       7 backend_ssl.go:64] adding secret kubernikus-system/kubernikus-api to the local store
I0108 12:31:21.483919       7 controller.go:1276] ignoring add for ingress gnsreg-3e10d3d57d1843c88f686672f970fcf5 based on annotation kubernetes.io/ingress.class with value k8sniff
I0108 12:31:21.483941       7 controller.go:1276] ignoring add for ingress test-6d24c4eac0fa4846b89611439ab6b481 based on annotation kubernetes.io/ingress.class with value k8sniff
I0108 12:31:21.484067       7 leaderelection.go:174] attempting to acquire leader lease...
I0108 12:31:21.492134       7 status.go:199] new leader elected: kubernikus-system-nginx-ingress-controller-1901956041-r2wpm
I0108 12:31:25.225399       7 main.go:49] Received SIGTERM, shutting down
I0108 12:31:25.225432       7 controller.go:1248] shutting down controller queues
I0108 12:31:25.225462       7 nginx.go:239] stopping NGINX process...
2018/01/08 12:31:25 [notice] 26#26: signal process started
```