### PR TITLE
Prevent CIDR overlap with control plane

### DIFF
--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -13,6 +14,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus"
+	"github.com/sapcc/kubernikus/pkg/util/ip"
 	k8sutil "github.com/sapcc/kubernikus/pkg/util/k8s"
 )
 
@@ -22,7 +24,8 @@ func NewCreateCluster(rt *api.Runtime) operations.CreateClusterHandler {
 
 type createCluster struct {
 	*api.Runtime
-	cpServiceIP net.IP
+	cpServiceCIDR *net.IPNet
+	cpClusterCIDR *net.IPNet
 }
 
 func (d *createCluster) Handle(params operations.CreateClusterParams, principal *models.Principal) middleware.Responder {
@@ -51,12 +54,15 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 		return NewErrorResponse(&operations.CreateClusterDefault{}, 400, err.Error())
 	}
 
-	//Ensure that the service CIDR range does not overlap with the control plane service CIDR
-	//Otherwise the wormhole server will prevent the kluster apiserver from reaching its etcd
-	if _, svcCIDR, err := net.ParseCIDR(kluster.Spec.ServiceCIDR); err == nil {
-		if svcIP := d.controlPlaneServiceIP(); svcIP != nil && svcCIDR.Contains(svcIP) {
-			return NewErrorResponse(&operations.CreateClusterDefault{}, 409, "Service CIDR %s not allowed", kluster.Spec.ServiceCIDR)
-		}
+	//Ensure that the service CIDR range does not overlap with any control plane CIDR
+	//Otherwise the wormhole server will prevent the kluster apiserver from functioning properly
+	if overlap, err := d.overlapWithControlPlane(kluster.Spec.ServiceCIDR); overlap {
+		return NewErrorResponse(&operations.CreateClusterDefault{}, 409, "Service CIDR %s not allowed: %s", kluster.Spec.ServiceCIDR, err)
+	}
+	//Ensure that the cluster CIDR range does not overlap with any control plane CIDR
+	//Otherwise the wormhole server will prevent the kluster apiserver from functioning properly
+	if overlap, err := d.overlapWithControlPlane(kluster.Spec.ClusterCIDR); overlap {
+		return NewErrorResponse(&operations.CreateClusterDefault{}, 409, "Cluster CIDR %s not allowed: %s", kluster.Spec.ClusterCIDR, err)
 	}
 
 	kluster.ObjectMeta = metav1.ObjectMeta{
@@ -83,15 +89,53 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 	return operations.NewCreateClusterCreated().WithPayload(klusterFromCRD(kluster))
 }
 
-//get (and cache) the kubernetes apiserver service ip of the control plane
-func (d *createCluster) controlPlaneServiceIP() net.IP {
-	if d.cpServiceIP != nil {
-		return d.cpServiceIP
+func (d *createCluster) overlapWithControlPlane(cidr string) (bool, error) {
+	_, inputCIDR, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, err
+	}
+	clusterCIDR := d.controlPlaneClusterCIDR()
+	if clusterCIDR != nil && ip.CIDROverlap(inputCIDR, clusterCIDR) {
+		return true, errors.New("overlap with control plane cluster CIDR")
+	}
+	svcCIDR := d.controlPlaneServiceCIDR()
+	if svcCIDR != nil && ip.CIDROverlap(inputCIDR, svcCIDR) {
+		return true, errors.New("overlap with control plane service CIDR")
+	}
+	return false, nil
+}
+
+//approximate the control plane service CIDR by getting one service IP and assuming a /17 prefix
+func (d *createCluster) controlPlaneServiceCIDR() *net.IPNet {
+	if d.cpServiceCIDR != nil {
+		return d.cpServiceCIDR
 	}
 	svc, err := d.Kubernetes.Core().Services("default").Get("kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil
 	}
-	d.cpServiceIP = net.ParseIP(svc.Spec.ClusterIP)
-	return d.cpServiceIP
+	_, ipnet, err := net.ParseCIDR(svc.Spec.ClusterIP + "/17")
+	if err != nil {
+		return nil
+	}
+	d.cpServiceCIDR = ipnet
+	return d.cpServiceCIDR
+}
+
+//we infer the clusterCIDR by taking a Pod IP and assuming /16
+func (d *createCluster) controlPlaneClusterCIDR() *net.IPNet {
+	if d.cpClusterCIDR != nil {
+		return d.cpClusterCIDR
+	}
+	podList, err := d.Kubernetes.Core().Pods(metav1.NamespaceAll).List(metav1.ListOptions{Limit: 1})
+	if err != nil || len(podList.Items) == 0 {
+		return nil
+	}
+	_, ipnet, err := net.ParseCIDR(podList.Items[0].Status.PodIP + "/16")
+
+	if err != nil {
+		return nil
+	}
+	d.cpClusterCIDR = ipnet
+	return d.cpClusterCIDR
 }

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -401,7 +401,7 @@ func init() {
         "clusterCIDR": {
           "description": "CIDR Range for Pods in the cluster. Can not be updated.",
           "type": "string",
-          "default": "198.19.0.0/16",
+          "default": "100.100.0.0/16",
           "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
           "x-nullable": false
         },

--- a/pkg/util/ip/cidr.go
+++ b/pkg/util/ip/cidr.go
@@ -1,0 +1,23 @@
+package ip
+
+import (
+	"net"
+)
+
+//adapted from  k8s.io/pkg/controller/route
+func CIDROverlap(cidr1, cidr2 *net.IPNet) bool {
+
+	lastIP1 := make([]byte, len(cidr1.IP))
+	for i := range lastIP1 {
+		lastIP1[i] = cidr1.IP[i] | ^cidr1.Mask[i]
+	}
+	lastIP2 := make([]byte, len(cidr2.IP))
+	for i := range lastIP2 {
+		lastIP2[i] = cidr2.IP[i] | ^cidr2.Mask[i]
+	}
+
+	if cidr2.Contains(cidr1.IP) || cidr2.Contains(lastIP1) || cidr1.Contains(cidr2.IP) || cidr1.Contains(lastIP2) {
+		return true
+	}
+	return false
+}

--- a/pkg/util/ip/cidr_test.go
+++ b/pkg/util/ip/cidr_test.go
@@ -1,0 +1,29 @@
+package ip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCIDROverlap(t *testing.T) {
+
+	testCases := []struct {
+		cidr1  string
+		cidr2  string
+		output bool
+	}{
+		{"10.0.0.0/8", "192.168.0.0/24", false},
+		{"10.0.0.0/8", "10.0.0.0/8", true},
+		{"10.0.0.0/8", "10.0.1.0/24", true},
+		{"10.0.1.0/24", "10.0.0.0/8", true},
+	}
+	for n, c := range testCases {
+		_, cidr1, _ := net.ParseCIDR(c.cidr1)
+		_, cidr2, _ := net.ParseCIDR(c.cidr2)
+		result := CIDROverlap(cidr1, cidr2)
+		assert.Equal(t, c.output, result, "case number %d failed", n+1)
+	}
+
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -345,7 +345,7 @@ definitions:
           ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
       clusterCIDR:
         description: CIDR Range for Pods in the cluster. Can not be updated.
-        default: 198.19.0.0/16
+        default: 100.100.0.0/16
         type: string
         x-nullable: false
         pattern: >-


### PR DESCRIPTION
Turns out we need to make sure both the service and cluster CIDR of clusters don't overlap with any of the control plane CIDRs. Otherwise there is a potential of conflict with the wormhole.
We already knew about the `serviceCIDR` range but we also need to ensure the same for the `clusterCIDR`.
This PR changes the default cluster CIDR to `100.100.0.0/16` so we fix new klusters on our existing control planes. Additionally the kubernikus apiserver activly refuses to create clusters with overlapping CIDR ranges.