### PR TITLE
Custom handling for 403 errors from compute

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5a4f6ca3c667d683e8ecf32067a37bdd403f700ff5d6b23fdb58f5a541bae202
-updated: 2018-02-19T13:13:22.522337+01:00
+hash: 8671e5d55bd26920ce1e87d65a2ccb4a3cc5cedc86ed1ff6bc255f27daa933c3
+updated: 2018-03-06T09:25:58.44956+01:00
 imports:
 - name: github.com/ajeddeloh/yaml
   version: 1072abfea31191db507785e2e0c1b8d1440d35a5
@@ -147,7 +147,7 @@ imports:
   - compiler
   - extensions
 - name: github.com/gophercloud/gophercloud
-  version: 3b177406222d4b76d93e90d6ab412e7b7dc160f4
+  version: fe864ba585e153c296567b9ab4bbb1345d05900a
   subpackages:
   - internal
   - openstack

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
   - log
 # overwrite gophercloud version given in k8s deps
 - package: github.com/gophercloud/gophercloud
-  version: 3b177406222d4b76d93e90d6ab412e7b7dc160f4
+  version: fe864ba585e153c296567b9ab4bbb1345d05900a
 # Dependencies extracted from go-swagger 0.13.0
 - package: github.com/go-openapi/errors
   version: 03cfca65330da08a5a440053faf994a3c682b5bf

--- a/pkg/client/openstack/compute/create.go
+++ b/pkg/client/openstack/compute/create.go
@@ -20,7 +20,7 @@ func (ce *createError) Error400(e gophercloud.ErrUnexpectedResponseCode) error {
 		} `json:"badRequest"`
 	}
 	if err := json.Unmarshal(e.Body, &response); err != nil || response.BadRequest.Message == "" {
-		return fmt.Errorf("Failed to parse response: %s", string(e.Body))
+		return fmt.Errorf("Failed to parse response from compute: %s", string(e.Body))
 	}
 	return fmt.Errorf("Response from compute: %d %s", e.Actual, response.BadRequest.Message)
 }
@@ -28,6 +28,19 @@ func (ce *createError) Error400(e gophercloud.ErrUnexpectedResponseCode) error {
 func (ce createError) Error() string {
 	//Unused, but we need to satisfy the error interface
 	return "Failed to create server. This shouldn't be returned ever."
+}
+
+func (ce *createError) Error403(e gophercloud.ErrUnexpectedResponseCode) error {
+	var response struct {
+		Forbidden struct {
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		} `json:"forbidden"`
+	}
+	if err := json.Unmarshal(e.Body, &response); err != nil || response.Forbidden.Message == "" {
+		return fmt.Errorf("Failed to parse response from compute: %s", string(e.Body))
+	}
+	return fmt.Errorf("Response from compute: %d %s", e.Actual, response.Forbidden.Message)
 }
 
 // Create requests a server to be provisioned to the user in the current tenant.

--- a/vendor/github.com/gophercloud/gophercloud/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/errors.go
@@ -72,6 +72,11 @@ type ErrDefault401 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault403 is the default error type returned on a 403 HTTP response code.
+type ErrDefault403 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault404 is the default error type returned on a 404 HTTP response code.
 type ErrDefault404 struct {
 	ErrUnexpectedResponseCode
@@ -108,6 +113,13 @@ func (e ErrDefault400) Error() string {
 func (e ErrDefault401) Error() string {
 	return "Authentication failed"
 }
+func (e ErrDefault403) Error() string {
+	e.DefaultErrString = fmt.Sprintf(
+		"Request forbidden: [%s %s], error message: %s",
+		e.Method, e.URL, e.Body,
+	)
+	return e.choseErrString()
+}
 func (e ErrDefault404) Error() string {
 	return "Resource not found"
 }
@@ -139,6 +151,12 @@ type Err400er interface {
 // from a 401 error.
 type Err401er interface {
 	Error401(ErrUnexpectedResponseCode) error
+}
+
+// Err403er is the interface resource error types implement to override the error message
+// from a 403 error.
+type Err403er interface {
+	Error403(ErrUnexpectedResponseCode) error
 }
 
 // Err404er is the interface resource error types implement to override the error message

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/doc.go
@@ -58,7 +58,7 @@ Example to Create a Server With a Key Pair
 		FlavorRef: "flavor-uuid",
 	}
 
-	createOpts := keypairs.CreateOpts{
+	createOpts := keypairs.CreateOptsExt{
 		CreateOptsBuilder: serverCreateOpts,
 		KeyName:           "keypair-name",
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
@@ -236,21 +236,22 @@ func GetExtraSpec(client *gophercloud.ServiceClient, flavorID string, key string
 // CreateExtraSpecsOptsBuilder allows extensions to add additional parameters to the
 // CreateExtraSpecs requests.
 type CreateExtraSpecsOptsBuilder interface {
-	ToExtraSpecsCreateMap() (map[string]interface{}, error)
+	ToFlavorExtraSpecsCreateMap() (map[string]interface{}, error)
 }
 
 // ExtraSpecsOpts is a map that contains key-value pairs.
 type ExtraSpecsOpts map[string]string
 
-// ToExtraSpecsCreateMap assembles a body for a Create request based on the
-// contents of a ExtraSpecsOpts
-func (opts ExtraSpecsOpts) ToExtraSpecsCreateMap() (map[string]interface{}, error) {
+// ToFlavorExtraSpecsCreateMap assembles a body for a Create request based on
+// the contents of ExtraSpecsOpts.
+func (opts ExtraSpecsOpts) ToFlavorExtraSpecsCreateMap() (map[string]interface{}, error) {
 	return map[string]interface{}{"extra_specs": opts}, nil
 }
 
-// CreateExtraSpecs will create or update the extra-specs key-value pairs for the specified Flavor
+// CreateExtraSpecs will create or update the extra-specs key-value pairs for
+// the specified Flavor.
 func CreateExtraSpecs(client *gophercloud.ServiceClient, flavorID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
-	b, err := opts.ToExtraSpecsCreateMap()
+	b, err := opts.ToFlavorExtraSpecsCreateMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -261,15 +262,15 @@ func CreateExtraSpecs(client *gophercloud.ServiceClient, flavorID string, opts C
 	return
 }
 
-// UpdateExtraSpecOptsBuilder allows extensions to add additional parameters to the
-// Update request.
+// UpdateExtraSpecOptsBuilder allows extensions to add additional parameters to
+// the Update request.
 type UpdateExtraSpecOptsBuilder interface {
-	ToExtraSpecUpdateMap() (map[string]string, string, error)
+	ToFlavorExtraSpecUpdateMap() (map[string]string, string, error)
 }
 
-// ToExtraSpecUpdateMap assembles a body for an Update request based on the
-// contents of a ExtraSpecOpts.
-func (opts ExtraSpecsOpts) ToExtraSpecUpdateMap() (map[string]string, string, error) {
+// ToFlavorExtraSpecUpdateMap assembles a body for an Update request based on
+// the contents of a ExtraSpecOpts.
+func (opts ExtraSpecsOpts) ToFlavorExtraSpecUpdateMap() (map[string]string, string, error) {
 	if len(opts) != 1 {
 		err := gophercloud.ErrInvalidInput{}
 		err.Argument = "flavors.ExtraSpecOpts"
@@ -285,9 +286,10 @@ func (opts ExtraSpecsOpts) ToExtraSpecUpdateMap() (map[string]string, string, er
 	return opts, key, nil
 }
 
-// UpdateExtraSpec will updates the value of the specified flavor's extra spec for the key in opts.
+// UpdateExtraSpec will updates the value of the specified flavor's extra spec
+// for the key in opts.
 func UpdateExtraSpec(client *gophercloud.ServiceClient, flavorID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
-	b, key, err := opts.ToExtraSpecUpdateMap()
+	b, key, err := opts.ToFlavorExtraSpecUpdateMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/endpoint_location.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/endpoint_location.go
@@ -84,7 +84,7 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 					return "", err
 				}
 				if (opts.Availability == gophercloud.Availability(endpoint.Interface)) &&
-					(opts.Region == "" || endpoint.Region == opts.Region) {
+					(opts.Region == "" || endpoint.Region == opts.Region || endpoint.RegionID == opts.Region) {
 					endpoints = append(endpoints, endpoint)
 				}
 			}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/results.go
@@ -13,6 +13,7 @@ import (
 type Endpoint struct {
 	ID        string `json:"id"`
 	Region    string `json:"region"`
+	RegionID  string `json:"region_id"`
 	Interface string `json:"interface"`
 	URL       string `json:"url"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -17,6 +17,7 @@ type ListOpts struct {
 	Distributed  *bool  `q:"distributed"`
 	Status       string `q:"status"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Limit        int    `q:"limit"`
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
@@ -53,6 +54,7 @@ type CreateOpts struct {
 	AdminStateUp          *bool        `json:"admin_state_up,omitempty"`
 	Distributed           *bool        `json:"distributed,omitempty"`
 	TenantID              string       `json:"tenant_id,omitempty"`
+	ProjectID             string       `json:"project_id,omitempty"`
 	GatewayInfo           *GatewayInfo `json:"external_gateway_info,omitempty"`
 	AvailabilityZoneHints []string     `json:"availability_zone_hints,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -54,9 +54,12 @@ type Router struct {
 	// ID is the unique identifier for the router.
 	ID string `json:"id"`
 
-	// TenantID is the owner of the router. Only admin users can specify a tenant
-	// identifier other than its own.
+	// TenantID is the project owner of the router. Only admin users can
+	// specify a project identifier other than its own.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the router.
+	ProjectID string `json:"project_id"`
 
 	// Routes are a collection of static routes that the router will host.
 	Routes []Route `json:"routes"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
@@ -11,13 +11,14 @@ import (
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID       string `q:"id"`
-	Name     string `q:"name"`
-	TenantID string `q:"tenant_id"`
-	Limit    int    `q:"limit"`
-	Marker   string `q:"marker"`
-	SortKey  string `q:"sort_key"`
-	SortDir  string `q:"sort_dir"`
+	ID        string `q:"id"`
+	Name      string `q:"name"`
+	TenantID  string `q:"tenant_id"`
+	ProjectID string `q:"project_id"`
+	Limit     int    `q:"limit"`
+	Marker    string `q:"marker"`
+	SortKey   string `q:"sort_key"`
+	SortDir   string `q:"sort_dir"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -45,9 +46,13 @@ type CreateOpts struct {
 	// Human-readable name for the Security Group. Does not have to be unique.
 	Name string `json:"name" required:"true"`
 
-	// The UUID of the tenant who owns the Group. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// TenantID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// Describes the security group.
 	Description string `json:"description,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -22,8 +22,11 @@ type SecGroup struct {
 	// traffic entering and leaving the group.
 	Rules []rules.SecGroupRule `json:"security_group_rules"`
 
-	// Owner of the security group.
+	// TenantID is the project owner of the security group.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the security group.
+	ProjectID string `json:"project_id"`
 }
 
 // SecGroupPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	RemoteIPPrefix string `q:"remote_ip_prefix"`
 	SecGroupID     string `q:"security_group_id"`
 	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
 	Limit          int    `q:"limit"`
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`
@@ -118,9 +119,9 @@ type CreateOpts struct {
 	// specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
 
-	// The UUID of the tenant who owns the Rule. Only administrative users
-	// can specify a tenant UUID other than their own.
-	TenantID string `json:"tenant_id,omitempty"`
+	// TenantID is the UUID of the project who owns the Rule.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // ToSecGroupRuleCreateMap builds a request body from CreateOpts.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -48,8 +48,11 @@ type SecGroupRule struct {
 	// matches the specified IP prefix as the source IP address of the IP packet.
 	RemoteIPPrefix string `json:"remote_ip_prefix"`
 
-	// The owner of this security group rule.
+	// TenantID is the project owner of this security group rule.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of this security group rule.
+	ProjectID string `json:"project_id"`
 }
 
 // SecGroupRulePage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
@@ -21,6 +21,7 @@ type ListOpts struct {
 	Name         string `q:"name"`
 	AdminStateUp *bool  `q:"admin_state_up"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	Shared       *bool  `q:"shared"`
 	ID           string `q:"id"`
 	Marker       string `q:"marker"`
@@ -70,6 +71,7 @@ type CreateOpts struct {
 	Name                  string   `json:"name,omitempty"`
 	Shared                *bool    `json:"shared,omitempty"`
 	TenantID              string   `json:"tenant_id,omitempty"`
+	ProjectID             string   `json:"project_id,omitempty"`
 	AvailabilityZoneHints []string `json:"availability_zone_hints,omitempty"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
@@ -64,8 +64,11 @@ type Network struct {
 	// Subnets associated with this network.
 	Subnets []string `json:"subnets"`
 
-	// Owner of network.
+	// TenantID is the project owner of the network.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the network.
+	ProjectID string `json:"project_id"`
 
 	// Specifies whether the network resource can be accessed by any tenant.
 	Shared bool `json:"shared"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -22,6 +22,7 @@ type ListOpts struct {
 	AdminStateUp *bool  `q:"admin_state_up"`
 	NetworkID    string `q:"network_id"`
 	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
 	DeviceOwner  string `q:"device_owner"`
 	MACAddress   string `q:"mac_address"`
 	ID           string `q:"id"`
@@ -81,6 +82,7 @@ type CreateOpts struct {
 	DeviceID            string        `json:"device_id,omitempty"`
 	DeviceOwner         string        `json:"device_owner,omitempty"`
 	TenantID            string        `json:"tenant_id,omitempty"`
+	ProjectID           string        `json:"project_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
@@ -84,8 +84,11 @@ type Port struct {
 	// the subnets where the IP addresses are picked from
 	FixedIPs []IP `json:"fixed_ips"`
 
-	// Owner of network.
+	// TenantID is the project owner of the port.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the port.
+	ProjectID string `json:"project_id"`
 
 	// Identifies the entity (e.g.: dhcp agent) using this port.
 	DeviceOwner string `json:"device_owner"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
@@ -21,12 +21,14 @@ type ListOpts struct {
 	EnableDHCP      *bool  `q:"enable_dhcp"`
 	NetworkID       string `q:"network_id"`
 	TenantID        string `q:"tenant_id"`
+	ProjectID       string `q:"project_id"`
 	IPVersion       int    `q:"ip_version"`
 	GatewayIP       string `q:"gateway_ip"`
 	CIDR            string `q:"cidr"`
 	IPv6AddressMode string `q:"ipv6_address_mode"`
 	IPv6RAMode      string `q:"ipv6_ra_mode"`
 	ID              string `q:"id"`
+	SubnetPoolID    string `q:"subnetpool_id"`
 	Limit           int    `q:"limit"`
 	Marker          string `q:"marker"`
 	SortKey         string `q:"sort_key"`
@@ -83,9 +85,13 @@ type CreateOpts struct {
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`
 
-	// The UUID of the tenant who owns the Subnet. Only administrative users
-	// can specify a tenant UUID other than their own.
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
 	TenantID string `json:"tenant_id,omitempty"`
+
+	// The UUID of the project who owns the Subnet. Only administrative users
+	// can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
 
 	// AllocationPools are IP Address pools that will be available for DHCP.
 	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`
@@ -114,6 +120,9 @@ type CreateOpts struct {
 	// The IPv6 router advertisement specifies whether the networking service
 	// should transmit ICMPv6 packets.
 	IPv6RAMode string `json:"ipv6_ra_mode,omitempty"`
+
+	// SubnetPoolID is the id of the subnet pool that subnet should be associated to.
+	SubnetPoolID string `json:"subnetpool_id,omitempty"`
 }
 
 // ToSubnetCreateMap builds a request body from CreateOpts.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
@@ -91,8 +91,11 @@ type Subnet struct {
 	// Specifies whether DHCP is enabled for this subnet or not.
 	EnableDHCP bool `json:"enable_dhcp"`
 
-	// Owner of network.
+	// TenantID is the project owner of the subnet.
 	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the subnet.
+	ProjectID string `json:"project_id"`
 
 	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
 	IPv6AddressMode string `json:"ipv6_address_mode"`
@@ -100,6 +103,9 @@ type Subnet struct {
 	// The IPv6 router advertisement specifies whether the networking service
 	// should transmit ICMPv6 packets.
 	IPv6RAMode string `json:"ipv6_ra_mode"`
+
+	// SubnetPoolID is the id of the subnet pool associated with the subnet.
+	SubnetPoolID string `json:"subnetpool_id"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -298,6 +298,11 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			if error401er, ok := errType.(Err401er); ok {
 				err = error401er.Error401(respErr)
 			}
+		case http.StatusForbidden:
+			err = ErrDefault403{respErr}
+			if error403er, ok := errType.(Err403er); ok {
+				err = error403er.Error403(respErr)
+			}
 		case http.StatusNotFound:
 			err = ErrDefault404{respErr}
 			if error404er, ok := errType.(Err404er); ok {


### PR DESCRIPTION
Now that https://github.com/gophercloud/gophercloud/pull/714 is merged upstream we can handle those pesky quota errors more gracefully.