### PR TITLE
Fix wormhole client deadlock

### DIFF
--- a/pkg/cmd/wormhole/client.go
+++ b/pkg/cmd/wormhole/client.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/databus23/guttle"
 	"github.com/go-kit/kit/log"
@@ -138,7 +139,8 @@ func (o *ClientOptions) Run(c *cobra.Command) error {
 		ServerAddr: serverAddr,
 		ListenAddr: o.ListenAddr,
 		Dial: func(network, address string) (net.Conn, error) {
-			conn, err := tls.Dial(network, address, &tls.Config{
+			dialer := &net.Dialer{Timeout: 10 * time.Second}
+			conn, err := tls.DialWithDialer(dialer, network, address, &tls.Config{
 				RootCAs:      rootCAs,
 				Certificates: []tls.Certificate{certificate},
 			})


### PR DESCRIPTION
Inspecting the stack dump of a stuck wormhole client I found out that it was stuck in `tls.Dial` for 5 days already. So if the network is flaky the TLS Handshake might never return.

I think this is a similar issue https://github.com/golang/go/issues/17708.

This PR should fix it by imposing a fixed 10 second timeout for tls connection setup and ensure that the wormhole client keeps trying to reconnect.