### PR TITLE
Disable kubelet readonly port

### DIFF
--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -83,6 +83,7 @@ systemd:
           --cluster-domain={{ .ClusterDomain }} \
           --client-ca-file=/etc/kubernetes/certs/kubelet-clients-ca.pem \
           --non-masquerade-cidr=0.0.0.0/0 \
+          --read-only-port=0 \
           --anonymous-auth=false
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -83,6 +83,7 @@ systemd:
           --cluster-domain={{ .ClusterDomain }} \
           --client-ca-file=/etc/kubernetes/certs/kubelet-clients-ca.pem \
           --non-masquerade-cidr=0.0.0.0/0 \
+          --read-only-port=0 \
           --anonymous-auth=false
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -83,6 +83,7 @@ systemd:
           --cluster-domain={{ .ClusterDomain }} \
           --client-ca-file=/etc/kubernetes/certs/kubelet-clients-ca.pem \
           --non-masquerade-cidr=0.0.0.0/0 \
+          --read-only-port=0 \
           --anonymous-auth=false
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always


### PR DESCRIPTION
The read-only port allows listing pods without authentication which might leak secrets.

Inspired by https://medium.com/handy-tech/analysis-of-a-kubernetes-hack-backdooring-through-kubelet-823be5c3d67c