### PR TITLE
Test get and setup kubernikusctl

### DIFF
--- a/ci/task_e2e_tests.yaml
+++ b/ci/task_e2e_tests.yaml
@@ -23,7 +23,7 @@ run:
       apk add --no-cache make git curl
       curl -fLo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl \
         && chmod +x /usr/bin/kubectl /usr/bin/kubectl \
-        && /usr/bin/kubectl version -c
+        && /usr/bin/kubectl version --client
 
       make test-e2e
 

--- a/test/e2e/auth.go
+++ b/test/e2e/auth.go
@@ -88,30 +88,34 @@ func getToken(c OpenStackCredentials) (string, error) {
 
 // Verify parameters used for OpenStack authentication
 func (c *OpenStackCredentials) Verify() error {
+	errorString := ""
 	if c.ProjectName == "" {
-		return fmt.Errorf("missing project name")
+		errorString += "missing OS_PROJECT_NAME\n"
 	}
 	if c.ProjectDomainName == "" {
-		return fmt.Errorf("missing project domain name")
+		errorString += "missing OS_PROJECT_DOMAIN_NAME\n"
 	}
 	if c.Username == "" {
-		return fmt.Errorf("missing username")
+		errorString += "missing OS_USERNAME\n"
 	}
 	if c.UserDomainName == "" {
-		return fmt.Errorf("missing user domain name")
+		errorString += "missing OS_USER_DOMAIN_NAME\n"
 	}
 	if c.Password == "" {
-		return fmt.Errorf("missing password")
+		errorString += "missing OS_PASSWORD\n"
 	}
 	if c.AuthURL == "" {
-		return fmt.Errorf("missing auth url")
+		errorString += "missing OS_AUTH_URL\n"
 	} else {
 		if !strings.HasSuffix(c.AuthURL, "/") {
 			c.AuthURL += "/"
 		}
 	}
 	if c.RegionName == "" {
-		return fmt.Errorf("missing region name")
+		errorString += "missing OS_REGION_NAME\n"
+	}
+	if errorString != "" {
+		return fmt.Errorf(errorString)
 	}
 	return nil
 }

--- a/test/e2e/cmdBuilder.go
+++ b/test/e2e/cmdBuilder.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type cmdBuilder struct {
+	cmd     *exec.Cmd
+	timeout <-chan time.Time
+}
+
+func (b cmdBuilder) Exec() (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := b.cmd
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	log.Printf("Running '%s %s'", cmd.Path, strings.Join(cmd.Args[1:], " ")) // skip arg[0] as it is printed separately
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("Error starting %v: \n Command stdout: \n %v \n stderr: \n %v \n error: \n %v \n", cmd, cmd.Stdout, cmd.Stderr, err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Wait()
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return "", fmt.Errorf("Error running %v:\nCommand stdout: \n %v \n stderr: \n %v \n error: \n %v \n", cmd, cmd.Stdout, cmd.Stderr, err)
+		}
+	case <-b.timeout:
+		b.cmd.Process.Kill()
+		return "", fmt.Errorf("Timed out waiting for command %v: \n Command stdout: \n %v \n stderr: \n %v \n", cmd, cmd.Stdout, cmd.Stderr)
+	}
+	if stderr.String() != "" {
+		log.Printf("stderr: %q", stderr.String())
+	}
+	return stdout.String(), nil
+}

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	yaml "gopkg.in/yaml.v2"
 	"os"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 type Config struct {
@@ -29,16 +30,16 @@ func ReadConfig(filePath string) (Config, error) {
 	return cfg, nil
 }
 
-func ReadFromEnv() (Config, error) {
+func ReadFromEnv() Config {
 	return Config{
 		APIURL:     os.Getenv("KUBERNIKUS_API_SERVER"),
 		APIVersion: os.Getenv("KUBERNIKUS_API_VERSION"),
-	}, nil
+	}
 }
 
 func (cfg *Config) Verify() error {
-	if cfg.APIURL == "" {
-		cfg.APIURL = "kubernikus.staging.cloud.sap"
+	if cfg.APIURL == "" && cfg.RegionName != "" {
+		cfg.APIURL = fmt.Sprintf("kubernikus.%s.cloud.sap", cfg.RegionName)
 	}
 	if cfg.APIVersion == "" {
 		cfg.APIVersion = "v1"

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -25,4 +25,7 @@ const (
 	PVCSize      = "1Gi"
 	PVCName      = "e2e-nginx-pvc"
 	PVCMountPath = "/mymount"
+
+	PathBin                 = "/usr/bin"
+	KubernikusctlBinaryName = "kubernikusctl"
 )

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -77,25 +77,30 @@ func (s *E2ETestSuite) Run(wg *sync.WaitGroup, sigs chan os.Signal, stopCh chan 
 	s.stopCh = stopCh
 	s.sigCh = sigs
 
-	log.Println("Running tests")
 	log.Printf(
 		`
-	#############################################
+	#################################################################
 
 	  Running Kubernikus e2e tests
 
-	  Creating kluster %s
-	  Region %s
-	  Domain %s
-	  Project %s
-	  Kubernikus API %s
+	  Creating kluster: %s
+	  Region: %s
+	  Project domain: %s
+	  Project: %s
+		Username: %s
+		User domain name: %s
+		Identity URL: %s
+	  Kubernikus API: %s
 
-	#############################################
+	#################################################################
 	`,
 		s.ClusterName,
 		s.RegionName,
 		s.ProjectDomainName,
 		s.ProjectName,
+		s.Username,
+		s.UserDomainName,
+		s.AuthURL,
 		s.APIURL,
 	)
 

--- a/test/e2e/e2e_config.yaml
+++ b/test/e2e/e2e_config.yaml
@@ -1,6 +1,8 @@
-kubernikus_api_server: "kubernikus.eu-nl-1.cloud.sap"
-kubernikus_api_version: "v1"
-kluster_kubeconfig: ""
+# example configuration for kubernikus e2e tests
+# parameters can also be provided via env
+
+kubernikus_api_server: ""
+kubernikus_api_version: ""
 
 openstack:
   project_name: ""

--- a/test/e2e/kubeCtlBuilder.go
+++ b/test/e2e/kubeCtlBuilder.go
@@ -1,19 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
 	"os/exec"
-	"strings"
-	"time"
 )
 
 type kubectlBuilder struct {
-	cmd     *exec.Cmd
-	timeout <-chan time.Time
+	cmdBuilder
 }
 
 func NewKubectlCommand(args ...string) *kubectlBuilder {
@@ -22,58 +15,15 @@ func NewKubectlCommand(args ...string) *kubectlBuilder {
 	return b
 }
 
-func RunHostCmd(config, namespace, name, cmd string) (string, error) {
-	return RunKubectl(config, "exec", fmt.Sprintf("--namespace=%v", namespace), name, "--", "/bin/sh", "-c", cmd)
+func RunKubectlHostCmd(namespace, name, cmd string) (string, error) {
+	return RunKubectl("exec", fmt.Sprintf("--namespace=%v", namespace), name, "--", "/bin/sh", "-c", cmd)
 }
 
-func RunKubectl(config string, args ...string) (string, error) {
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
-	if err != nil {
-		return "", fmt.Errorf("Couldn't create temporary kubeconfig: %v", err)
-	}
-	defer os.Remove(tmpfile.Name())
-
-	if _, err := tmpfile.Write([]byte(config)); err != nil {
-		return "", fmt.Errorf("Couldn't write temporary kubeconfig: %v", err)
-	}
-
-	if err := tmpfile.Close(); err != nil {
-		return "", fmt.Errorf("Couldn't close temporary kubeconfig: %v", err)
-	}
-
-	kubeConfigArg := fmt.Sprintf("--kubeconfig=%s", tmpfile.Name())
-	args = append([]string{kubeConfigArg}, args...)
-
+func RunKubectl(args ...string) (string, error) {
 	return NewKubectlCommand(args...).Exec()
 }
 
 func KubectlCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command("kubectl", args...)
 	return cmd
-}
-
-func (b kubectlBuilder) Exec() (string, error) {
-	var stdout, stderr bytes.Buffer
-	cmd := b.cmd
-	cmd.Stdout, cmd.Stderr = &stdout, &stderr
-
-	log.Printf("Running '%s %s'", cmd.Path, strings.Join(cmd.Args[1:], " ")) // skip arg[0] as it is printed separately
-	if err := cmd.Start(); err != nil {
-		return "", fmt.Errorf("Error starting %v: \n Command stdout: \n %v \n stderr: \n %v \n error: \n %v \n", cmd, cmd.Stdout, cmd.Stderr, err)
-	}
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- cmd.Wait()
-	}()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return "", fmt.Errorf("Error running %v:\nCommand stdout: \n %v \n stderr: \n %v \n error: \n %v \n", cmd, cmd.Stdout, cmd.Stderr, err)
-		}
-	case <-b.timeout:
-		b.cmd.Process.Kill()
-		return "", fmt.Errorf("Timed out waiting for command %v: \n Command stdout: \n %v \n stderr: \n %v \n", cmd, cmd.Stdout, cmd.Stderr)
-	}
-	log.Printf("stderr: %q", stderr.String())
-	return stdout.String(), nil
 }

--- a/test/e2e/kubernikusCtlBuilder.go
+++ b/test/e2e/kubernikusCtlBuilder.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os/exec"
+)
+
+type kubernikusctlBuilder struct {
+	cmdBuilder
+}
+
+func NewKubernikusctlCommand(args ...string) *kubernikusctlBuilder {
+	b := new(kubernikusctlBuilder)
+	b.cmd = KubernikusctlCmd(args...)
+	return b
+}
+
+func RunKubernikusctlHostCmd(args ...string) (string, error) {
+	return NewKubernikusctlCommand(args...).Exec()
+}
+
+func KubernikusctlCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command(KubernikusctlBinaryName, args...)
+	return cmd
+}

--- a/test/e2e/options.go
+++ b/test/e2e/options.go
@@ -1,9 +1,5 @@
 package main
 
-import (
-	"github.com/golang/glog"
-)
-
 type E2ETestSuiteOptions struct {
 	Config
 	ConfigFile string
@@ -20,17 +16,14 @@ type E2ETestSuiteOptions struct {
 }
 
 func (o *E2ETestSuiteOptions) OptionsFromConfigFile() error {
-	if o.ConfigFile == "" {
-		o.ConfigFile = "test/e2e/e2e_config.yaml"
-		glog.Infof("mandatory path to config not provided. trying default.")
+	if o.ConfigFile != "" {
+		cfg, err := ReadConfig(o.ConfigFile)
+		if err != nil {
+			return err
+		}
+		o.Config = cfg
 	}
 
-	cfg, err := ReadConfig(o.ConfigFile)
-	if err != nil {
-		return err
-	}
-
-	o.Config = cfg
 	o.checkTestPhases()
 
 	return nil

--- a/test/e2e/setupSmokeTest.go
+++ b/test/e2e/setupSmokeTest.go
@@ -63,8 +63,7 @@ func (s *E2ETestSuite) createPods() {
 				},
 			},
 			Spec: v1.PodSpec{
-				NodeName:    node.Name,
-				HostNetwork: true,
+				NodeName: node.Name,
 				Containers: []v1.Container{
 					{
 						Image: NginxImage,

--- a/test/e2e/smokeTests.go
+++ b/test/e2e/smokeTests.go
@@ -2,15 +2,22 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
+	"os/exec"
+	"runtime"
 
 	"k8s.io/api/core/v1"
+
+	"github.com/sapcc/kubernikus/pkg/api/client/operations"
 )
 
 func (s *E2ETestSuite) SetupSmokeTest() {
 	// double check if cluster is ready for smoke test or exit
 	s.isClusterUpOrWait()
+	s.TestSetupKubernikusCtl()
 	s.createClientset()
 	s.getReadyPods()
 	s.getReadyNodes()
@@ -29,7 +36,83 @@ func (s *E2ETestSuite) RunSmokeTest() {
 		s.TestAttachVolume()
 	}
 
-	log.Print("[passed smoke tests]")
+	log.Print("[passed] smoke tests")
+}
+
+func (s *E2ETestSuite) TestSetupKubernikusCtl() {
+	log.Printf("Setting up kubernikusctl")
+	// get kluster info which contains the URL to the kubernikusctl binary and download it
+	if err := s.getKubernikusctlBinary(); err != nil {
+		s.handleError(fmt.Errorf("[failure] could not get kubernikusctl. reason: %v", err))
+	}
+	// auth init to get kubeconfig for kluster
+	if err := s.initKubernikusctl(); err != nil {
+		s.handleError(fmt.Errorf("[failure] could not 'kubernikusctl auth init'. reason: %v", err))
+	}
+}
+
+func (s *E2ETestSuite) getKubernikusctlBinary() error {
+	log.Printf("getting info for kluster %s to obtain link to kubernikusctl", s.ClusterName)
+	info, err := s.kubernikusClient.Operations.GetClusterInfo(operations.NewGetClusterInfoParams().WithName(s.ClusterName), s.authFunc())
+	if err != nil {
+		return err
+	}
+	for _, b := range info.Payload.Binaries {
+		if b.Name == "kubernikusctl" {
+			for _, l := range b.Links {
+				if l.Platform == runtime.GOOS {
+					filePath := fmt.Sprintf("%s/%s", PathBin, KubernikusctlBinaryName)
+
+					p := PathBin + ":" + os.Getenv("PATH")
+					if err := os.Setenv("PATH", p); err != nil {
+						return err
+					}
+					log.Printf("updated PATH=%v", os.Getenv("PATH"))
+
+					log.Printf("Downloading %s", l.Link)
+					resp, err := http.Get(l.Link)
+					if err != nil {
+						return err
+					}
+					defer resp.Body.Close()
+
+					fOut, err := os.Create(filePath)
+					if err != nil {
+						return err
+					}
+					defer fOut.Close()
+
+					_, err = io.Copy(fOut, resp.Body)
+					if err != nil {
+						return err
+					}
+
+					if err := fOut.Chmod(0777); err != nil {
+						return err
+					}
+					// make sure the file is closed before using it
+					fOut.Close()
+
+					path, err := exec.LookPath(KubernikusctlBinaryName)
+					if err != nil {
+						return err
+					}
+					log.Printf("found %s", path)
+
+					_, err = RunKubernikusctlHostCmd("--help")
+					return err
+				}
+			}
+		}
+	}
+	return fmt.Errorf("no link for kubernikusctl binary found for os: %v", runtime.GOOS)
+}
+
+func (s *E2ETestSuite) initKubernikusctl() error {
+	// gets auth params from env
+	out, err := RunKubernikusctlHostCmd("auth", "init")
+	log.Println(out)
+	return err
 }
 
 func (s *E2ETestSuite) TestAttachVolume() {
@@ -148,12 +231,12 @@ func (s *E2ETestSuite) dialServiceName(source *v1.Pod, target *v1.Service) {
 
 func (s *E2ETestSuite) dial(sourcePod *v1.Pod, targetIP string, targetPort int32) (string, error) {
 	cmd := fmt.Sprintf("wget --timeout=%v -O - http://%v:%v", TimeoutWGET, targetIP, targetPort)
-	return RunHostCmd(s.KubeConfig, sourcePod.GetNamespace(), sourcePod.GetName(), cmd)
+	return RunKubectlHostCmd(sourcePod.GetNamespace(), sourcePod.GetName(), cmd)
 }
 
 func (s *E2ETestSuite) writeFileToMountedVolume() {
 	cmd := fmt.Sprintf("echo hase > %v/myfile", PVCMountPath)
-	_, err := RunHostCmd(s.KubeConfig, Namespace, PVCName, cmd)
+	_, err := RunKubectlHostCmd(Namespace, PVCName, cmd)
 	result := "success"
 	if err != nil {
 		result = "failure"
@@ -169,7 +252,7 @@ func (s *E2ETestSuite) writeFileToMountedVolume() {
 
 func (s *E2ETestSuite) readFileFromMountedVolume() {
 	cmd := fmt.Sprintf("cat %v/myfile", PVCMountPath)
-	_, err := RunHostCmd(s.KubeConfig, Namespace, PVCName, cmd)
+	_, err := RunKubectlHostCmd(Namespace, PVCName, cmd)
 	result := "success"
 	if err != nil {
 		result = "failure"


### PR DESCRIPTION
Basically this PR introduces another test for the kubernikusctl:
(1) get kluster info; contains link to kubernikusctl 
(2) download kubernikusctl and `kubernikusctl auth init`

This overwrites 7c5feeaf2cd6a9254859d8f6ca746ba5f47d7569