### PR TITLE
Retry kluster update operations

### DIFF
--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	listers_v1 "k8s.io/client-go/listers/core/v1"
+	informers_v1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -29,6 +29,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"github.com/sapcc/kubernikus/pkg/controller/ground"
 	"github.com/sapcc/kubernikus/pkg/controller/metrics"
+	informers_kubernikus "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/util"
 	helm_util "github.com/sapcc/kubernikus/pkg/util/helm"
 	waitutil "github.com/sapcc/kubernikus/pkg/util/wait"
@@ -51,9 +52,8 @@ type GroundControl struct {
 	Recorder record.EventRecorder
 
 	queue           workqueue.RateLimitingInterface
-	klusterInformer cache.SharedIndexInformer
-	podInformer     cache.SharedIndexInformer
-	podLister       listers_v1.PodLister
+	klusterInformer informers_kubernikus.KlusterInformer
+	podInformer     informers_v1.PodInformer
 
 	Logger log.Logger
 }
@@ -68,19 +68,18 @@ func NewGroundController(factories config.Factories, clients config.Clients, rec
 		Config:          config,
 		Recorder:        recorder,
 		queue:           workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(5*time.Second, 300*time.Second)),
-		klusterInformer: factories.Kubernikus.Kubernikus().V1().Klusters().Informer(),
-		podInformer:     factories.Kubernetes.Core().V1().Pods().Informer(),
-		podLister:       listers_v1.NewPodLister(factories.Kubernetes.Core().V1().Pods().Informer().GetIndexer()),
+		klusterInformer: factories.Kubernikus.Kubernikus().V1().Klusters(),
+		podInformer:     factories.Kubernetes.Core().V1().Pods(),
 		Logger:          logger,
 	}
 
-	operator.klusterInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	operator.klusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    operator.klusterAdd,
 		UpdateFunc: operator.klusterUpdate,
 		DeleteFunc: operator.klusterTerminate,
 	})
 
-	operator.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	operator.podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    operator.podAdd,
 		UpdateFunc: operator.podUpdate,
 		DeleteFunc: operator.podDelete,
@@ -147,8 +146,17 @@ func (op *GroundControl) processNextWorkItem() bool {
 	return true
 }
 
+func (op *GroundControl) updateKluster(namespace, name string, updateFunc func(kluster *v1.Kluster) error) error {
+	_, err := util.UpdateKlusterWithRetries(
+		op.Clients.Kubernikus.Kubernikus().Klusters(namespace),
+		op.klusterInformer.Lister().Klusters(namespace),
+		name,
+		updateFunc)
+	return err
+}
+
 func (op *GroundControl) handler(key string) error {
-	obj, exists, err := op.klusterInformer.GetIndexer().GetByKey(key)
+	obj, exists, err := op.klusterInformer.Informer().GetIndexer().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch key %s from cache: %s", key, err)
 	}
@@ -172,7 +180,7 @@ func (op *GroundControl) handler(key string) error {
 		case models.KlusterPhasePending:
 			{
 				if op.requiresOpenstackInfo(kluster) {
-					if err := op.discoverOpenstackInfo(kluster); err != nil {
+					if err := op.updateKluster(kluster.Namespace, kluster.Name, op.discoverOpenstackInfo); err != nil {
 						op.Recorder.Eventf(kluster, api_v1.EventTypeWarning, ConfigurationError, "Discovery of openstack parameters failed: %s", err)
 						return err
 					}
@@ -180,7 +188,7 @@ func (op *GroundControl) handler(key string) error {
 				}
 
 				if op.requiresKubernikusInfo(kluster) {
-					if err := op.discoverKubernikusInfo(kluster); err != nil {
+					if err := op.updateKluster(kluster.Namespace, kluster.Name, op.discoverKubernikusInfo); err != nil {
 						op.Recorder.Eventf(kluster, api_v1.EventTypeWarning, ConfigurationError, "Discovery of kubernikus parameters failed: %s", err)
 						return err
 					}
@@ -210,7 +218,7 @@ func (op *GroundControl) handler(key string) error {
 					"phase", kluster.Status.Phase)
 			}
 		case models.KlusterPhaseCreating:
-			pods, err := op.podLister.List(labels.SelectorFromValidatedSet(map[string]string{"release": kluster.GetName()}))
+			pods, err := op.podInformer.Lister().List(labels.SelectorFromValidatedSet(map[string]string{"release": kluster.GetName()}))
 			if err != nil {
 				return err
 			}
@@ -328,24 +336,19 @@ func (op *GroundControl) klusterUpdate(cur, old interface{}) {
 }
 
 func (op *GroundControl) updatePhase(kluster *v1.Kluster, phase models.KlusterPhase, message string) error {
-	//Never modify the cache, at least that's what I've been told
-	kluster, err := op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Get(kluster.Name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
 
 	//Do nothing is the phase is not changing
 	if kluster.Status.Phase == phase {
 		return nil
 	}
-	op.Recorder.Eventf(kluster, api_v1.EventTypeNormal, string(phase), "%s cluster", phase)
-	kluster.Status.Message = message
-	kluster.Status.Phase = phase
+	err := util.UpdateKlusterPhase(op.Clients.Kubernikus.Kubernikus(), kluster, phase)
 
-	_, err = op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Update(kluster)
 	if err == nil {
+		op.Recorder.Eventf(kluster, api_v1.EventTypeNormal, string(phase), "%s kluster", phase)
+		kluster.Status.Message = message
+		kluster.Status.Phase = phase
 		//Wait for up to 5 seconds for the local cache to reflect the phase change
-		waitutil.WaitForKluster(kluster, op.klusterInformer.GetIndexer(), func(k *v1.Kluster) (bool, error) {
+		waitutil.WaitForKluster(kluster, op.klusterInformer.Informer().GetIndexer(), func(k *v1.Kluster) (bool, error) {
 			return k.Status.Phase == phase, nil
 		})
 	}
@@ -379,7 +382,7 @@ func (op *GroundControl) createKluster(kluster *v1.Kluster) error {
 		return err
 	}
 
-	if err := util.EnsureFinalizerCreated(op.Clients.Kubernikus.KubernikusV1(), kluster, GroundctlFinalizer); err != nil {
+	if err := util.EnsureFinalizerCreated(op.Clients.Kubernikus.KubernikusV1(), op.klusterInformer.Lister(), kluster, GroundctlFinalizer); err != nil {
 		return err
 	}
 
@@ -455,7 +458,7 @@ func (op *GroundControl) terminateKluster(kluster *v1.Kluster) error {
 		return err
 	}
 
-	if err := util.EnsureFinalizerRemoved(op.Clients.Kubernikus.KubernikusV1(), kluster, GroundctlFinalizer); err != nil {
+	if err := util.EnsureFinalizerRemoved(op.Clients.Kubernikus.KubernikusV1(), op.klusterInformer.Lister(), kluster, GroundctlFinalizer); err != nil {
 		return err
 	}
 
@@ -475,7 +478,7 @@ func (op *GroundControl) terminateKluster(kluster *v1.Kluster) error {
 		Error()
 
 	if err == nil {
-		waitutil.WaitForKlusterDeletion(kluster, op.klusterInformer.GetIndexer())
+		waitutil.WaitForKlusterDeletion(kluster, op.klusterInformer.Informer().GetIndexer())
 	}
 	return err
 }
@@ -499,31 +502,25 @@ func (op *GroundControl) discoverKubernikusInfo(kluster *v1.Kluster) error {
 		"project", kluster.Account(),
 		"v", 5)
 
-	copy, err := op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Get(kluster.Name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	if copy.Status.Apiserver == "" {
-		copy.Status.Apiserver = fmt.Sprintf("https://%s.%s", kluster.GetName(), op.Config.Kubernikus.Domain)
+	if kluster.Status.Apiserver == "" {
+		kluster.Status.Apiserver = fmt.Sprintf("https://%s.%s", kluster.GetName(), op.Config.Kubernikus.Domain)
 		op.Logger.Log(
 			"msg", "discovered ServerURL",
-			"url", copy.Status.Apiserver,
+			"url", kluster.Status.Apiserver,
 			"kluster", kluster.GetName(),
 			"project", kluster.Account())
 	}
 
-	if copy.Status.Wormhole == "" {
-		copy.Status.Wormhole = fmt.Sprintf("https://%s-wormhole.%s", kluster.GetName(), op.Config.Kubernikus.Domain)
+	if kluster.Status.Wormhole == "" {
+		kluster.Status.Wormhole = fmt.Sprintf("https://%s-wormhole.%s", kluster.GetName(), op.Config.Kubernikus.Domain)
 		op.Logger.Log(
 			"msg", "discovered WormholeURL",
-			"url", copy.Status.Wormhole,
+			"url", kluster.Status.Wormhole,
 			"kluster", kluster.GetName(),
 			"project", kluster.Account())
 	}
 
-	_, err = op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Update(copy)
-	return err
+	return nil
 }
 
 func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
@@ -538,20 +535,18 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		return err
 	}
 
-	copy := kluster.DeepCopy()
-
-	if copy.Spec.Openstack.ProjectID == "" {
-		copy.Spec.Openstack.ProjectID = kluster.Account()
+	if kluster.Spec.Openstack.ProjectID == "" {
+		kluster.Spec.Openstack.ProjectID = kluster.Account()
 		op.Logger.Log(
 			"msg", "discovered ProjectID",
-			"id", copy.Spec.Openstack.ProjectID,
+			"id", kluster.Spec.Openstack.ProjectID,
 			"kluster", kluster.GetName(),
 			"project", kluster.Account())
 	}
 
 	var selectedRouter *openstack.Router
 
-	if routerID := copy.Spec.Openstack.RouterID; routerID != "" {
+	if routerID := kluster.Spec.Openstack.RouterID; routerID != "" {
 		for _, router := range routers {
 			if router.ID == routerID {
 				selectedRouter = &router
@@ -569,7 +564,7 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 				"id", selectedRouter.ID,
 				"kluster", kluster.GetName(),
 				"project", kluster.Account())
-			copy.Spec.Openstack.RouterID = selectedRouter.ID
+			kluster.Spec.Openstack.RouterID = selectedRouter.ID
 		} else {
 			return fmt.Errorf("Found %d routers in project. Auto-configuration not possible.", numRouters)
 		}
@@ -578,7 +573,7 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 	//we have a router beyond this point
 	var selectedNetwork *openstack.Network
 
-	if networkID := copy.Spec.Openstack.NetworkID; networkID != "" {
+	if networkID := kluster.Spec.Openstack.NetworkID; networkID != "" {
 		for _, network := range selectedRouter.Networks {
 			if network.ID == networkID {
 				selectedNetwork = &network
@@ -591,7 +586,7 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 	} else {
 		if numNetworks := len(selectedRouter.Networks); numNetworks == 1 {
 			selectedNetwork = &selectedRouter.Networks[0]
-			copy.Spec.Openstack.NetworkID = selectedNetwork.ID
+			kluster.Spec.Openstack.NetworkID = selectedNetwork.ID
 			op.Logger.Log(
 				"msg", "discovered NetworkID",
 				"id", selectedNetwork.ID,
@@ -603,7 +598,7 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		}
 	}
 
-	if subnetID := copy.Spec.Openstack.LBSubnetID; subnetID != "" {
+	if subnetID := kluster.Spec.Openstack.LBSubnetID; subnetID != "" {
 		found := false
 		for _, subnet := range selectedNetwork.Subnets {
 			if subnet.ID == subnetID {
@@ -616,10 +611,10 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		}
 	} else {
 		if numSubnets := len(selectedNetwork.Subnets); numSubnets == 1 {
-			copy.Spec.Openstack.LBSubnetID = selectedNetwork.Subnets[0].ID
+			kluster.Spec.Openstack.LBSubnetID = selectedNetwork.Subnets[0].ID
 			op.Logger.Log(
 				"msg", "discovered LBSubnetID",
-				"id", copy.Spec.Openstack.LBSubnetID,
+				"id", kluster.Spec.Openstack.LBSubnetID,
 				"kluster", kluster.GetName(),
 				"project", kluster.Account())
 		} else {
@@ -627,7 +622,7 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		}
 	}
 
-	if floatingNetworkID := copy.Spec.Openstack.LBFloatingNetworkID; floatingNetworkID != "" {
+	if floatingNetworkID := kluster.Spec.Openstack.LBFloatingNetworkID; floatingNetworkID != "" {
 		if selectedRouter.ExternalNetworkID != "" && floatingNetworkID != selectedRouter.ExternalNetworkID {
 			return fmt.Errorf("External network missmatch. Router is configured with %s but config specifies %s", selectedRouter.ExternalNetworkID, floatingNetworkID)
 		}
@@ -635,24 +630,23 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		if selectedRouter.ExternalNetworkID == "" {
 			return fmt.Errorf("Selected router %s doesn't have an external network ID set", selectedRouter.ID)
 		} else {
-			copy.Spec.Openstack.LBFloatingNetworkID = selectedRouter.ExternalNetworkID
+			kluster.Spec.Openstack.LBFloatingNetworkID = selectedRouter.ExternalNetworkID
 			op.Logger.Log(
 				"msg", "discovered LBFloatingNetworkID",
-				"id", copy.Spec.Openstack.LBFloatingNetworkID,
+				"id", kluster.Spec.Openstack.LBFloatingNetworkID,
 				"kluster", kluster.GetName(),
 				"project", kluster.Account())
 		}
 	}
 
-	if copy.Spec.Openstack.SecurityGroupName == "" {
-		copy.Spec.Openstack.SecurityGroupName = "default"
+	if kluster.Spec.Openstack.SecurityGroupName == "" {
+		kluster.Spec.Openstack.SecurityGroupName = "default"
 	}
-	if _, err := op.Clients.Openstack.GetSecurityGroupID(kluster.Account(), copy.Spec.Openstack.SecurityGroupName); err != nil {
+	if _, err := op.Clients.Openstack.GetSecurityGroupID(kluster.Account(), kluster.Spec.Openstack.SecurityGroupName); err != nil {
 		return fmt.Errorf("Security group %s invalid: ", err)
 	}
 
-	_, err = op.Clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Update(copy)
-	return err
+	return nil
 }
 
 func (op *GroundControl) podAdd(obj interface{}) {

--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -82,6 +82,7 @@ func (cpm *ConcretePoolManager) SetStatus(status *PoolStatus) error {
 		Schedulable: int64(status.Running),
 	}
 
+	//TODO: Use util.UpdateKlusterWithRetries here
 	copy, err := cpm.Clients.Kubernikus.Kubernikus().Klusters(cpm.Kluster.Namespace).Get(cpm.Kluster.Name, metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/pkg/util/kluster.go
+++ b/pkg/util/kluster.go
@@ -1,24 +1,48 @@
 package util
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	clientset "github.com/sapcc/kubernikus/pkg/generated/clientset/typed/kubernikus/v1"
+	listers_kubernikus "github.com/sapcc/kubernikus/pkg/generated/listers/kubernikus/v1"
 )
 
-func EnsureFinalizerCreated(client clientset.KubernikusV1Interface, kluster *v1.Kluster, finalizer string) (err error) {
+func EnsureFinalizerCreated(client clientset.KubernikusV1Interface, lister listers_kubernikus.KlusterLister, kluster *v1.Kluster, finalizer string) (err error) {
 	if kluster.NeedsFinalizer(finalizer) {
-		copy := kluster.DeepCopy()
-		copy.AddFinalizer(finalizer)
-		_, err = client.Klusters(copy.Namespace).Update(copy)
+		_, err = UpdateKlusterWithRetries(client.Klusters(kluster.Namespace), lister.Klusters(kluster.Namespace), kluster.Name, func(kluster *v1.Kluster) error {
+			kluster.AddFinalizer(finalizer)
+			return nil
+		})
 	}
 	return err
 }
 
-func EnsureFinalizerRemoved(client clientset.KubernikusV1Interface, kluster *v1.Kluster, finalizer string) (err error) {
+func EnsureFinalizerRemoved(client clientset.KubernikusV1Interface, lister listers_kubernikus.KlusterLister, kluster *v1.Kluster, finalizer string) (err error) {
 	if kluster.HasFinalizer(finalizer) {
-		copy := kluster.DeepCopy()
-		copy.RemoveFinalizer(finalizer)
-		_, err = client.Klusters(copy.Namespace).Update(copy)
+		_, err = UpdateKlusterWithRetries(client.Klusters(kluster.Namespace), lister.Klusters(kluster.Namespace), kluster.Name, func(kluster *v1.Kluster) error {
+			kluster.RemoveFinalizer(finalizer)
+			return nil
+		})
 	}
+	return err
+}
+
+func UpdateKlusterPhase(client clientset.KubernikusV1Interface, kluster *v1.Kluster, phase models.KlusterPhase) error {
+
+	//Because we specify raw json for the patch I put this here to make sure field is still part of the struct
+	var _ = kluster.Status.Phase
+
+	//According to this comment https://github.com/kubernetes/kubernetes/issues/21479#issuecomment-186454413
+	//patches are retried on the server side so a single try should be sufficient
+
+	_, err := client.Klusters(kluster.Namespace).Patch(
+		kluster.Name,
+		types.MergePatchType,
+		[]byte(fmt.Sprintf(`{"status":{"phase":"%s"}}`, phase)),
+	)
 	return err
 }

--- a/pkg/util/log/logging.go
+++ b/pkg/util/log/logging.go
@@ -16,7 +16,6 @@ func NewLogger(flags *pflag.FlagSet) kitLog.Logger {
 	if v := flags.Lookup("v"); v != nil {
 		level, _ = strconv.Atoi(v.Value.String())
 	}
-	fmt.Println("Logging with level ", level)
 
 	var logger kitLog.Logger
 	logger = kitLog.NewLogfmtLogger(kitLog.NewSyncWriter(os.Stderr))

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"errors"
+
+	"k8s.io/client-go/util/retry"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	client "github.com/sapcc/kubernikus/pkg/generated/clientset/typed/kubernikus/v1"
+	listers_kubernikus "github.com/sapcc/kubernikus/pkg/generated/listers/kubernikus/v1"
+)
+
+type updateKlusterFunc func(kluster *v1.Kluster) error
+
+var KlusterNotUpdated = errors.New("Kluster not updated")
+
+// UpdateKlusterWithRetries updates a kluster with given applyUpdate function.
+func UpdateKlusterWithRetries(klusterClient client.KlusterInterface, klusterLister listers_kubernikus.KlusterNamespaceLister, name string, applyUpdate updateKlusterFunc) (*v1.Kluster, error) {
+	var kluster *v1.Kluster
+
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var err error
+		kluster, err = klusterLister.Get(name)
+		if err != nil {
+			return err
+		}
+		kluster = kluster.DeepCopy()
+		// Apply the update, then attempt to push it to the apiserver.
+		if applyErr := applyUpdate(kluster); applyErr != nil {
+			if err == KlusterNotUpdated {
+				return nil
+			}
+			return applyErr
+		}
+		kluster, err = klusterClient.Update(kluster)
+		return err
+	})
+
+	return kluster, retryErr
+}

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// RetryConflict executes the provided function repeatedly, retrying if the server returns a conflicting
+// write. Callers should preserve previous executions if they wish to retry changes. It performs an
+// exponential backoff.
+//
+//     var pod *api.Pod
+//     err := RetryOnConflict(DefaultBackoff, func() (err error) {
+//       pod, err = c.Pods("mynamespace").UpdateStatus(podStatus)
+//       return
+//     })
+//     if err != nil {
+//       // may be conflict if max retries were hit
+//       return err
+//     }
+//     ...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	var lastConflictErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.IsConflict(err):
+			lastConflictErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastConflictErr
+	}
+	return err
+}


### PR DESCRIPTION
This PR adds a `util.UpdateKlusterWithRetries` method that uses the local cache to retry an update to the Kluster CRD 4 times before it fails. It also changes to phase change to a PATCH operation that should be more robust against write conflicts.