### PR TITLE
Generate a random ssh password per kluster

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 1.9.0-kubernikus.0
+version: 1.9.0-kubernikus.1

--- a/charts/kube-master/templates/secrets.yaml
+++ b/charts/kube-master/templates/secrets.yaml
@@ -18,9 +18,9 @@ data:
   openstack-router-id: {{ required "missing openstack-router-id" .Values.openstack.routerID | b64enc }}
   openstack-project-id: {{ required "missing openstack-project-id" .Values.openstack.projectID | b64enc }}
   openstack-region: {{ required "missing openstack-region" .Values.openstack.region | b64enc }}
-
   bootstrapToken: {{ required "missing boostrapToken" .Values.bootstrapToken | b64enc }}
   token.csv: {{ include (print $.Template.BasePath "/_token.csv.tpl") . | b64enc }}
+  node-password: {{ required "missing node-password" .Values.nodePassword | b64enc }}
 
 {{- if empty .Values.certsSecretName }}
 {{- range list "apiserver-clients-ca-key.pem" "apiserver-clients-ca.pem" "apiserver-clients-cluster-admin-key.pem" "apiserver-clients-cluster-admin.pem" "apiserver-clients-system-kube-controller-manager-key.pem" "apiserver-clients-system-kube-controller-manager.pem" "apiserver-clients-system-kube-proxy-key.pem" "apiserver-clients-system-kube-proxy.pem"  "apiserver-clients-system-kube-scheduler-key.pem" "apiserver-clients-system-kube-scheduler.pem" "apiserver-clients-kubernikus-wormhole.pem" "apiserver-clients-kubernikus-wormhole-key.pem" "apiserver-nodes-ca-key.pem" "apiserver-nodes-ca.pem" "etcd-clients-apiserver-key.pem" "etcd-clients-apiserver.pem" "etcd-clients-ca-key.pem" "etcd-clients-ca.pem" "etcd-peers-ca-key.pem" "etcd-peers-ca.pem" "kubelet-clients-apiserver-key.pem" "kubelet-clients-apiserver.pem" "kubelet-clients-ca-key.pem" "kubelet-clients-ca.pem" "tls-ca-key.pem" "tls-ca.pem" "tls-apiserver.pem" "tls-apiserver-key.pem" "tls-wormhole.pem" "tls-wormhole-key.pem"}}

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -30,6 +30,7 @@ clusterCIDR: 198.19.0.0/16
 serviceCIDR: 198.18.128.0/17
 advertiseAddress: 198.18.128.1
 #bootstrapToken
+#nodePassword:
 
 version:
 # kubernikus:

--- a/glide.lock
+++ b/glide.lock
@@ -272,6 +272,12 @@ imports:
   version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
   subpackages:
   - assert
+- name: github.com/tredoe/osutil
+  version: 7d3ee1afa71c90fd1514c8f557ae6c5f414208eb
+  subpackages:
+  - user/crypt
+  - user/crypt/common
+  - user/crypt/sha512_crypt
 - name: github.com/tylerb/graceful
   version: d72b0151351a13d0421b763b88f791469c4f5dc7
 - name: github.com/vincent-petithory/dataurl

--- a/pkg/templates/ignition_test.go
+++ b/pkg/templates/ignition_test.go
@@ -35,15 +35,24 @@ func TestGenerateNode(t *testing.T) {
 			Apiserver: "https://apiserver.somewhere",
 		},
 	}
-	secretData := make(map[string][]byte, len(Ignition.requiredNodeSecrets))
+	secretData := make(map[string][]byte, len(Ignition.requiredNodeSecrets)+1)
 	for _, f := range Ignition.requiredNodeSecrets {
 		secretData[f] = []byte(fmt.Sprintf("[DATA for %s]", f))
 	}
+	secretData["node-password"] = []byte("password")
 
 	secret := v1.Secret{
 		ObjectMeta: kluster.ObjectMeta,
 		Data:       secretData,
 	}
-	_, err := Ignition.GenerateNode(&kluster, &secret, log.NewNopLogger())
-	assert.NoError(t, err)
+
+	for _, version := range []string{"1.7", "1.8", "1.9"} {
+		kluster.Spec.Version = version
+		data, err := Ignition.GenerateNode(&kluster, &secret, log.NewNopLogger())
+		if assert.NoError(t, err, "Failed to generate node for version %s", version) {
+			//Ensure we rendered the expected template
+			assert.Contains(t, string(data), fmt.Sprintf("KUBELET_IMAGE_TAG=v%s", version))
+		}
+		//fmt.Printf("data = %+v\n", string(data))
+	}
 }

--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -6,7 +6,7 @@ var Node_1_7 = `
 passwd:
   users:
     - name:          core
-      password_hash: xyTGJkB462ewk
+      password_hash: {{ .LoginPassword }}
       ssh_authorized_keys: 
         - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAvFapuevZeHFpFn438XMjvEQYd0wt7+tzUdAkMiSd007Tx1h79Xm9ZziDDUe4W6meinVOq93MAS/ER27hoVWGo2H/vn/Cz5M8xr2j5rQODnrF3RmfrJTbZAWaDN0JTq2lFjmCHhZJNhr+VQP1uw4z2ofMBP6MLybnLmm9ukzxFYZqCCyfEEUTCMA9SWywtTpGQp8VLM4INCxzBSCuyt3SO6PBvJSo4HoKg/sLvmRwpCVZth48PI0EUbJ72wp88Cw3bv8CLce2TOkLMwkE6NRN55w2aOyqP1G3vixHa6YcVaLlkQhJoJsBwE3rX5603y2KjOhMomqHfXxXn/3GKTWlsQ== michael.j.schmidt@gmail.com"
 

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -6,7 +6,7 @@ var Node_1_8 = `
 passwd:
   users:
     - name:          core
-      password_hash: xyTGJkB462ewk
+      password_hash: {{ .LoginPassword }}
       ssh_authorized_keys: 
         - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAvFapuevZeHFpFn438XMjvEQYd0wt7+tzUdAkMiSd007Tx1h79Xm9ZziDDUe4W6meinVOq93MAS/ER27hoVWGo2H/vn/Cz5M8xr2j5rQODnrF3RmfrJTbZAWaDN0JTq2lFjmCHhZJNhr+VQP1uw4z2ofMBP6MLybnLmm9ukzxFYZqCCyfEEUTCMA9SWywtTpGQp8VLM4INCxzBSCuyt3SO6PBvJSo4HoKg/sLvmRwpCVZth48PI0EUbJ72wp88Cw3bv8CLce2TOkLMwkE6NRN55w2aOyqP1G3vixHa6YcVaLlkQhJoJsBwE3rX5603y2KjOhMomqHfXxXn/3GKTWlsQ== michael.j.schmidt@gmail.com"
 

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -6,8 +6,8 @@ var Node_1_9 = `
 passwd:
   users:
     - name:          core
-      password_hash: xyTGJkB462ewk
-      ssh_authorized_keys: 
+      password_hash: {{ .LoginPassword }}
+      ssh_authorized_keys:
         - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAvFapuevZeHFpFn438XMjvEQYd0wt7+tzUdAkMiSd007Tx1h79Xm9ZziDDUe4W6meinVOq93MAS/ER27hoVWGo2H/vn/Cz5M8xr2j5rQODnrF3RmfrJTbZAWaDN0JTq2lFjmCHhZJNhr+VQP1uw4z2ofMBP6MLybnLmm9ukzxFYZqCCyfEEUTCMA9SWywtTpGQp8VLM4INCxzBSCuyt3SO6PBvJSo4HoKg/sLvmRwpCVZth48PI0EUbJ72wp88Cw3bv8CLce2TOkLMwkE6NRN55w2aOyqP1G3vixHa6YcVaLlkQhJoJsBwE3rX5603y2KjOhMomqHfXxXn/3GKTWlsQ== michael.j.schmidt@gmail.com"
 
 locksmith:

--- a/vendor/github.com/tredoe/osutil/LICENSE-MPL.txt
+++ b/vendor/github.com/tredoe/osutil/LICENSE-MPL.txt
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/tredoe/osutil/user/crypt/LICENSE
+++ b/vendor/github.com/tredoe/osutil/user/crypt/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012, Jeramey Crawford <jeramey@antihe.ro>
+Copyright (c) 2013, Jonas mg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/tredoe/osutil/user/crypt/common/base64.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/common/base64.go
@@ -1,0 +1,60 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+package common
+
+const alphabet = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// Base64_24Bit is a variant of Base64 encoding, commonly used with password
+// hashing algorithms to encode the result of their checksum output.
+//
+// The algorithm operates on up to 3 bytes at a time, encoding the following
+// 6-bit sequences into up to 4 hash64 ASCII bytes.
+//
+//   1. Bottom 6 bits of the first byte
+//   2. Top 2 bits of the first byte, and bottom 4 bits of the second byte.
+//   3. Top 4 bits of the second byte, and bottom 2 bits of the third byte.
+//   4. Top 6 bits of the third byte.
+//
+// This encoding method does not emit padding bytes as Base64 does.
+func Base64_24Bit(src []byte) (hash []byte) {
+	if len(src) == 0 {
+		return []byte{} // TODO: return nil
+	}
+
+	hashSize := (len(src) * 8) / 6
+	if (len(src) % 6) != 0 {
+		hashSize += 1
+	}
+	hash = make([]byte, hashSize)
+
+	dst := hash
+	for len(src) > 0 {
+		switch len(src) {
+		default:
+			dst[0] = alphabet[src[0]&0x3f]
+			dst[1] = alphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
+			dst[2] = alphabet[((src[1]>>4)|(src[2]<<4))&0x3f]
+			dst[3] = alphabet[(src[2]>>2)&0x3f]
+			src = src[3:]
+			dst = dst[4:]
+		case 2:
+			dst[0] = alphabet[src[0]&0x3f]
+			dst[1] = alphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
+			dst[2] = alphabet[(src[1]>>4)&0x3f]
+			src = src[2:]
+			dst = dst[3:]
+		case 1:
+			dst[0] = alphabet[src[0]&0x3f]
+			dst[1] = alphabet[(src[0]>>6)&0x3f]
+			src = src[1:]
+			dst = dst[2:]
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/common/doc.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/common/doc.go
@@ -1,0 +1,13 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package common contains routines used by multiple password hashing
+// algorithms.
+//
+// Generally, you will never import this package directly. Many of the
+// *_crypt packages will import this package if they require it.
+package common

--- a/vendor/github.com/tredoe/osutil/user/crypt/common/salt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/common/salt.go
@@ -1,0 +1,105 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+package common
+
+import (
+	"crypto/rand"
+	"errors"
+	"strconv"
+)
+
+var (
+	ErrSaltPrefix = errors.New("invalid magic prefix")
+	ErrSaltFormat = errors.New("invalid salt format")
+	ErrSaltRounds = errors.New("invalid rounds")
+)
+
+// Salt represents a salt.
+type Salt struct {
+	MagicPrefix []byte
+
+	SaltLenMin int
+	SaltLenMax int
+
+	RoundsMin     int
+	RoundsMax     int
+	RoundsDefault int
+}
+
+// Generate generates a random salt of a given length.
+//
+// The length is set thus:
+//
+//   length > SaltLenMax: length = SaltLenMax
+//   length < SaltLenMin: length = SaltLenMin
+func (s *Salt) Generate(length int) []byte {
+	if length > s.SaltLenMax {
+		length = s.SaltLenMax
+	} else if length < s.SaltLenMin {
+		length = s.SaltLenMin
+	}
+
+	saltLen := (length * 6 / 8)
+	if (length*6)%8 != 0 {
+		saltLen += 1
+	}
+	salt := make([]byte, saltLen)
+	rand.Read(salt)
+
+	out := make([]byte, len(s.MagicPrefix)+length)
+	copy(out, s.MagicPrefix)
+	copy(out[len(s.MagicPrefix):], Base64_24Bit(salt))
+	return out
+}
+
+// GenerateWRounds creates a random salt with the random bytes being of the
+// length provided, and the rounds parameter set as specified.
+//
+// The parameters are set thus:
+//
+//   length > SaltLenMax: length = SaltLenMax
+//   length < SaltLenMin: length = SaltLenMin
+//
+//   rounds < 0: rounds = RoundsDefault
+//   rounds < RoundsMin: rounds = RoundsMin
+//   rounds > RoundsMax: rounds = RoundsMax
+//
+// If rounds is equal to RoundsDefault, then the "rounds=" part of the salt is
+// removed.
+func (s *Salt) GenerateWRounds(length, rounds int) []byte {
+	if length > s.SaltLenMax {
+		length = s.SaltLenMax
+	} else if length < s.SaltLenMin {
+		length = s.SaltLenMin
+	}
+	if rounds < 0 {
+		rounds = s.RoundsDefault
+	} else if rounds < s.RoundsMin {
+		rounds = s.RoundsMin
+	} else if rounds > s.RoundsMax {
+		rounds = s.RoundsMax
+	}
+
+	saltLen := (length * 6 / 8)
+	if (length*6)%8 != 0 {
+		saltLen += 1
+	}
+	salt := make([]byte, saltLen)
+	rand.Read(salt)
+
+	roundsText := ""
+	if rounds != s.RoundsDefault {
+		roundsText = "rounds=" + strconv.Itoa(rounds)
+	}
+
+	out := make([]byte, len(s.MagicPrefix)+len(roundsText)+length)
+	copy(out, s.MagicPrefix)
+	copy(out[len(s.MagicPrefix):], []byte(roundsText))
+	copy(out[len(s.MagicPrefix)+len(roundsText):], Base64_24Bit(salt))
+	return out
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/crypt.go
@@ -1,0 +1,108 @@
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package crypt provides interface for password crypt functions and collects
+// common constants.
+package crypt
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/tredoe/osutil/user/crypt/common"
+)
+
+var ErrKeyMismatch = errors.New("hashed value is not the hash of the given password")
+
+// Crypter is the common interface implemented by all crypt functions.
+type Crypter interface {
+	// Generate performs the hashing algorithm, returning a full hash suitable
+	// for storage and later password verification.
+	//
+	// If the salt is empty, a randomly-generated salt will be generated with a
+	// length of SaltLenMax and number RoundsDefault of rounds.
+	//
+	// Any error only can be got when the salt argument is not empty.
+	Generate(key, salt []byte) (string, error)
+
+	// Verify compares a hashed key with its possible key equivalent.
+	// Returns nil on success, or an error on failure; if the hashed key is
+	// diffrent, the error is "ErrKeyMismatch".
+	Verify(hashedKey string, key []byte) error
+
+	// Cost returns the hashing cost (in rounds) used to create the given hashed
+	// key.
+	//
+	// When, in the future, the hashing cost of a key needs to be increased in
+	// order to adjust for greater computational power, this function allows one
+	// to establish which keys need to be updated.
+	//
+	// The algorithms based in MD5-crypt use a fixed value of rounds.
+	Cost(hashedKey string) (int, error)
+
+	// SetSalt sets a different salt. It is used to easily create derivated
+	// algorithms, i.e. "apr1_crypt" from "md5_crypt".
+	SetSalt(salt common.Salt)
+}
+
+// Crypt identifies a crypt function that is implemented in another package.
+type Crypt uint
+
+const (
+	APR1   Crypt = iota + 1 // import "github.com/tredoe/osutil/user/crypt/apr1_crypt"
+	MD5                     // import "github.com/tredoe/osutil/user/crypt/md5_crypt"
+	SHA256                  // import "github.com/tredoe/osutil/user/crypt/sha256_crypt"
+	SHA512                  // import "github.com/tredoe/osutil/user/crypt/sha512_crypt"
+	maxCrypt
+)
+
+var cryptPrefixes = make([]string, maxCrypt)
+
+var crypts = make([]func() Crypter, maxCrypt)
+
+// RegisterCrypt registers a function that returns a new instance of the given
+// crypt function. This is intended to be called from the init function in
+// packages that implement crypt functions.
+func RegisterCrypt(c Crypt, f func() Crypter, prefix string) {
+	if c >= maxCrypt {
+		panic("crypt: RegisterHash of unknown crypt function")
+	}
+	crypts[c] = f
+	cryptPrefixes[c] = prefix
+}
+
+// New returns a new crypter.
+func New(c Crypt) Crypter {
+	f := crypts[c]
+	if f != nil {
+		return f()
+	}
+	panic("crypt: requested crypt function is unavailable")
+}
+
+// NewFromHash returns a new Crypter using the prefix in the given hashed key.
+func NewFromHash(hashedKey string) Crypter {
+	var f func() Crypter
+
+	if strings.HasPrefix(hashedKey, cryptPrefixes[SHA512]) {
+		f = crypts[SHA512]
+	} else if strings.HasPrefix(hashedKey, cryptPrefixes[SHA256]) {
+		f = crypts[SHA256]
+	} else if strings.HasPrefix(hashedKey, cryptPrefixes[MD5]) {
+		f = crypts[MD5]
+	} else if strings.HasPrefix(hashedKey, cryptPrefixes[APR1]) {
+		f = crypts[APR1]
+	} else {
+		toks := strings.SplitN(hashedKey, "$", 3)
+		prefix := "$" + toks[1] + "$"
+		panic("crypt: unknown cryp function from prefix: " + prefix)
+	}
+
+	if f != nil {
+		return f()
+	}
+	panic("crypt: requested cryp function is unavailable")
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/sha512_crypt/sha512_crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/sha512_crypt/sha512_crypt.go
@@ -1,0 +1,254 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package sha512_crypt implements Ulrich Drepper's SHA512-crypt password
+// hashing algorithm.
+//
+// The specification for this algorithm can be found here:
+// http://www.akkadia.org/drepper/SHA-crypt.txt
+package sha512_crypt
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"strconv"
+
+	"github.com/tredoe/osutil/user/crypt"
+	"github.com/tredoe/osutil/user/crypt/common"
+)
+
+func init() {
+	crypt.RegisterCrypt(crypt.SHA512, New, MagicPrefix)
+}
+
+const (
+	MagicPrefix   = "$6$"
+	SaltLenMin    = 1
+	SaltLenMax    = 16
+	RoundsMin     = 1000
+	RoundsMax     = 999999999
+	RoundsDefault = 5000
+)
+
+var _rounds = []byte("rounds=")
+
+type crypter struct{ Salt common.Salt }
+
+// New returns a new crypt.Crypter computing the SHA512-crypt password hashing.
+func New() crypt.Crypter {
+	return &crypter{GetSalt()}
+}
+
+func (c *crypter) Generate(key, salt []byte) (string, error) {
+	var rounds int
+	var isRoundsDef bool
+
+	if len(salt) == 0 {
+		salt = c.Salt.GenerateWRounds(SaltLenMax, RoundsDefault)
+	}
+	if !bytes.HasPrefix(salt, c.Salt.MagicPrefix) {
+		return "", common.ErrSaltPrefix
+	}
+
+	saltToks := bytes.Split(salt, []byte{'$'})
+	if len(saltToks) < 3 {
+		return "", common.ErrSaltFormat
+	}
+
+	if bytes.HasPrefix(saltToks[2], _rounds) {
+		isRoundsDef = true
+		pr, err := strconv.ParseInt(string(saltToks[2][7:]), 10, 32)
+		if err != nil {
+			return "", common.ErrSaltRounds
+		}
+		rounds = int(pr)
+		if rounds < RoundsMin {
+			rounds = RoundsMin
+		} else if rounds > RoundsMax {
+			rounds = RoundsMax
+		}
+		salt = saltToks[3]
+	} else {
+		rounds = RoundsDefault
+		salt = saltToks[2]
+	}
+
+	if len(salt) > SaltLenMax {
+		salt = salt[0:SaltLenMax]
+	}
+
+	// Compute alternate SHA512 sum with input KEY, SALT, and KEY.
+	Alternate := sha512.New()
+	Alternate.Write(key)
+	Alternate.Write(salt)
+	Alternate.Write(key)
+	AlternateSum := Alternate.Sum(nil) // 64 bytes
+
+	A := sha512.New()
+	A.Write(key)
+	A.Write(salt)
+	// Add for any character in the key one byte of the alternate sum.
+	i := len(key)
+	for ; i > 64; i -= 64 {
+		A.Write(AlternateSum)
+	}
+	A.Write(AlternateSum[0:i])
+
+	// Take the binary representation of the length of the key and for every add
+	// the alternate sum, for every 0 the key.
+	for i = len(key); i > 0; i >>= 1 {
+		if (i & 1) != 0 {
+			A.Write(AlternateSum)
+		} else {
+			A.Write(key)
+		}
+	}
+	Asum := A.Sum(nil)
+
+	// Start computation of P byte sequence.
+	P := sha512.New()
+	// For every character in the password add the entire password.
+	for i = 0; i < len(key); i++ {
+		P.Write(key)
+	}
+	Psum := P.Sum(nil)
+	// Create byte sequence P.
+	Pseq := make([]byte, 0, len(key))
+	for i = len(key); i > 64; i -= 64 {
+		Pseq = append(Pseq, Psum...)
+	}
+	Pseq = append(Pseq, Psum[0:i]...)
+
+	// Start computation of S byte sequence.
+	S := sha512.New()
+	for i = 0; i < (16 + int(Asum[0])); i++ {
+		S.Write(salt)
+	}
+	Ssum := S.Sum(nil)
+	// Create byte sequence S.
+	Sseq := make([]byte, 0, len(salt))
+	for i = len(salt); i > 64; i -= 64 {
+		Sseq = append(Sseq, Ssum...)
+	}
+	Sseq = append(Sseq, Ssum[0:i]...)
+
+	Csum := Asum
+
+	// Repeatedly run the collected hash value through SHA512 to burn CPU cycles.
+	for i = 0; i < rounds; i++ {
+		C := sha512.New()
+
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(Pseq)
+		} else {
+			C.Write(Csum)
+		}
+		// Add salt for numbers not divisible by 3.
+		if (i % 3) != 0 {
+			C.Write(Sseq)
+		}
+		// Add key for numbers not divisible by 7.
+		if (i % 7) != 0 {
+			C.Write(Pseq)
+		}
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(Csum)
+		} else {
+			C.Write(Pseq)
+		}
+
+		Csum = C.Sum(nil)
+	}
+
+	out := make([]byte, 0, 123)
+	out = append(out, c.Salt.MagicPrefix...)
+	if isRoundsDef {
+		out = append(out, []byte("rounds="+strconv.Itoa(rounds)+"$")...)
+	}
+	out = append(out, salt...)
+	out = append(out, '$')
+	out = append(out, common.Base64_24Bit([]byte{
+		Csum[42], Csum[21], Csum[0],
+		Csum[1], Csum[43], Csum[22],
+		Csum[23], Csum[2], Csum[44],
+		Csum[45], Csum[24], Csum[3],
+		Csum[4], Csum[46], Csum[25],
+		Csum[26], Csum[5], Csum[47],
+		Csum[48], Csum[27], Csum[6],
+		Csum[7], Csum[49], Csum[28],
+		Csum[29], Csum[8], Csum[50],
+		Csum[51], Csum[30], Csum[9],
+		Csum[10], Csum[52], Csum[31],
+		Csum[32], Csum[11], Csum[53],
+		Csum[54], Csum[33], Csum[12],
+		Csum[13], Csum[55], Csum[34],
+		Csum[35], Csum[14], Csum[56],
+		Csum[57], Csum[36], Csum[15],
+		Csum[16], Csum[58], Csum[37],
+		Csum[38], Csum[17], Csum[59],
+		Csum[60], Csum[39], Csum[18],
+		Csum[19], Csum[61], Csum[40],
+		Csum[41], Csum[20], Csum[62],
+		Csum[63],
+	})...)
+
+	// Clean sensitive data.
+	A.Reset()
+	Alternate.Reset()
+	P.Reset()
+	for i = 0; i < len(Asum); i++ {
+		Asum[i] = 0
+	}
+	for i = 0; i < len(AlternateSum); i++ {
+		AlternateSum[i] = 0
+	}
+	for i = 0; i < len(Pseq); i++ {
+		Pseq[i] = 0
+	}
+
+	return string(out), nil
+}
+
+func (c *crypter) Verify(hashedKey string, key []byte) error {
+	newHash, err := c.Generate(key, []byte(hashedKey))
+	if err != nil {
+		return err
+	}
+	if newHash != hashedKey {
+		return crypt.ErrKeyMismatch
+	}
+	return nil
+}
+
+func (c *crypter) Cost(hashedKey string) (int, error) {
+	saltToks := bytes.Split([]byte(hashedKey), []byte{'$'})
+	if len(saltToks) < 3 {
+		return 0, common.ErrSaltFormat
+	}
+
+	if !bytes.HasPrefix(saltToks[2], _rounds) {
+		return RoundsDefault, nil
+	}
+	roundToks := bytes.Split(saltToks[2], []byte{'='})
+	cost, err := strconv.ParseInt(string(roundToks[1]), 10, 0)
+	return int(cost), err
+}
+
+func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+		RoundsMin:     RoundsMin,
+		RoundsMax:     RoundsMax,
+	}
+}


### PR DESCRIPTION
Instead of hardcoding a global password into the ignition template we now generate a random 12 char password for each kluster and use that in the ignition templates for the kluster nodes.
Existing klusters that don’t have this are staying on the old hard coded value for now.

This password is not exposed anyware at the moment. Its meant as a diagnostic backdoor during the techpreview. We can think about exposing this password to the enduser in the future.

Manually tested that this actually works.