### PR TITLE
KubernikusKlusterUnavailable checks if the kluster is running

### DIFF
--- a/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
+++ b/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
@@ -26,7 +26,7 @@ groups:
       summary: "{{ $labels.instance }} is unavailable"
   
   - alert: KubernikusKlusterUnavailable
-    expr: probe_success{kubernetes_namespace="kubernikus"} != 1
+    expr: (probe_success{kubernetes_namespace="kubernikus"} != 1) / on (kubernetes_name) label_replace(kubernikus_kluster_status_phase{phase="Running"} == 1, "kubernetes_name", "$1", "kluster_id", "(.*)")
     for: 10m
     labels:
       tier: kubernikus


### PR DESCRIPTION
That might do the trick. Should only alert when kluster api cannot be reached && kluster is running