### PR TITLE
Remove host field from healthz check

### DIFF
--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -83,7 +83,6 @@ spec:
             - --use-service-account-credentials
           livenessProbe:
             httpGet:
-              host: 127.0.0.1
               path: /healthz
               port: 10252
             initialDelaySeconds: 120


### PR DESCRIPTION
The healthz check is not issued from within the netns of the pod so 127.0.0.1 seems only to work for host networked containers.