### PR TITLE
Rename sysctl conf file to .conf

### DIFF
--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -238,7 +238,7 @@ storage:
           -A POSTROUTING -p udp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32678-65535
           -A POSTROUTING -p icmp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE
           COMMIT
-    - path: /etc/sysctl.d/10-enable-icmp-redirects
+    - path: /etc/sysctl.d/10-enable-icmp-redirects.conf
       filesystem: root
       mode: 0644
       contents:

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -238,7 +238,7 @@ storage:
           -A POSTROUTING -p udp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32678-65535
           -A POSTROUTING -p icmp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE
           COMMIT
-    - path: /etc/sysctl.d/10-enable-icmp-redirects
+    - path: /etc/sysctl.d/10-enable-icmp-redirects.conf
       filesystem: root
       mode: 0644
       contents:

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -238,7 +238,7 @@ storage:
           -A POSTROUTING -p udp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE --to-ports 32678-65535
           -A POSTROUTING -p icmp ! -d {{ .ClusterCIDR }} -m addrtype ! --dst-type LOCAL -j MASQUERADE
           COMMIT
-    - path: /etc/sysctl.d/10-enable-icmp-redirects
+    - path: /etc/sysctl.d/10-enable-icmp-redirects.conf
       filesystem: root
       mode: 0644
       contents:


### PR DESCRIPTION
icmp redirects currently not working due to the config being ignored.
config files have to end in .conf