### PR TITLE
The SAPNET root cert has changed and we use its fingerprint to ensure the update has run

### DIFF
--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -156,7 +156,7 @@ systemd:
       contents: |
         [Unit]
         Description=Update the certificates w/ self-signed root CAs
-        ConditionPathIsSymbolicLink=!/etc/ssl/certs/48b11003.0
+        ConditionPathIsSymbolicLink=!/etc/ssl/certs/381107d7.0
         Before=early-docker.service docker.service
         [Service]
         ExecStart=/usr/sbin/update-ca-certificates

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -156,7 +156,7 @@ systemd:
       contents: |
         [Unit]
         Description=Update the certificates w/ self-signed root CAs
-        ConditionPathIsSymbolicLink=!/etc/ssl/certs/48b11003.0
+        ConditionPathIsSymbolicLink=!/etc/ssl/certs/381107d7.0
         Before=early-docker.service docker.service
         [Service]
         ExecStart=/usr/sbin/update-ca-certificates

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -156,7 +156,7 @@ systemd:
       contents: |
         [Unit]
         Description=Update the certificates w/ self-signed root CAs
-        ConditionPathIsSymbolicLink=!/etc/ssl/certs/48b11003.0
+        ConditionPathIsSymbolicLink=!/etc/ssl/certs/381107d7.0
         Before=early-docker.service docker.service
         [Service]
         ExecStart=/usr/sbin/update-ca-certificates


### PR DESCRIPTION
This should fix #123 until we remove the cert as a whole as no SAP specific cert should be delivered.

