### PR TITLE
Use Finalizers for Orchestrating Kluster Deletion

### DIFF
--- a/pkg/apis/kubernikus/v1/kluster.go
+++ b/pkg/apis/kubernikus/v1/kluster.go
@@ -43,3 +43,52 @@ func (spec Kluster) ApiServiceIP() (net.IP, error) {
 	return ip, nil
 
 }
+
+func (k *Kluster) NeedsFinalizer(finalizer string) bool {
+	if k.ObjectMeta.DeletionTimestamp != nil {
+		// already deleted. do not add another finalizer anymore
+		return false
+	}
+
+	for _, f := range k.ObjectMeta.Finalizers {
+		if f == finalizer {
+			// Finalizer is already present, nothing to do
+			return false
+		}
+	}
+
+	return true
+}
+
+func (k *Kluster) HasFinalizer(finalizer string) bool {
+	if k.ObjectMeta.DeletionTimestamp == nil {
+		// not deleted. do not remove finalizers at this time
+		return false
+	}
+
+	for _, f := range k.ObjectMeta.Finalizers {
+		if f == finalizer {
+			// Finalizer is already present
+			return true
+		}
+	}
+
+	return false
+}
+
+func (k *Kluster) AddFinalizer(finalizer string) {
+	if k.NeedsFinalizer(finalizer) {
+		k.Finalizers = append(k.Finalizers, finalizer)
+	}
+}
+
+func (k *Kluster) RemoveFinalizer(finalizer string) {
+	if k.HasFinalizer(finalizer) {
+		for i, f := range k.Finalizers {
+			if f == finalizer {
+				k.Finalizers = append(k.Finalizers[:i], k.Finalizers[i+1:]...)
+				break
+			}
+		}
+	}
+}

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -38,6 +38,8 @@ const (
 	//Reason constants for the event recorder
 	ConfigurationError = "ConfigurationError"
 	FailedCreate       = "FailedCreate"
+
+	GroundctlFinalizer = "groundctl"
 )
 
 type GroundControl struct {
@@ -191,7 +193,6 @@ func (op *GroundControl) handler(key string) error {
 					"kluster", kluster.GetName(),
 					"project", kluster.Account(),
 					"phase", kluster.Status.Phase)
-
 				if err := op.createKluster(kluster); err != nil {
 					op.Recorder.Eventf(kluster, api_v1.EventTypeWarning, FailedCreate, "Failed to create cluster: %s", err)
 					return err
@@ -249,6 +250,20 @@ func (op *GroundControl) handler(key string) error {
 			}
 		case models.KlusterPhaseTerminating:
 			{
+				// Wait until all other finalizers are done.
+				//
+				// Groundctl needs to be last because it deletes the API machinery, which is
+				// needed for cleanup of Openstack resources, like Volumes, LBs, Routes.
+				// Additionally, this also removes the Secret and ServiceUsers. Without them
+				// clean-up is impossiple.
+				//
+				// There's a "soft" agreement that Finalizers are executed in order from
+				// first to last. Here we check that Groundctl is the last remaining one and
+				// spare us the trouble to maintain a ordered list.
+				if !(len(kluster.Finalizers) == 1 && kluster.Finalizers[0] == GroundctlFinalizer) {
+					return nil
+				}
+
 				op.Logger.Log(
 					"msg", "terminating kluster",
 					"kluster", kluster.GetName(),
@@ -365,6 +380,10 @@ func (op *GroundControl) createKluster(kluster *v1.Kluster) error {
 		return err
 	}
 
+	if err := util.EnsureFinalizerCreated(op.Clients.Kubernikus.KubernikusV1(), kluster, GroundctlFinalizer); err != nil {
+		return err
+	}
+
 	op.Logger.Log(
 		"msg", "creating service user",
 		"username", username,
@@ -437,6 +456,18 @@ func (op *GroundControl) terminateKluster(kluster *v1.Kluster) error {
 		return err
 	}
 
+	if err := util.EnsureFinalizerRemoved(op.Clients.Kubernikus.KubernikusV1(), kluster, GroundctlFinalizer); err != nil {
+		return err
+	}
+
+	// There's a bug in the garbage-collector regarding CRDs in 1.7. It will not delete
+	// the CRD even though all Finalizers are gone. As a workaround, here we try to just
+	// delte the kluster again.
+	//
+	// This can be removed once the control-planes include garbage collector fixes
+	// for CDRs (1.8+)
+	//
+	// See: https://github.com/kubernetes/kubernetes/issues/50528
 	err = op.Clients.Kubernikus.Discovery().RESTClient().Delete().AbsPath("apis/kubernikus.sap.cc/v1").
 		Namespace(kluster.Namespace).
 		Resource("klusters").

--- a/pkg/util/kluster.go
+++ b/pkg/util/kluster.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	clientset "github.com/sapcc/kubernikus/pkg/generated/clientset/typed/kubernikus/v1"
+)
+
+func EnsureFinalizerCreated(client clientset.KubernikusV1Interface, kluster *v1.Kluster, finalizer string) (err error) {
+	if kluster.NeedsFinalizer(finalizer) {
+		copy := kluster.DeepCopy()
+		copy.AddFinalizer(finalizer)
+		_, err = client.Klusters(copy.Namespace).Update(copy)
+	}
+	return err
+}
+
+func EnsureFinalizerRemoved(client clientset.KubernikusV1Interface, kluster *v1.Kluster, finalizer string) (err error) {
+	if kluster.HasFinalizer(finalizer) {
+		copy := kluster.DeepCopy()
+		copy.RemoveFinalizer(finalizer)
+		_, err = client.Klusters(copy.Namespace).Update(copy)
+	}
+	return err
+}


### PR DESCRIPTION
This refactors the orchestration for Kluster Deletion. It makes use of
the Finalizers concept. It allows to shift the responsibility of
cleaning up to individual controllers. It spares us the implementation
of a more complicated kluster-phase state machine.

See: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#finalizers

We need this as a prerequisite for the implementation of the Deorbiter
in #144.