### PR TITLE
Add liveness probe to controller-manager deployment

### DIFF
--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -86,7 +86,7 @@ spec:
               host: 127.0.0.1
               path: /healthz
               port: 10252
-            initialDelaySeconds: 15
+            initialDelaySeconds: 120
             timeoutSeconds: 1
           volumeMounts:
             - mountPath: /etc/kubernetes/certs/

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -81,6 +81,13 @@ spec:
             - --service-account-private-key-file=/etc/kubernetes/certs/apiserver-clients-ca-key.pem
             - --service-cluster-ip-range={{ .Values.serviceCIDR }}
             - --use-service-account-credentials
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10252
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
           volumeMounts:
             - mountPath: /etc/kubernetes/certs/
               name: certs


### PR DESCRIPTION
We currently deploy the controller-manager without a liveness probe.

