### PR TITLE
Register routegc metrics

### DIFF
--- a/pkg/controller/metrics/launch.go
+++ b/pkg/controller/metrics/launch.go
@@ -2,6 +2,15 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+func init() {
+	prometheus.MustRegister(
+		LaunchOperationsLatency,
+		LaunchOperationsTotal,
+		LaunchSuccessfulOperationsTotal,
+		LaunchFailedOperationsTotal,
+	)
+}
+
 var LaunchOperationsLatency = prometheus.NewSummaryVec(
 	prometheus.SummaryOpts{
 		Namespace: "kubernikus",

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -174,10 +174,6 @@ func init() {
 		klusterBootDurationSummary,
 		nodePoolSize,
 		nodePoolStatus,
-		LaunchOperationsLatency,
-		LaunchOperationsTotal,
-		LaunchSuccessfulOperationsTotal,
-		LaunchFailedOperationsTotal,
 	)
 }
 

--- a/pkg/controller/metrics/routegc.go
+++ b/pkg/controller/metrics/routegc.go
@@ -2,6 +2,13 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+func init() {
+	prometheus.MustRegister(
+		OrphanedRoutesTotal,
+		RouteGCFailedOperationsTotal,
+	)
+}
+
 var OrphanedRoutesTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "kubernikus",


### PR DESCRIPTION
I missed that they were supposed to be added in the `init` method of `metrics.go` which defeats the purpose of splitting up the metrics by component. I think it makes sense to have the register calls in the same file were the metrics are defined.