### PR TITLE
 Probe ingresses in kubernikus-system over region_probed_from

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,2 @@
+The directory names correspond to the namespaces of the entities created by the Helm charts with the exception of `kube-master`.
+`kube-master` contains the Helm charts used to create the Kubernetes master (API, controller manager, etcd, etc.) for our Kubernikus users.

--- a/charts/kube-master/templates/ingress.yaml
+++ b/charts/kube-master/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: k8sniff
     ingress.kubernetes.io/ssl-passthrough: "true"
+    prometheus.io/probe: "true"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name }}

--- a/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
+++ b/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
@@ -250,8 +250,8 @@ scrape_configs:
       regex: (.+)
       target_label: __metrics_path__
       replacement: /api/v1/nodes/${1}:4194/proxy/metrics
+{{- range .Values.region_probed_from }}
 
-{{- range .Values.prometheus.region_probed_from }}
 - job_name: 'blackbox-ingress-{{ . }}'
   scrape_interval: 5s
   metrics_path: /probe

--- a/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
+++ b/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
@@ -294,7 +294,7 @@ scrape_configs:
     target_label: kubernetes_name
   - source_labels: [__meta_kubernetes_ingress_path]
     target_label: path
-  - target_label: region_probed_from
+  - target_label: probed_from
     replacement: {{ . }}
 {{- end}}
 

--- a/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
+++ b/charts/kubernikus-system/charts/prometheus/templates/_prometheus.yaml.tpl
@@ -250,53 +250,6 @@ scrape_configs:
       regex: (.+)
       target_label: __metrics_path__
       replacement: /api/v1/nodes/${1}:4194/proxy/metrics
-{{- range .Values.region_probed_from }}
-
-- job_name: 'blackbox-ingress-{{ . }}'
-  scrape_interval: 5s
-  metrics_path: /probe
-  params:
-    # Look for a HTTP 200 response per default.
-    # Can be overwritten by annotating the ingress resource with the expected return codes, e.g. `prometheus.io/probe_code: "4xx"`
-    module: [http_2xx]
-  kubernetes_sd_configs:
-  - role: ingress
-  relabel_configs:
-  # don't scrape yourself
-  - source_labels: [__meta_kubernetes_ingress_path]
-    regex: /prometheus
-    action: drop
-  - source_labels: [__meta_kubernetes_ingress_annotation_prometheus_io_probe]
-    action: keep
-    regex: true
-  # consider prometheus.io/probe_code annotation.
-  - source_labels: [__meta_kubernetes_ingress_annotation_prometheus_io_probe_code]
-    regex: (\b\w{3,})
-    replacement: http_${1}
-    target_label: __param_module
-  - source_labels: [__meta_kubernetes_ingress_scheme,__address__,__meta_kubernetes_ingress_path]
-    regex: (.+);(.+);(.+)
-    replacement: ${1}://${2}${3}
-    target_label: __param_target
-  - target_label: __address__
-  {{- if eq . $.Values.global.region }}
-    replacement: blackbox-exporter.kubernikus-system.svc:9115
-  {{- else }}
-    replacement: prober.{{ . }}.cloud.sap
-  {{- end }}
-  - source_labels: [__param_target]
-    target_label: instance
-  - action: labelmap
-    regex: __meta_kubernetes_ingress_label_(.+)
-  - source_labels: [__meta_kubernetes_namespace]
-    target_label: kubernetes_namespace
-  - source_labels: [__meta_kubernetes_ingress_name]
-    target_label: kubernetes_name
-  - source_labels: [__meta_kubernetes_ingress_path]
-    target_label: path
-  - target_label: probed_from
-    replacement: {{ . }}
-{{- end}}
 
 # Static Targets 
 #

--- a/charts/kubernikus-system/values.yaml
+++ b/charts/kubernikus-system/values.yaml
@@ -11,9 +11,6 @@
 
 #global:
 #  region: eu-de-1
-#  region_probed_from:
-#  - eu-de-1
-#  - eu-nl-1
 
 nginx-ingress:
   enabled: true

--- a/charts/kubernikus-system/values.yaml
+++ b/charts/kubernikus-system/values.yaml
@@ -11,6 +11,9 @@
 
 #global:
 #  region: eu-de-1
+#  region_probed_from:
+#  - eu-de-1
+#  - eu-nl-1
 
 nginx-ingress:
   enabled: true


### PR DESCRIPTION
Solves Issue #213 

We probe all ingresses in kubernikus-system every five seconds with the
blackbox-exporter/prober from all the regions mentioned in the list
`region_probed_from`.
If the region the ingress is running in is part of the list it will
be treated specially and probe from inside the cluster using the
internal service instead of the ingress.

This was done to not be flooded in redundant probes while stile having
a probe from outside of the region whose number can be raised easily.
The rationale behind the handpicking of the regions listed in `region_probed_from`
is to be able to define a region that is nearby to probe from and to be flexible to add more.

This can also be used to probe other ingresses by adding the annotation `prometheus.io/probe: "true"`