### PR TITLE
add kubernikus_node_pool_status metric

### DIFF
--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -97,6 +97,16 @@ func (cpm *ConcretePoolManager) SetStatus(status *PoolStatus) error {
 		Schedulable: int64(schedulable),
 	}
 
+	metrics.SetMetricNodePoolStatus(
+		cpm.Kluster.GetName(),
+		cpm.Pool.Name,
+		map[string]int64{
+			"running":     newInfo.Running,
+			"healthy":     newInfo.Healthy,
+			"schedulable": newInfo.Schedulable,
+		},
+	)
+
 	//TODO: Use util.UpdateKlusterWithRetries here
 	copy, err := cpm.Clients.Kubernikus.Kubernikus().Klusters(cpm.Kluster.Namespace).Get(cpm.Kluster.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -124,11 +124,11 @@ func setMetricNodePoolSize(klusterID, nodePoolName, imageName, flavorName string
 
 /*
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="<status>"} < number of nodes in that status >
-kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="ready"} 1
+kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="schedulable"} 1
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="running"} 1
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="healthy"} 1
 */
-func setMetricNodePoolStatus(klusterID, nodePoolName string, status map[string]int64) {
+func SetMetricNodePoolStatus(klusterID, nodePoolName string, status map[string]int64) {
 	if status != nil {
 		for s, v := range status {
 			nodePoolStatus.With(prometheus.Labels{

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -26,9 +26,9 @@ kubernikus_node_pool_size{flavor_name="flavorName",image_name="imageName",kluste
 		nodePoolStatus: `
 # HELP kubernikus_node_pool_status status of the node pool and the number of nodes nodes in that status
 # TYPE kubernikus_node_pool_status gauge
-kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="ready"} 2
+kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="schedulable"} 2
 kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="running"} 2
-kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="starting"} 1
+kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="healthy"} 1
 		`,
 		klusterInfo: `
 # HELP kubernikus_kluster_info detailed information on a kluster
@@ -47,7 +47,7 @@ kubernikus_kluster_status_phase{kluster_id="klusterID",phase="Terminating"} 0
 
 	// call functions that update the metrics here
 	setMetricNodePoolSize("klusterID", "nodePoolName", "imageName", "flavorName", 3)
-	setMetricNodePoolStatus("klusterID", "nodePoolName", map[string]int64{"running": 2, "starting": 1, "ready": 2})
+	SetMetricNodePoolStatus("klusterID", "nodePoolName", map[string]int64{"schedulable": 2, "healthy": 1, "running": 2})
 	SetMetricKlusterInfo("namespace", "klusterName", "version", "projectID", map[string]string{"creator": "D012345"}, map[string]string{"account": "account"})
 	SetMetricKlusterStatusPhase("klusterID", models.KlusterPhaseRunning)
 


### PR DESCRIPTION
Add `kubernikus_node_pool_status` metric per `klusterName` and `poolName`, to have all the information in the metric. Potentially produces more metrics than we need, so do we want to keep as-is or drop these labels and just have a total number per status `kubernikus_node_pool_status{status="<status>"} <count>`?