### PR TITLE
Use nodeobservatory to update node pool status

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -5,6 +5,7 @@ package extra_dependencies
 
 import (
 	_ "github.com/stretchr/testify/assert"
+	_ "github.com/stretchr/testify/require"
 	_ "k8s.io/client-go/kubernetes/fake"
 	_ "k8s.io/code-generator/cmd/client-gen"
 	_ "k8s.io/code-generator/cmd/informer-gen"

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -1,11 +1,9 @@
 package kubernetes
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
-	"sync"
 	"time"
 
 	kitlog "github.com/go-kit/kit/log"
@@ -16,96 +14,12 @@ import (
 	apiutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	kubernikus_v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
-
-type SharedClientFactory struct {
-	clients          *sync.Map
-	secretsInterface typedv1.SecretInterface
-	Logger           kitlog.Logger
-}
-
-func NewSharedClientFactory(secrets typedv1.SecretInterface, klusterEvents cache.SharedIndexInformer, logger kitlog.Logger) *SharedClientFactory {
-	factory := &SharedClientFactory{
-		clients:          new(sync.Map),
-		secretsInterface: secrets,
-		Logger:           kitlog.With(logger, "client", "kubernetes"),
-	}
-
-	if klusterEvents != nil {
-		klusterEvents.AddEventHandler(cache.ResourceEventHandlerFuncs{
-			DeleteFunc: func(obj interface{}) {
-				if kluster, ok := obj.(*kubernikus_v1.Kluster); ok {
-					factory.clients.Delete(kluster.GetUID())
-					factory.Logger.Log(
-						"msg", "deleted shared kubernetes client",
-						"kluster", kluster.GetName(),
-						"project", kluster.Account(),
-						"v", 2,
-					)
-				}
-			},
-		})
-	}
-
-	return factory
-}
-
-func (f *SharedClientFactory) ClientFor(k *kubernikus_v1.Kluster) (clientset kubernetes.Interface, err error) {
-	defer func() {
-		f.Logger.Log(
-			"msg", "created shared kubernetes client",
-			"kluster", k.GetName(),
-			"project", k.Account(),
-			"v", 2,
-			"err", err,
-		)
-	}()
-
-	if client, found := f.clients.Load(k.GetUID()); found {
-		return client.(kubernetes.Interface), nil
-	}
-	secret, err := f.secretsInterface.Get(k.GetName(), metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	apiserverCACert, ok := secret.Data["tls-ca.pem"]
-	if !ok {
-		return nil, errors.New("tls-ca.pem not found in secret")
-	}
-	clientCert, ok := secret.Data["apiserver-clients-cluster-admin.pem"]
-	if !ok {
-		return nil, errors.New("tls-ca.pem not found in secret")
-	}
-	clientKey, ok := secret.Data["apiserver-clients-cluster-admin-key.pem"]
-	if !ok {
-		return nil, errors.New("tls-ca.pem not found in secret")
-	}
-
-	c := rest.Config{
-		Host: k.Status.Apiserver,
-		TLSClientConfig: rest.TLSClientConfig{
-			CertData: clientCert,
-			KeyData:  clientKey,
-			CAData:   apiserverCACert,
-		},
-	}
-
-	clientset, err = kubernetes.NewForConfig(&c)
-	if err != nil {
-		return nil, err
-	}
-
-	f.clients.Store(k.GetUID(), clientset)
-	return clientset, nil
-
-}
 
 func NewConfig(kubeconfig, context string) (*rest.Config, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()

--- a/pkg/client/kubernetes/shared_client_factory.go
+++ b/pkg/client/kubernetes/shared_client_factory.go
@@ -1,0 +1,110 @@
+package kubernetes
+
+import (
+	"errors"
+	"sync"
+
+	kitlog "github.com/go-kit/kit/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	kubernikus_v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+)
+
+type SharedClientFactory interface {
+	ClientFor(k *kubernikus_v1.Kluster) (clientset kubernetes.Interface, err error)
+}
+
+type sharedClientFactory struct {
+	clients          *sync.Map
+	secretsInterface typedv1.SecretInterface
+	Logger           kitlog.Logger
+}
+
+func NewSharedClientFactory(secrets typedv1.SecretInterface, klusterEvents cache.SharedIndexInformer, logger kitlog.Logger) SharedClientFactory {
+	factory := &sharedClientFactory{
+		clients:          new(sync.Map),
+		secretsInterface: secrets,
+		Logger:           kitlog.With(logger, "client", "kubernetes"),
+	}
+
+	if klusterEvents != nil {
+		klusterEvents.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				if kluster, ok := obj.(*kubernikus_v1.Kluster); ok {
+					factory.clients.Delete(kluster.GetUID())
+					factory.Logger.Log(
+						"msg", "deleted shared kubernetes client",
+						"kluster", kluster.GetName(),
+						"project", kluster.Account(),
+						"v", 2,
+					)
+				}
+			},
+		})
+	}
+
+	return factory
+}
+
+func (f *sharedClientFactory) ClientFor(k *kubernikus_v1.Kluster) (clientset kubernetes.Interface, err error) {
+	defer func() {
+		f.Logger.Log(
+			"msg", "created shared kubernetes client",
+			"kluster", k.GetName(),
+			"project", k.Account(),
+			"v", 2,
+			"err", err,
+		)
+	}()
+
+	if client, found := f.clients.Load(k.GetUID()); found {
+		return client.(kubernetes.Interface), nil
+	}
+	secret, err := f.secretsInterface.Get(k.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	apiserverCACert, ok := secret.Data["tls-ca.pem"]
+	if !ok {
+		return nil, errors.New("tls-ca.pem not found in secret")
+	}
+	clientCert, ok := secret.Data["apiserver-clients-cluster-admin.pem"]
+	if !ok {
+		return nil, errors.New("tls-ca.pem not found in secret")
+	}
+	clientKey, ok := secret.Data["apiserver-clients-cluster-admin-key.pem"]
+	if !ok {
+		return nil, errors.New("tls-ca.pem not found in secret")
+	}
+
+	c := rest.Config{
+		Host: k.Status.Apiserver,
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: clientCert,
+			KeyData:  clientKey,
+			CAData:   apiserverCACert,
+		},
+	}
+
+	clientset, err = kubernetes.NewForConfig(&c)
+	if err != nil {
+		return nil, err
+	}
+
+	f.clients.Store(k.GetUID(), clientset)
+	return clientset, nil
+
+}
+
+type MockSharedClientFactory struct {
+	Clientset kubernetes.Interface
+}
+
+func (m *MockSharedClientFactory) ClientFor(k *kubernikus_v1.Kluster) (kubernetes.Interface, error) {
+	return m.Clientset, nil
+
+}

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	kube "github.com/sapcc/kubernikus/pkg/client/kubernetes"
 	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
 	kubernikus_clientset "github.com/sapcc/kubernikus/pkg/generated/clientset"
 	kubernikus_informers "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions"
 )
@@ -53,6 +54,7 @@ type Clients struct {
 }
 
 type Factories struct {
-	Kubernikus kubernikus_informers.SharedInformerFactory
-	Kubernetes kubernetes_informers.SharedInformerFactory
+	Kubernikus       kubernikus_informers.SharedInformerFactory
+	Kubernetes       kubernetes_informers.SharedInformerFactory
+	NodesObservatory *nodeobservatory.InformerFactory
 }

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -48,7 +48,7 @@ type Config struct {
 type Clients struct {
 	Kubernikus kubernikus_clientset.Interface
 	Kubernetes kubernetes_clientset.Interface
-	Satellites *kube.SharedClientFactory
+	Satellites kube.SharedClientFactory
 	Openstack  openstack.Client
 	Helm       *helm.Client
 }

--- a/pkg/controller/deorbit/controller.go
+++ b/pkg/controller/deorbit/controller.go
@@ -58,7 +58,8 @@ func NewController(threadiness int, factories config.Factories, clients config.C
 		metrics.DeorbitSuccessfulOperationsTotal,
 		metrics.DeorbitFailedOperationsTotal,
 	}
-	return base.NewController(threadiness, factories, clients, reconciler, logger)
+	return base.NewController(threadiness, factories, reconciler, logger, nil)
+
 }
 
 func (d *DeorbitReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {

--- a/pkg/controller/nodeobservatory/controller.go
+++ b/pkg/controller/nodeobservatory/controller.go
@@ -1,20 +1,23 @@
 package nodeobservatory
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
+	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	listers_core_v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	core_v1 "k8s.io/api/core/v1"
-
+	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/controller/config"
+	kube "github.com/sapcc/kubernikus/pkg/client/kubernetes"
+	kubernikus_informers_v1 "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
 )
 
 const (
@@ -28,10 +31,15 @@ type (
 	UpdateFunc func(kluster *v1.Kluster, nodeCur, nodeOld *core_v1.Node)
 	DeleteFunc func(kluster *v1.Kluster, node *core_v1.Node)
 
+	NodeEventHandlerFuncs struct {
+		AddFunc    AddFunc
+		UpdateFunc UpdateFunc
+		DeleteFunc DeleteFunc
+	}
+
 	NodeObservatory struct {
-		config.Controller
-		config.Factories
-		config.Clients
+		clientFactory       *kube.SharedClientFactory
+		klusterInformer     kubernikus_informers_v1.KlusterInformer
 		namespace           string
 		queue               workqueue.RateLimitingInterface
 		logger              log.Logger
@@ -41,28 +49,26 @@ type (
 		updateEventHandlers []UpdateFunc
 		deleteEventHandlers []DeleteFunc
 		stopCh              <-chan struct{}
-		informerWg          *sync.WaitGroup
 		threadiness         int
 	}
 )
 
-func NewController(factories config.Factories, clients config.Clients, logger log.Logger, namespace string, threadiness int) *NodeObservatory {
+func NewController(informer kubernikus_informers_v1.KlusterInformer, factory *kube.SharedClientFactory, logger log.Logger, threadiness int) *NodeObservatory {
 	logger = log.With(logger,
 		"controller", "nodeobservatory",
 		"threadiness", threadiness,
 	)
 
 	controller := &NodeObservatory{
-		Factories:       factories,
-		Clients:         clients,
-		namespace:       namespace,
+		clientFactory:   factory,
+		klusterInformer: informer,
 		queue:           workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(BaseDelay, MaxDelay)),
 		logger:          logger,
 		nodeInformerMap: sync.Map{},
 		threadiness:     threadiness,
 	}
 
-	controller.Factories.Kubernikus.Kubernikus().V1().Klusters().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.klusterAddFunc,
 		UpdateFunc: controller.klusterUpdateFunc,
 		DeleteFunc: controller.klusterDeleteFunc,
@@ -71,18 +77,15 @@ func NewController(factories config.Factories, clients config.Clients, logger lo
 	return controller
 }
 
-func (n *NodeObservatory) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+func (n *NodeObservatory) Run(stopCh <-chan struct{}) {
 	n.logger.Log(
 		"msg", "starting run loop",
 		"v", 2,
 	)
 
 	n.stopCh = stopCh
-	n.informerWg = wg
 
 	defer n.queue.ShutDown()
-	defer wg.Done()
-	wg.Add(1)
 
 	for i := 0; i < n.threadiness; i++ {
 		go wait.Until(n.runWorker, time.Second, stopCh)
@@ -112,7 +115,7 @@ func (n *NodeObservatory) requeueAllKlusters() (err error) {
 		)
 	}()
 
-	klusters, err := n.Factories.Kubernikus.Kubernikus().V1().Klusters().Lister().Klusters(n.namespace).List(labels.Everything())
+	klusters, err := n.klusterInformer.Lister().Klusters(n.namespace).List(labels.Everything())
 	if err != nil {
 		return err
 	}
@@ -153,7 +156,7 @@ func (n *NodeObservatory) processNextWorkItem() bool {
 	var kluster *v1.Kluster
 	var requeue bool
 
-	if obj, exists, _ := n.Factories.Kubernikus.Kubernikus().V1().Klusters().Informer().GetIndexer().GetByKey(key.(string)); exists {
+	if obj, exists, _ := n.klusterInformer.Informer().GetIndexer().GetByKey(key.(string)); exists {
 		kluster = obj.(*v1.Kluster)
 	}
 
@@ -191,7 +194,7 @@ func (n *NodeObservatory) reconcile(kluster *v1.Kluster) (bool, error) {
 
 	n.cleanUpInformers()
 
-	if kluster != nil {
+	if kluster != nil && (kluster.Status.Phase == models.KlusterPhaseRunning || kluster.Status.Phase == models.KlusterPhaseTerminating) {
 		if err := n.createAndWatchNodeInformerForKluster(kluster); err != nil {
 			return true, err
 		}
@@ -203,7 +206,7 @@ func (n *NodeObservatory) reconcile(kluster *v1.Kluster) (bool, error) {
 func (n *NodeObservatory) cleanUpInformers() {
 	n.nodeInformerMap.Range(
 		func(key, value interface{}) bool {
-			if _, exists, _ := n.Factories.Kubernikus.Kubernikus().V1().Klusters().Informer().GetIndexer().GetByKey(key.(string)); !exists {
+			if _, exists, _ := n.klusterInformer.Informer().GetIndexer().GetByKey(key.(string)); !exists {
 				if i, ok := n.nodeInformerMap.Load(key); ok {
 					informer := i.(*NodeInformer)
 					informer.close()
@@ -226,7 +229,7 @@ func (n *NodeObservatory) createAndWatchNodeInformerForKluster(kluster *v1.Klust
 			"creating nodeInformer for kluster %s", key,
 			"v", 2,
 		)
-		nodeInformer, err := newNodeInformerForKluster(n.Clients.Satellites, kluster)
+		nodeInformer, err := newNodeInformerForKluster(n.clientFactory, kluster)
 		if err != nil {
 			return err
 		}
@@ -279,8 +282,6 @@ func (n *NodeObservatory) createAndWatchNodeInformerForKluster(kluster *v1.Klust
 		)
 
 		go func(informer *NodeInformer) {
-			n.informerWg.Add(1)
-			defer n.informerWg.Done()
 			ch := make(chan struct{})
 
 			go func() {
@@ -301,7 +302,7 @@ func (n *NodeObservatory) createAndWatchNodeInformerForKluster(kluster *v1.Klust
 }
 
 func (n *NodeObservatory) getKlusterByKey(key string) (*v1.Kluster, error) {
-	o, exists, err := n.Factories.Kubernikus.Kubernikus().V1().Klusters().Informer().GetIndexer().GetByKey(key)
+	o, exists, err := n.klusterInformer.Informer().GetIndexer().GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
@@ -333,21 +334,16 @@ func (n *NodeObservatory) klusterDeleteFunc(obj interface{}) {
 }
 
 // GetStoreForKluster returns the SharedIndexInformers cache.Store for a given kluster or an error
-func (n *NodeObservatory) GetStoreForKluster(kluster *v1.Kluster) (cache.Store, error) {
+func (n *NodeObservatory) GetListerForKluster(kluster *v1.Kluster) (listers_core_v1.NodeLister, error) {
 	informer, err := n.getNodeInformerForKluster(kluster)
 	if err != nil {
 		return nil, err
 	}
-	return informer.GetStore(), nil
-}
 
-// GetIndexerForKluster returns the SharedIndexInformers cache.Indexer for a given kluster or an error
-func (n *NodeObservatory) GetIndexerForKluster(kluster *v1.Kluster) (cache.Indexer, error) {
-	informer, err := n.getNodeInformerForKluster(kluster)
-	if err != nil {
-		return nil, err
+	if err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) { return informer.HasSynced(), nil }); err != nil {
+		return nil, errors.New("Node cache not synced")
 	}
-	return informer.GetIndexer(), nil
+	return listers_core_v1.NewNodeLister(informer.GetIndexer()), nil
 }
 
 func (n *NodeObservatory) getNodeInformerForKluster(kluster *v1.Kluster) (*NodeInformer, error) {
@@ -376,17 +372,17 @@ func (n *NodeObservatory) HasSyncedForKluster(kluster *v1.Kluster) bool {
 }
 
 // AddEventHandlerFuncs adds event handlers to the SharedIndexInformer
-func (n *NodeObservatory) AddEventHandlerFuncs(addFunc AddFunc, updateFunc UpdateFunc, deleteFunc DeleteFunc) {
+func (n *NodeObservatory) AddEventHandlerFuncs(handlers NodeEventHandlerFuncs) {
 	n.handlersMux.Lock()
 	defer n.handlersMux.Unlock()
 
-	if addFunc != nil {
-		n.addEventHandlers = append(n.addEventHandlers, addFunc)
+	if handlers.AddFunc != nil {
+		n.addEventHandlers = append(n.addEventHandlers, handlers.AddFunc)
 	}
-	if updateFunc != nil {
-		n.updateEventHandlers = append(n.updateEventHandlers, updateFunc)
+	if handlers.UpdateFunc != nil {
+		n.updateEventHandlers = append(n.updateEventHandlers, handlers.UpdateFunc)
 	}
-	if deleteFunc != nil {
-		n.deleteEventHandlers = append(n.deleteEventHandlers, deleteFunc)
+	if handlers.DeleteFunc != nil {
+		n.deleteEventHandlers = append(n.deleteEventHandlers, handlers.DeleteFunc)
 	}
 }

--- a/pkg/controller/nodeobservatory/controller_test.go
+++ b/pkg/controller/nodeobservatory/controller_test.go
@@ -1,23 +1,19 @@
 package nodeobservatory
 
 import (
-	"os"
 	"testing"
-	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	api_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
 
-	kitLog "github.com/go-kit/kit/log"
-	"github.com/stretchr/testify/assert"
-
+	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
-	"github.com/sapcc/kubernikus/pkg/controller/config"
 	kubernikusfake "github.com/sapcc/kubernikus/pkg/generated/clientset/fake"
 	kubernikus_informers "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions"
 )
@@ -26,101 +22,29 @@ const (
 	KlusterName      = "fakeKluster"
 	KlusterNamespace = "default"
 	NodeName         = "node0"
-	Reconciliation   = 1 * time.Minute
 )
 
 func createFakeNodeObservatory(kluster *v1.Kluster, node *api_v1.Node) NodeObservatory {
-	dummyCertPEM := []byte(`
------BEGIN CERTIFICATE-----
-MIIDZzCCAk+gAwIBAgIJAKR66aipzKWxMA0GCSqGSIb3DQEBBQUAME8xCzAJBgNV
-BAYTAkNOMQswCQYDVQQIEwJHRDELMAkGA1UEBxMCU1oxEzARBgNVBAoTCkFjbWUs
-IEluYy4xETAPBgNVBAMTCE15Um9vdENBMB4XDTE3MTIxMTIxMTAxOVoXDTE3MTIy
-MTIxMTAxOVowVjELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAkdEMQswCQYDVQQHEwJT
-WjETMBEGA1UEChMKQWNtZSwgSW5jLjEYMBYGA1UEAxMPd3d3LmV4YW1wbGUuY29t
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq2X0gM8UyKKJFPFaBCiY
-cN43/h4NgvmL/2BQ7JretsD1iDZm7bicYLjJn7wkzhuAz2HfxO6Hr0XAAEllqCTu
-tqenSM+sX8hROUBA5KDkdDf1QZddEBwWbTVwfYw4vdSx05OdACzH557eKJvHp071
-+V53EoPVHRxk8jl6FX/57+r8P/MbOSPAsm84da79UNKpp+1gh+kY1bK2bTGXMEr7
-idm2BqOWmz9nFpR+h94wUhq7Hxdwyg6pwxUcAy0m2w8J73JhZdxbSvCJX8aSEbjU
-C7W9Xpm2zxXDNvUh7iHtIIqlXqHLa0ZoaIuRK3U4DTiFJYJqASl8vSUKggapX++s
-uwIDAQABoz8wPTA7BgNVHREENDAyggtleGFtcGxlLmNvbYIPd3d3LmV4YW1wbGUu
-Y29tghJ3d3cubXktZXhhbXBsZS5jb20wDQYJKoZIhvcNAQEFBQADggEBAI8XdSbw
-Dyeff77OAyKGG5w5Dzhy6Czhtb2C7mtRonE5iUlNC4lD2wDyRGMVo1kK/Q/Z8WRy
-g4arhwElX1FwrnulU/P/7cQn1mvtFfhXrwXXrlEUJjpA83a9sitsGuTImv+1tobk
-QC4xVuBo9IbLApCtISBT9didHigZfHqIZjrfJNi46rQEr+rh2ao5xvqGOVLwwBur
-mm7Lfxh5ET2KRZPQ31S1mL0i9G6gUqVw4eybmmvnyyP10VP5NYVuHECQrcUPvEvg
-wcNw5Ufl8Idbpz5xKFr4K12Jd9q8dPDskw3LA8l3iUuIigG7mKCdFB9HSCro7OAh
-t6cvIMqAVp6arvU=
------END CERTIFICATE-----
-`)
 
-	dummyKeyPEM := []byte(
-		`
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAq2X0gM8UyKKJFPFaBCiYcN43/h4NgvmL/2BQ7JretsD1iDZm
-7bicYLjJn7wkzhuAz2HfxO6Hr0XAAEllqCTutqenSM+sX8hROUBA5KDkdDf1QZdd
-EBwWbTVwfYw4vdSx05OdACzH557eKJvHp071+V53EoPVHRxk8jl6FX/57+r8P/Mb
-OSPAsm84da79UNKpp+1gh+kY1bK2bTGXMEr7idm2BqOWmz9nFpR+h94wUhq7Hxdw
-yg6pwxUcAy0m2w8J73JhZdxbSvCJX8aSEbjUC7W9Xpm2zxXDNvUh7iHtIIqlXqHL
-a0ZoaIuRK3U4DTiFJYJqASl8vSUKggapX++suwIDAQABAoIBAC8Ii0/Ng6aK85ML
-p+f8O9i9IiBZntuSHxi1FX/X/8WmrbnzM8uIHWFtU+bBelgUtAQ0l3MzAYjXWxi5
-C2xYtijpWL5iPqsKDT/ooeYbQJWjxWl6X89L5duSDoxlLizpcOLeXvbtUu38ano6
-RU9kG5uSkJpEEvcqE4lkvFuqAqwTHKxrYLMI9yFsJ94wHmfXO1kizU0Y2dYwxiqa
-eVs9G5tEC3RJzb0OiyHuIlPoXqPLPZXetTPqm21vr67GxPYZJMDy/rRBX5b+f/6r
-73w8jXc+CkyRnXODN87D4HWXJLPMYC0JMDRRaA7Z7eCNx9YOQ3UDxZkdlr3cE89z
-C5wrxgECgYEA1ChMq91oxIY9OhZI6sqCv2byS/GSvKDV7VaDZZLG/uZRlSfsZwz1
-ggGs9idQPS3k0RsSJPEd0y2RkrGnNFSYVIGBgcegdKSUAxKP9JBS1ieXIH7yZKhE
-RZAWerbCScvihJOi1fmVxUKslFR4fVtxAaNsxHDtdYyqUcoOLMswyvUCgYEAztFi
-1PYDRHOqHhyNS5QgClzLKNvxl6o8CksOQFaXP7VNRWufeFc5YTP5sVgz8vfiiPmY
-udEzIAkOgoHxn6p5+HlyPre95WRWuy6GIQiD6u7jX674tzQEzZEQ/63tYn3dmDtg
-BeDQHpbPi/NKgMoQCHjfD74yPIyuZhss8Pn+Ku8CgYEAoWhXjJnST1Hh2wOBTj/r
-4TqtNGIBxUiH+R1MskZM5zjK8LODA5O0ZMhpkoyuWx1DbGMwFrLqgfO1QOmvz/xc
-OE6e/OGnjZZ4lS3WH7Z9jzhnne129GWgK1xH/ex1PDfFih/YTvqnm3/yVJc/Y//h
-peFzqrBPuJLgMYGL70BXStECgYBlwcXjzAs9gb9Aw4GNnxrInnFi8ByFJ8AUvGsN
-os0WDmkvb81tk1TrC3yeEiy1Lduq00uemVyTNYGLGs48Zc9PPsnEK/llxSGbRT+/
-PwZQ8Cq1KEy9Lv3x+p8nfXbfz9fYj9Yl7j/X3RHO5OxSQ5jx4i61+zmSaxFfsZ1C
-D25LxwKBgB+CY9XHW/k+18tuu85aJXVFYaQG3BPYFr1tYyIP7WLO1Ea6daI6J+0N
-41ljcA8+cVeUbw7K+lNd/uRiJfgTeTmYva9dFFEkEB+lOK+nDal3ZdIaZFEWVDh4
-g1GGPll8zndfDTDecJrHjV4G7Bj+QVGuArVG0dAF6Gk3lEzS9AVb
------END RSA PRIVATE KEY-----
-`)
-
-	secret := &api_v1.Secret{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: KlusterNamespace,
-			Name:      KlusterName,
-		},
-		Data: map[string][]byte{
-			"apiserver-clients-cluster-admin.pem":     dummyCertPEM,
-			"apiserver-clients-cluster-admin-key.pem": dummyKeyPEM,
-			"tls-ca.pem":                              dummyCertPEM,
-		},
-	}
-
-	fakeKubernetesClientset := fake.NewSimpleClientset(node, secret)
+	fakeKubernetesClientset := fake.NewSimpleClientset(node)
 	fakeKubernikusClientset := kubernikusfake.NewSimpleClientset(kluster)
-	kubernikusInformerFactory := kubernikus_informers.NewSharedInformerFactory(fakeKubernikusClientset, Reconciliation)
+	kubernikusInformerFactory := kubernikus_informers.NewSharedInformerFactory(fakeKubernikusClientset, 0)
 
 	return NodeObservatory{
-		Clients: config.Clients{
-			Kubernetes: fakeKubernetesClientset,
-			Kubernikus: fakeKubernikusClientset,
-			Satellites: kubernetes.NewSharedClientFactory(
-				fakeKubernetesClientset.Core().Secrets(KlusterNamespace),
-				kubernikusInformerFactory.Kubernikus().V1().Klusters().Informer(),
-				kitLog.NewLogfmtLogger(kitLog.NewSyncWriter(os.Stdout)),
-			),
-		},
+		klusterInformer: kubernikusInformerFactory.Kubernikus().V1().Klusters(),
+		clientFactory:   &kubernetes.MockSharedClientFactory{fakeKubernetesClientset},
+		logger:          log.NewNopLogger(),
 	}
 }
 
-//FIXME: mock list,watch for nodes not working. so the NodeInformer will be empty
-/*func TestCreateWatcherForNodeInKluster(t *testing.T) {
-
+func TestReconilation(t *testing.T) {
 	kluster := &v1.Kluster{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Namespace: KlusterNamespace,
 			Name:      KlusterName,
+		},
+		Status: models.KlusterStatus{
+			Phase: models.KlusterPhaseRunning,
 		},
 	}
 
@@ -134,81 +58,12 @@ g1GGPll8zndfDTDecJrHjV4G7Bj+QVGuArVG0dAF6Gk3lEzS9AVb
 	}
 
 	no := createFakeNodeObservatory(kluster, node)
+	require.NoError(t, no.reconcile(kluster))
 
-	no.AddEventHandlerFuncs(
-		func(kluster *v1.Kluster, node *api_v1.Node) {
-			no.logger.Log("kluster %s/%s: added node %s", kluster.GetNamespace(), kluster.GetName(), node.GetName())
-		},
-		func(kluster *v1.Kluster, nodeCur, nodeOld *api_v1.Node) {
-			no.logger.Log("updated %s/%s: added node %s", kluster.GetNamespace(), kluster.GetName(), nodeOld.GetName())
-		},
-		func(kluster *v1.Kluster, node *api_v1.Node) {
-			no.logger.Log("kluster %s/%s: added node %s", kluster.GetNamespace(), kluster.GetName(), node.GetName())
-		},
-	)
+	lister, err := no.GetListerForKluster(kluster)
+	require.NoError(t, err)
+	nodes, err := lister.List(labels.Everything())
+	require.NoError(t, err)
+	assert.Contains(t, nodes, node)
 
-	if err := no.createAndWatchNodeInformerForKluster(kluster); err != nil {
-		t.Errorf("failed to createAndWatchNodeInformerForKluster: %v", err)
-	}
-
-	key, err := cache.MetaNamespaceKeyFunc(kluster)
-	if err != nil {
-		t.Errorf("couldn't create key for kluster %v: %v", kluster, err)
-	}
-
-	i, ok := no.nodeInformerMap.Load(key)
-	if !ok {
-		t.Errorf("could'nt find any watcher for kluster %s", key)
-	}
-
-	informer := i.(*NodeInformer)
-	assert.NotNil(t, informer)
-}*/
-
-func TestGetStoreForKluster(t *testing.T) {
-	kluster := &v1.Kluster{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: KlusterNamespace,
-			Name:      KlusterName,
-		},
-	}
-
-	node := &api_v1.Node{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: NodeName,
-		},
-		Status: api_v1.NodeStatus{
-			Phase: api_v1.NodeRunning,
-		},
-	}
-
-	no := createFakeNodeObservatory(kluster, node)
-	stopCh := make(chan struct{})
-	ni := NodeInformer{kluster: kluster, stopCh: stopCh}
-	ni.SharedIndexInformer = cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return no.Clients.Kubernetes.CoreV1().Nodes().List(meta_v1.ListOptions{})
-			},
-			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return no.Clients.Kubernetes.CoreV1().Nodes().Watch(meta_v1.ListOptions{})
-			},
-		},
-		&api_v1.Node{},
-		NodeResyncPeriod,
-		cache.Indexers{},
-	)
-	if err := ni.SharedIndexInformer.GetStore().Add(node); err != nil {
-		t.Error(err)
-	}
-
-	key, _ := cache.MetaNamespaceKeyFunc(kluster)
-	no.nodeInformerMap.Store(key, &ni)
-
-	store, err := no.GetStoreForKluster(kluster)
-	if err != nil {
-		t.Error(err)
-	}
-
-	assert.Contains(t, store.List(), node)
 }

--- a/pkg/controller/nodeobservatory/factory.go
+++ b/pkg/controller/nodeobservatory/factory.go
@@ -1,0 +1,44 @@
+package nodeobservatory
+
+import (
+	"sync"
+
+	"github.com/go-kit/kit/log"
+
+	kube "github.com/sapcc/kubernikus/pkg/client/kubernetes"
+	kubernikus_informers_v1 "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
+)
+
+func NewInformerFactory(informer kubernikus_informers_v1.KlusterInformer, clients *kube.SharedClientFactory, logger log.Logger) *InformerFactory {
+	return &InformerFactory{
+		informer:      informer,
+		clientFactory: clients,
+		logger:        logger,
+	}
+}
+
+type InformerFactory struct {
+	lock          sync.Mutex
+	observatory   *NodeObservatory
+	informer      kubernikus_informers_v1.KlusterInformer
+	clientFactory *kube.SharedClientFactory
+	logger        log.Logger
+}
+
+func (f *InformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.observatory != nil {
+		go f.observatory.Run(stopCh)
+	}
+}
+
+func (f *InformerFactory) NodeInformer() *NodeObservatory {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.observatory != nil {
+		return f.observatory
+	}
+	f.observatory = NewController(f.informer, f.clientFactory, f.logger, 10)
+	return f.observatory
+}

--- a/pkg/controller/nodeobservatory/factory.go
+++ b/pkg/controller/nodeobservatory/factory.go
@@ -9,7 +9,7 @@ import (
 	kubernikus_informers_v1 "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
 )
 
-func NewInformerFactory(informer kubernikus_informers_v1.KlusterInformer, clients *kube.SharedClientFactory, logger log.Logger) *InformerFactory {
+func NewInformerFactory(informer kubernikus_informers_v1.KlusterInformer, clients kube.SharedClientFactory, logger log.Logger) *InformerFactory {
 	return &InformerFactory{
 		informer:      informer,
 		clientFactory: clients,
@@ -21,7 +21,7 @@ type InformerFactory struct {
 	lock          sync.Mutex
 	observatory   *NodeObservatory
 	informer      kubernikus_informers_v1.KlusterInformer
-	clientFactory *kube.SharedClientFactory
+	clientFactory kube.SharedClientFactory
 	logger        log.Logger
 }
 

--- a/pkg/controller/nodeobservatory/nodeInformer.go
+++ b/pkg/controller/nodeobservatory/nodeInformer.go
@@ -26,7 +26,7 @@ type NodeInformer struct {
 	stopCh  chan struct{}
 }
 
-func newNodeInformerForKluster(clientFactory *kubernetes.SharedClientFactory, kluster *v1.Kluster) (*NodeInformer, error) {
+func newNodeInformerForKluster(clientFactory kubernetes.SharedClientFactory, kluster *v1.Kluster) (*NodeInformer, error) {
 	client, err := clientFactory.ClientFor(kluster)
 	if err != nil {
 		return nil, err

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -1,0 +1,14 @@
+package util
+
+import "k8s.io/api/core/v1"
+
+//Taken from https://github.com/kubernetes/kubernetes/blob/886e04f1fffbb04faf8a9f9ee141143b2684ae68/pkg/api/v1/node/util.go
+// IsNodeReady returns true if a node is ready; false otherwise.
+func IsNodeReady(node *v1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -6,9 +6,6 @@ const (
 	Timeout       = 10 * time.Minute
 	CheckInterval = 10 * time.Second
 
-	// time after creating smoke test prerequisites (pods,svc) and before running smoke test
-	SmokeTestWaitTime = 300 * time.Second
-
 	TimeoutPod = 5 * time.Minute
 
 	ClusterName               = "e2e"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 
 	"k8s.io/api/core/v1"
 
@@ -114,10 +113,6 @@ func (s *E2ETestSuite) Run(wg *sync.WaitGroup, sigs chan os.Signal, stopCh chan 
 		s.TestShowCluster()
 		s.TestUpdateCluster()
 		s.TestGetClusterInfo()
-
-		// FIXME: wait before starting smoke test to mitigate risk of kluster that is not yet ready, though node health might indicate this
-		log.Printf("Waiting %v before running smoke test to ensure all nodes are healthy and ready for action", SmokeTestWaitTime)
-		time.Sleep(SmokeTestWaitTime)
 	}
 
 	// Smoke tests

--- a/vendor/github.com/stretchr/testify/require/doc.go
+++ b/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,28 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//    import (
+//      "testing"
+//      "github.com/stretchr/testify/require"
+//    )
+//
+//    func TestSomething(t *testing.T) {
+//
+//      var a string = "Hello"
+//      var b string = "Hello"
+//
+//      require.Equal(t, a, b, "The two words should be the same.")
+//
+//    }
+//
+// Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate go run ../_codegen/main.go -output-package=require -template=require_forward.go.tmpl -include-format-funcs

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,979 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if !assert.Condition(t, comp, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if !assert.Conditionf(t, comp, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Contains(t, "Hello World", "World")
+//    assert.Contains(t, ["Hello", "World"], "World")
+//    assert.Contains(t, {"Hello": "World"}, "Hello")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.Contains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//    assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//    assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if !assert.Containsf(t, s, contains, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if !assert.DirExists(t, path, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if !assert.DirExistsf(t, path, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2]))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if !assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if !assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Empty(t, obj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Empty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Emptyf(t, obj, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.Emptyf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Equal asserts that two objects are equal.
+//
+//    assert.Equal(t, 123, 123)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Equal(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualError(t, err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if !assert.EqualErrorf(t, theError, errString, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValues(t, uint32(123), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualValuesf asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValuesf(t, uint32(123, "error message %s", "formatted"), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.EqualValuesf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Equalf asserts that two objects are equal.
+//
+//    assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.Equalf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Error(t, err) {
+// 	   assert.Equal(t, expectedError, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.Error(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Errorf(t, err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedErrorf, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if !assert.Errorf(t, err, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//    assert.Exactly(t, int32(123), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.Exactlyf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if !assert.Fail(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if !assert.FailNow(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if !assert.FailNowf(t, failureMessage, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if !assert.Failf(t, failureMessage, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// False asserts that the specified value is false.
+//
+//    assert.False(t, myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.False(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Falsef asserts that the specified value is false.
+//
+//    assert.Falsef(t, myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if !assert.Falsef(t, value, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if !assert.FileExists(t, path, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if !assert.FileExistsf(t, path, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContainsf(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if !assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContainsf(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if !assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if !assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if !assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if !assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if !assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if !assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if !assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//    assert.Implementsf(t, (*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if !assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if !assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if !assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDeltaf(t, math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if !assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if !assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if !assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if !assert.IsTypef(t, expectedType, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if !assert.JSONEqf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    assert.Len(t, mySlice, 3)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if !assert.Lenf(t, object, length, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    assert.Nil(t, err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Nil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//    assert.Nilf(t, err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.Nilf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoError(t, err) {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoErrorf(t, err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if !assert.NoErrorf(t, err, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContains(t, "Hello World", "Earth")
+//    assert.NotContains(t, ["Hello", "World"], "Earth")
+//    assert.NotContains(t, {"Hello": "World"}, "Earth")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotContains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//    assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//    assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if !assert.NotContainsf(t, s, contains, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmpty(t, obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEmpty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.NotEmptyf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    assert.NotEqual(t, obj1, obj2)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//    assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.NotEqualf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    assert.NotNil(t, err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotNil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//    assert.NotNilf(t, err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.NotNilf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanics(t, func(){ RemainCalm() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.NotPanics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if !assert.NotPanicsf(t, f, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  assert.NotRegexp(t, "^start", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexpf(t, regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
+//  assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if !assert.NotRegexpf(t, rx, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotSubset asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.NotSubset(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotSubset(t, list, subset, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.NotSubsetf(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if !assert.NotSubsetf(t, list, subset, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotZero asserts that i is not the zero value for its type and returns the truth.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotZero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotZerof asserts that i is not the zero value for its type and returns the truth.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if !assert.NotZerof(t, i, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.Panics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if !assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if !assert.Panicsf(t, f, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  assert.Regexp(t, "start...$", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//  assert.Regexpf(t, regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
+//  assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if !assert.Regexpf(t, rx, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Subset asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.Subset(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if !assert.Subset(t, list, subset, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Subsetf asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.Subsetf(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if !assert.Subsetf(t, list, subset, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// True asserts that the specified value is true.
+//
+//    assert.True(t, myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.True(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Truef asserts that the specified value is true.
+//
+//    assert.Truef(t, myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if !assert.Truef(t, value, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if !assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Zero asserts that i is the zero value for its type and returns the truth.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if !assert.Zero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Zerof asserts that i is the zero value for its type and returns the truth.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if !assert.Zerof(t, i, msg, args...) {
+		t.FailNow()
+	}
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,799 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Contains("Hello World", "World")
+//    a.Contains(["Hello", "World"], "World")
+//    a.Contains({"Hello": "World"}, "Hello")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Containsf("Hello World", "World", "error message %s", "formatted")
+//    a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//    a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2]))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Empty(obj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Emptyf(obj, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    a.Equal(123, 123)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualError(err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValues(uint32(123), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValuesf(uint32(123, "error message %s", "formatted"), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//    a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Error(err) {
+// 	   assert.Equal(t, expectedError, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	Error(a.t, err, msgAndArgs...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Errorf(err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedErrorf, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	Errorf(a.t, err, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//    a.Exactly(int32(123), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//    a.Exactlyf(int32(123, "error message %s", "formatted"), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//    a.False(myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//    a.Falsef(myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContainsf(myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContainsf(myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//  a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//    a.Implementsf((*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDeltaf(math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//  a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    a.Len(mySlice, 3)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//    a.Lenf(mySlice, 3, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    a.Nil(err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//    a.Nilf(err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoError(err) {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoErrorf(err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContains("Hello World", "Earth")
+//    a.NotContains(["Hello", "World"], "Earth")
+//    a.NotContains({"Hello": "World"}, "Earth")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//    a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//    a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmpty(obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmptyf(obj, "error message %s", "formatted") {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    a.NotEqual(obj1, obj2)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//    a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    a.NotNil(err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//    a.NotNilf(err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanics(func(){ RemainCalm() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//  a.NotRegexp("^start", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexpf(regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
+//  a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSubset asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    a.NotSubset([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    a.NotSubsetf([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type and returns the truth.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type and returns the truth.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panics(func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  a.Regexp(regexp.MustCompile("start"), "it's starting")
+//  a.Regexp("start...$", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//  a.Regexpf(regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
+//  a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Subset asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    a.Subset([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    a.Subsetf([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//    a.True(myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//    a.Truef(myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type and returns the truth.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type and returns the truth.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	Zerof(a.t, i, msg, args...)
+}

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,9 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+//go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl -include-format-funcs


### PR DESCRIPTION
This change refactors the NodeObservatory to act more like an informer instead of a controller. It also adds a factory for it so that the NodeObservatory only started when it actually request by a controller.
Secondly launchctl now uses the NodeObservatory to update the `Healthy` and `Schedulable` status of node pools.