### PR TITLE
Adds Public-Key to GetMetadata Call

### DIFF
--- a/pkg/api/models/openstack_metadata.go
+++ b/pkg/api/models/openstack_metadata.go
@@ -220,6 +220,9 @@ type KeyPair struct {
 
 	// name
 	Name string `json:"name,omitempty"`
+
+	// public key
+	PublicKey string `json:"publicKey,omitempty"`
 }
 
 // Validate validates this key pair

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -569,6 +569,9 @@ func init() {
             "properties": {
               "name": {
                 "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
               }
             },
             "x-go-name": "KeyPair"

--- a/pkg/client/openstack/scoped/client.go
+++ b/pkg/client/openstack/scoped/client.go
@@ -201,7 +201,7 @@ func (c *client) getKeyPairs() ([]*models.KeyPair, error) {
 	}
 
 	for _, key := range keyList {
-		result = append(result, &models.KeyPair{Name: key.Name})
+		result = append(result, &models.KeyPair{Name: key.Name, PublicKey: key.PublicKey})
 	}
 
 	return result, nil

--- a/swagger.yml
+++ b/swagger.yml
@@ -235,6 +235,9 @@ definitions:
           properties:
             name:
               type: string
+            publicKey: 
+              type: string
+
       routers:
         type: array
         items:


### PR DESCRIPTION
This PR adds the public-key to the `getmetadata` call. The intention is to use this as a convenience feature in the UI.

The key will be copied to a free-text field. Alernatively the user will be able to provide a whole different key by herself. 

Fixes #156