### PR TITLE
Surface nova errors message for bad request responses (400)

### DIFF
--- a/pkg/client/openstack/client.go
+++ b/pkg/client/openstack/client.go
@@ -579,7 +579,7 @@ func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePoo
 
 	name = v1.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", kluster.Spec.Name, pool.Name))
 
-	server, err := servers.Create(client, compute.CreateOpts{
+	server, err := compute.Create(client, compute.CreateOpts{
 		CreateOpts: servers.CreateOpts{
 			Name:           name,
 			FlavorName:     pool.Flavor,

--- a/pkg/client/openstack/compute/create.go
+++ b/pkg/client/openstack/compute/create.go
@@ -26,7 +26,8 @@ func (ce *createError) Error400(e gophercloud.ErrUnexpectedResponseCode) error {
 }
 
 func (ce createError) Error() string {
-	return "Failed to create server. This should not never be printed."
+	//Unused, but we need to satisfy the error interface
+	return "Failed to create server. This shouldn't be returned ever."
 }
 
 // Create requests a server to be provisioned to the user in the current tenant.

--- a/pkg/client/openstack/compute/create.go
+++ b/pkg/client/openstack/compute/create.go
@@ -1,0 +1,43 @@
+package compute
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+type createError struct {
+}
+
+func (ce *createError) Error400(e gophercloud.ErrUnexpectedResponseCode) error {
+
+	var response struct {
+		BadRequest struct {
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		} `json:"badRequest"`
+	}
+	if err := json.Unmarshal(e.Body, &response); err != nil || response.BadRequest.Message == "" {
+		return fmt.Errorf("Failed to parse response: %s", string(e.Body))
+	}
+	return fmt.Errorf("Response from compute: %d %s", e.Actual, response.BadRequest.Message)
+}
+
+func (ce createError) Error() string {
+	return "Failed to create server. This should not never be printed."
+}
+
+// Create requests a server to be provisioned to the user in the current tenant.
+func Create(client *gophercloud.ServiceClient, opts servers.CreateOptsBuilder) (r servers.CreateResult) {
+	reqBody, err := opts.ToServerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(client.ServiceURL("servers"), reqBody, &r.Body, &gophercloud.RequestOpts{
+		ErrorContext: &createError{},
+	})
+	return
+}


### PR DESCRIPTION
gophercloud at the moment just returns a generic “bad request” error message when nova returns a status 400 response for a server create request.
But the response actually contains a detailed error message as to why the payload wasn’t accepted. (e.g. given image/flavor/key not found etc.)

There is a 1 year old upstream PR solving the same thing but unfortuantely its going nowhere: https://github.com/gophercloud/gophercloud/pull/303