### PR TITLE
fix install for kluster names longer then 11 chars

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 1.9.0-kubernikus.1
+version: 1.9.0-kubernikus.2

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -15,11 +15,15 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      app: {{ include "master.fullname" . }}-controller-manager
+      app: controller-manager
+      kluster: {{ .Values.name }}
+      account: {{ .Values.account }}
   template:
     metadata:
       labels:
-        app: {{ include "master.fullname" . }}-controller-manager
+        app: controller-manager
+        kluster: {{ .Values.name }}
+        account: {{ .Values.account }}
         release: {{ .Release.Name }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -2,7 +2,7 @@
 apiVersion: "extensions/v1beta1"
 kind: Deployment
 metadata:
-  name: {{ include "master.fullname" . }}-c-manager
+  name: {{ include "master.fullname" . }}-cmanager
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name }}

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -31,6 +31,8 @@ serviceCIDR: 198.18.128.0/17
 advertiseAddress: 198.18.128.1
 #bootstrapToken
 #nodePassword:
+#name:
+#account:
 
 version:
 # kubernikus:

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -59,6 +59,8 @@ type kubernikusHelmValues struct {
 	Etcd             etcdValues        `yaml:"etcd,omitempty"`
 	Api              apiValues         `yaml:"api,omitempty"`
 	NodePassword     string            `yaml:"nodePassword,omitempty"`
+	Name             string            `yaml:"name"`
+	Account          string            `yaml:"account"`
 }
 
 func KlusterToHelmValues(kluster *v1.Kluster, openstack *OpenstackOptions, certificates map[string]string, bootstrapToken string, accessMode string) ([]byte, error) {
@@ -78,11 +80,13 @@ func KlusterToHelmValues(kluster *v1.Kluster, openstack *OpenstackOptions, certi
 	}
 
 	values := kubernikusHelmValues{
+		Account:          kluster.Account(),
 		BoostrapToken:    bootstrapToken,
 		Certs:            certificates,
 		ClusterCIDR:      kluster.Spec.ClusterCIDR,
 		ServiceCIDR:      kluster.Spec.ServiceCIDR,
 		AdvertiseAddress: kluster.Spec.AdvertiseAddress,
+		Name:             kluster.Spec.Name,
 		NodePassword:     password,
 		Version: versionValues{
 			Kubernetes: kluster.Spec.Version,


### PR DESCRIPTION
turns out labels also are limited to 64 characters, who knew…

This is a follow up for #193 