### PR TITLE
Use the config-drive option to deliver ignition json to the node

### DIFF
--- a/pkg/client/openstack/client.go
+++ b/pkg/client/openstack/client.go
@@ -613,6 +613,7 @@ func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePoo
 
 	name = SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", kluster.Spec.Name, pool.Name))
 
+	configDrive := true
 	server, err := compute.Create(client, servers.CreateOpts{
 		Name:           name,
 		FlavorName:     pool.Flavor,
@@ -621,6 +622,7 @@ func (c *client) CreateNode(kluster *kubernikus_v1.Kluster, pool *models.NodePoo
 		UserData:       userData,
 		ServiceClient:  client,
 		SecurityGroups: []string{kluster.Spec.Openstack.SecurityGroupName},
+		ConfigDrive:    &configDrive,
 	}).Extract()
 
 	if err != nil {


### PR DESCRIPTION
We are currently dependent on aligning all the stars to get a node to boot-up.
While it works ( as it does now ) but we can alleviate the issues with DHCP and DVS by 
using the config-drive.

OpenStack puts everything it would serve via http into an iso image and attaches it to the vm.
Ignition then recognises the clouddrive and uses it to access it's configuration.

Pro: 
- everytime we have the node configured correctly including passwords
- we do not have to "adapt" the image to ensure a bigger ignition timeout 

Contra:
- we shadow some problems as we will still need to reach the network and dhcp as they are our dns servers as well.

