### PR TITLE
Add sperate policy for ccadmin only operation

### DIFF
--- a/charts/kubernikus/templates/api.yaml
+++ b/charts/kubernikus/templates/api.yaml
@@ -30,7 +30,7 @@ spec:
             - --auth-url={{ trimSuffix "/" .Values.openstack.auth_url | trimSuffix "/v3" }}/v3
             - --v={{ default 1 .Values.api.log_level }}
             - --namespace={{ default "kubernikus" .Values.namespace }}
-            - --policy=/etc/kubernikus/policy.json
+            - --policy={{ default "/etc/kubernikus/policy.json" .Values.api.policyFile }}
           ports:
             - name: http
               containerPort: {{ .Values.api.port }}

--- a/charts/kubernikus/values.yaml
+++ b/charts/kubernikus/values.yaml
@@ -13,6 +13,7 @@ openstack:
 api:
   port: 1234
   log_level: 1
+  policyFile: /etc/kubernikus/policy.json
 
 groundctl:
   log_level: 1

--- a/etc/policy-ccadmin.json
+++ b/etc/policy-ccadmin.json
@@ -1,0 +1,14 @@
+{
+  "kubernetes_admin": "role:kubernetes_admin and domain_name:ccadmin",
+  "kubernetes_user": "(role:kubernetes_member or role:kubernetes_admin) and domain_name:ccadmin",
+
+  "GetOpenstackMetadata": "rule:kubernetes_admin",
+  "ListClusters": "rule:kubernetes_user",
+  "CreateCluster": "rule:kubernetes_admin",
+  "ShowCluster": "rule:kubernetes_user",
+  "TerminateCluster": "rule:kubernetes_admin",
+  "UpdateCluster": "rule:kubernetes_admin",
+  "GetClusterCredentials": "rule:kubernetes_user",
+  "GetClusterEvents": "rule:kubernetes_user",
+  "GetClusterInfo": "rule:kubernetes_user"
+}

--- a/pkg/api/auth/authorizer.go
+++ b/pkg/api/auth/authorizer.go
@@ -96,7 +96,7 @@ func (o *osloPolicyAuthorizer) Authorize(req *http.Request, principal interface{
 	}
 
 	allowed := o.enforcer.Enforce(operationID, policy.Context{
-		Auth:    map[string]string{"user_id": authUser.ID, "project_id": authUser.Account},
+		Auth:    map[string]string{"user_id": authUser.ID, "project_id": authUser.Account, "domain_name": authUser.Domain},
 		Roles:   authUser.Roles,
 		Request: requestVars,
 	})


### PR DESCRIPTION
This allows us to restrict the consumption of our control plane tier to our openstack admin domain.