### PR TITLE
Blackbox

### DIFF
--- a/charts/kubernikus-system/charts/blackbox-exporter/templates/configmap.yaml
+++ b/charts/kubernikus-system/charts/blackbox-exporter/templates/configmap.yaml
@@ -11,40 +11,34 @@ data:
     modules:
       http_2xx:
         prober: http
-      http_post_2xx:
+        http:
+          fail_if_not_ssl: true
+          no_follow_redirects: false
+      http_400:
         prober: http
         http:
-          method: POST
-      icmp:
-        prober: icmp
-      irc_banner:
-        prober: tcp
-        tcp:
-          query_response:
-          - send: NICK prober
-          - send: USER prober prober prober :prober
-          - expect: PING :([^ ]+)
-            send: PONG ${1}
-          - expect: ^:[^ ]+ 001
-      pop3s_banner:
-        prober: tcp
-        tcp:
-          query_response:
-          - expect: ^+OK
-          tls: true
-      ssh_banner:
-        prober: tcp
-        tcp:
-          query_response:
-          - expect: ^SSH-2.0-
-      tcp_connect:
-        prober: tcp
-
-      http_4xx:
+          fail_if_not_ssl: true
+          valid_status_codes: [400]
+      http_401:
         prober: http
         http:
-          valid_status_codes: [401,403]
+          fail_if_not_ssl: true
+          valid_status_codes: [401]
+      http_403:
+        prober: http
+        http:
+          fail_if_not_ssl: true
+          valid_status_codes: [403]
       http_post_4xx:
         prober: http
         http:
+          fail_if_not_ssl: true
           method: POST
+      icmp:
+        prober: icmp
+      tcp_connect:
+        prober: tcp
+        timeout: 5s
+        tcp:
+          tls: true
+      

--- a/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
+++ b/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
@@ -269,7 +269,7 @@ scrape_configs:
     regex: true
   # consider prometheus.io/probe_code annotation.
   - source_labels: [__meta_kubernetes_ingress_annotation_prometheus_io_probe_code]
-    regex: \b\w{3,}
+    regex: (\b\w{3,})
     replacement: http_${1}
     target_label: __param_module
   - source_labels: [__meta_kubernetes_ingress_scheme,__address__,__meta_kubernetes_ingress_path]

--- a/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
+++ b/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
@@ -267,10 +267,10 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_ingress_annotation_prometheus_io_probe]
     action: keep
     regex: true
-  # consider prometheus.io/probe_code annotation. mind below regex.
+  # consider prometheus.io/probe_code annotation.
   - source_labels: [__meta_kubernetes_ingress_annotation_prometheus_io_probe_code]
-    regex: ^(\d).+
-    replacement: http_${1}xx
+    regex: \b\w{3,}
+    replacement: http_${1}
     target_label: __param_module
   - source_labels: [__meta_kubernetes_ingress_scheme,__address__,__meta_kubernetes_ingress_path]
     regex: (.+);(.+);(.+)

--- a/charts/kubernikus-system/templates/grafana-ingress.yaml
+++ b/charts/kubernikus-system/templates/grafana-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     vice-president: "true"
     prometheus.io/probe: "true"
+    prometheus.io/probe_code: "400"
     nginx.ingress.kubernetes.io/configuration-snippet: | 
       rewrite ^/$ /dashboard/db/kubernikus?refresh=1m&orgId=1&kiosk=true redirect;
     {{- if .Values.authentication.enabled}}

--- a/charts/kubernikus-system/templates/prometheus-ingress.yaml
+++ b/charts/kubernikus-system/templates/prometheus-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     vice-president: "true"
     prometheus.io/probe: "true"
+    prometheus.io/probe_code: "400"
     {{- if .Values.authentication.enabled}}
     nginx.ingress.kubernetes.io/auth-tls-secret: "kubernikus-system/ca-crt"
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"


### PR DESCRIPTION
- if the expected response code is not 2xx specify `probe_code` on ingress
- cross regional monitoring: Currently we only probe within the (k/c)ontrol plane. We could have another regions blackbox exporter check the availability of the endpoints. To avoid setting the regions manually I'd like to set them via the pipeline based on the kubernikus-values.yaml files in the secrets repo. Would be the same setup as for the bm clusters. Should I @BugRoger? 
