### PR TITLE
Stop! Hammer time.

### DIFF
--- a/pkg/cmd/kubernikus/operator.go
+++ b/pkg/cmd/kubernikus/operator.go
@@ -48,7 +48,7 @@ func NewOperatorOptions() *Options {
 	options.KubernikusDomain = "kluster.staging.cloud.sap"
 	options.Namespace = "kubernikus"
 	options.MetricPort = 9091
-	options.Controllers = []string{"groundctl", "launchctl", "deorbiter", "routegc", "flight", "migration"}
+	options.Controllers = []string{"groundctl", "launchctl", "deorbiter", "routegc", "flight", "migration", "hammertime"}
 	return options
 }
 

--- a/pkg/controller/base/polling_controller.go
+++ b/pkg/controller/base/polling_controller.go
@@ -1,0 +1,101 @@
+package base
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	informers_v1 "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
+)
+
+type PollingReconciler interface {
+	Reconcile(kluster *v1.Kluster) error
+}
+
+type pollingController struct {
+	logger       log.Logger
+	watchers     sync.Map
+	syncPeriod   time.Duration
+	klusterIndex cache.Indexer
+	reconciler   PollingReconciler
+}
+
+func NewPollingController(syncPeriod time.Duration, informer informers_v1.KlusterInformer, reconciler PollingReconciler, logger log.Logger) Controller {
+	controller := &pollingController{
+		logger:       logger,
+		syncPeriod:   syncPeriod,
+		klusterIndex: informer.Informer().GetIndexer(),
+		reconciler:   reconciler,
+	}
+
+	informer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    controller.klusterAdd,
+			UpdateFunc: controller.klusterUpdated,
+			DeleteFunc: controller.klusterDelete,
+		})
+	return controller
+}
+
+func (pc *pollingController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	pc.logger.Log("msg", "Starting", "interval", pc.syncPeriod)
+	defer pc.logger.Log("msg", "Stopped")
+	<-stopCh
+	//Stop all reconciliation loops
+	pc.watchers.Range(func(key, value interface{}) bool {
+		close(value.(chan struct{}))
+		return true
+	})
+}
+
+func (pc *pollingController) klusterAdd(obj interface{}) {
+	if obj.(*v1.Kluster).Disabled() {
+		//stop the watcher for disabled klusters
+		pc.klusterDelete(obj)
+	}
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	closeCh := make(chan struct{})
+	if _, alreadyStored := pc.watchers.LoadOrStore(key, closeCh); alreadyStored {
+		return
+	}
+	go pc.watchKluster(key, closeCh)
+}
+func (p *pollingController) klusterUpdated(_, obj interface{}) {
+	p.klusterAdd(obj)
+}
+
+func (pc *pollingController) watchKluster(key string, stop <-chan struct{}) {
+	reconcile := func() {
+		obj, exists, err := pc.klusterIndex.GetByKey(key)
+		if !exists || err != nil {
+			return
+		}
+		kluster := obj.(*v1.Kluster)
+		logger := log.With(pc.logger, "kluster", kluster.Name)
+		begin := time.Now()
+		err = pc.reconciler.Reconcile(kluster)
+		logger.Log("msg", "Reconciling", "took", time.Since(begin), "v", 5, "err", err)
+	}
+	wait.JitterUntil(reconcile, pc.syncPeriod, 0.5, true, stop)
+}
+
+func (pc *pollingController) klusterDelete(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	if stopCh, found := pc.watchers.Load(key); found {
+		close(stopCh.(chan struct{}))
+		pc.watchers.Delete(key)
+	}
+}

--- a/pkg/controller/hammertime/hammertime.go
+++ b/pkg/controller/hammertime/hammertime.go
@@ -1,0 +1,114 @@
+package hammertime
+
+import (
+	"fmt"
+	"time"
+
+	kitlog "github.com/go-kit/kit/log"
+	core_v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/base"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
+)
+
+type hammertimeController struct {
+	nodeObervatory *nodeobservatory.NodeObservatory
+	client         kubernetes.Interface
+	timeout        time.Duration
+	logger         kitlog.Logger
+	recorder       record.EventRecorder
+}
+
+func New(syncPeriod time.Duration, timeout time.Duration, factories config.Factories, clients config.Clients, recorder record.EventRecorder, logger kitlog.Logger) base.Controller {
+
+	logger = kitlog.With(logger, "controller", "hammertime")
+
+	controller := hammertimeController{
+		nodeObervatory: factories.NodesObservatory.NodeInformer(),
+		client:         clients.Kubernetes,
+		timeout:        timeout,
+		logger:         logger,
+		recorder:       recorder,
+	}
+
+	return base.NewPollingController(syncPeriod, factories.Kubernikus.Kubernikus().V1().Klusters(), &controller, logger)
+}
+
+func (hc *hammertimeController) Reconcile(kluster *v1.Kluster) error {
+	logger := kitlog.With(hc.logger, "kluster", kluster.GetName())
+
+	lister, err := hc.nodeObervatory.GetListerForKluster(kluster)
+	if err != nil {
+		return fmt.Errorf("Failed to get node lister: %s", err)
+	}
+	nodes, err := lister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("listing nodes failed: %s", err)
+	}
+
+	if len(nodes) < 2 {
+		return nil
+	}
+	//var oldestHeartbeat time.Time = time.Now()
+	var newestHearbeat time.Time = time.Time{}
+	for _, node := range nodes {
+		ready := nodeReadyCondition(node)
+		if ready == nil {
+			continue
+		}
+		if ready.LastHeartbeatTime.After(newestHearbeat) {
+			newestHearbeat = ready.LastHeartbeatTime.Time
+		}
+	}
+
+	timeout_exeeded := time.Now().Sub(newestHearbeat) > hc.timeout
+
+	return hc.scaleDeployment(kluster, timeout_exeeded, logger)
+
+}
+
+func (hc *hammertimeController) scaleDeployment(kluster *v1.Kluster, disable bool, logger kitlog.Logger) error {
+
+	deploymentClient := hc.client.ExtensionsV1beta1().Deployments(kluster.Namespace)
+
+	deploymentName := fmt.Sprintf("%s-cmanager", kluster.GetName())
+	scale, err := deploymentClient.GetScale(deploymentName, meta_v1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		deploymentName = fmt.Sprintf("%s-controller-manager", kluster.GetName())
+		scale, err = deploymentClient.GetScale(deploymentName, meta_v1.GetOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to get deployment scale: %s", err)
+	}
+
+	if scale.Spec.Replicas > 0 {
+		if disable {
+			scale.Spec.Replicas = 0
+			_, err = deploymentClient.UpdateScale(deploymentName, scale)
+			logger.Log("msg", "Scaling down", "deployment", deploymentName, "err", err)
+		}
+	} else {
+		if !disable {
+			scale.Spec.Replicas = 1
+			_, err = deploymentClient.UpdateScale(deploymentName, scale)
+			logger.Log("msg", "Scaling up", "deployment", deploymentName, "err", err)
+		}
+	}
+	return err
+}
+
+func nodeReadyCondition(node *core_v1.Node) *core_v1.NodeCondition {
+	for _, c := range node.Status.Conditions {
+		if c.Type == core_v1.NodeReady {
+			return &c
+		}
+	}
+	return nil
+}

--- a/pkg/controller/hammertime/hammertime.go
+++ b/pkg/controller/hammertime/hammertime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/controller/base"
 	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/metrics"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
 )
 
@@ -69,6 +70,11 @@ func (hc *hammertimeController) Reconcile(kluster *v1.Kluster) error {
 	}
 
 	timeout_exeeded := time.Now().Sub(newestHearbeat) > hc.timeout
+	if timeout_exeeded {
+		metrics.HammertimeStatus.WithLabelValues(kluster.Name).Set(1)
+	} else {
+		metrics.HammertimeStatus.WithLabelValues(kluster.Name).Set(0)
+	}
 
 	return hc.scaleDeployment(kluster, timeout_exeeded, logger)
 

--- a/pkg/controller/metrics/hammertime.go
+++ b/pkg/controller/metrics/hammertime.go
@@ -1,0 +1,19 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func init() {
+	prometheus.MustRegister(
+		HammertimeStatus,
+	)
+}
+
+var HammertimeStatus = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "kubernikus",
+		Subsystem: "hammertime",
+		Name:      "status",
+		Help:      "Status of hammertime (controler manager scaled down)",
+	},
+	[]string{"kluster"},
+)

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"github.com/sapcc/kubernikus/pkg/controller/deorbit"
 	"github.com/sapcc/kubernikus/pkg/controller/flight"
+	"github.com/sapcc/kubernikus/pkg/controller/hammertime"
 	"github.com/sapcc/kubernikus/pkg/controller/launch"
 	"github.com/sapcc/kubernikus/pkg/controller/migration"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
@@ -180,6 +181,8 @@ func NewKubernikusOperator(options *KubernikusOperatorOptions, logger log.Logger
 			o.Config.Kubernikus.Controllers["flight"] = flight.NewController(10, o.Factories, o.Clients, recorder, logger)
 		case "migration":
 			o.Config.Kubernikus.Controllers["migration"] = migration.NewController(10, o.Factories, o.Clients, recorder, logger)
+		case "hammertime":
+			o.Config.Kubernikus.Controllers["hammertime"] = hammertime.New(10*time.Second, 20*time.Second, o.Factories, o.Clients, recorder, logger)
 		}
 	}
 

--- a/pkg/controller/routegc/controller.go
+++ b/pkg/controller/routegc/controller.go
@@ -3,7 +3,6 @@ package routegc
 import (
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -13,60 +12,40 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	os_client "github.com/sapcc/kubernikus/pkg/client/openstack"
+	"github.com/sapcc/kubernikus/pkg/controller/base"
 	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"github.com/sapcc/kubernikus/pkg/controller/metrics"
-	"github.com/sapcc/kubernikus/pkg/version"
 )
 
-type RouteGarbageCollector struct {
-	config.Factories
-	logger       log.Logger
-	watchers     sync.Map
-	syncPeriod   time.Duration
-	klusterIndex cache.Indexer
+type routeGarbageCollector struct {
+	logger          log.Logger
+	osClientFactory os_client.SharedOpenstackClientFactory
 }
 
-func New(syncPeriod time.Duration, factories config.Factories, logger log.Logger) *RouteGarbageCollector {
-	gc := &RouteGarbageCollector{
-		Factories:    factories,
-		logger:       log.With(logger, "controller", "routegc"),
-		syncPeriod:   syncPeriod,
-		klusterIndex: factories.Kubernikus.Kubernikus().V1().Klusters().Informer().GetIndexer(),
+func New(syncPeriod time.Duration, factories config.Factories, logger log.Logger) base.Controller {
+
+	logger = log.With(logger, "controller", "routegc")
+
+	routeGC := routeGarbageCollector{
+		logger:          logger,
+		osClientFactory: factories.Openstack,
 	}
 
-	factories.Kubernikus.Kubernikus().V1().Klusters().Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    gc.klusterAdd,
-			DeleteFunc: gc.klusterDelete,
-		})
-	return gc
-
+	return base.NewPollingController(syncPeriod, factories.Kubernikus.Kubernikus().V1().Klusters(), &routeGC, logger)
 }
 
-func (r *RouteGarbageCollector) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
-	wg.Add(1)
-	defer wg.Done()
-
-	r.logger.Log("msg", "Starting", "version", version.GitCommit, "interval", r.syncPeriod)
-	defer r.logger.Log("msg", "Stopped")
-	<-stopCh
-	//Stop all reconciliation loops
-	r.watchers.Range(func(key, value interface{}) bool {
-		close(value.(chan struct{}))
-		return true
-	})
-}
-
-func (r *RouteGarbageCollector) reconcile(kluster *v1.Kluster, logger log.Logger) error {
+func (w *routeGarbageCollector) Reconcile(kluster *v1.Kluster) (err error) {
 	routerID := kluster.Spec.Openstack.RouterID
 	defer func(begin time.Time) {
+		if err != nil {
+			metrics.OrphanedRoutesTotal.With(prometheus.Labels{}).Add(1)
+		}
 	}(time.Now())
 
-	providerClient, err := r.Openstack.ProviderClientForKluster(kluster, logger)
+	providerClient, err := w.osClientFactory.ProviderClientForKluster(kluster, w.logger)
 	if err != nil {
 		return err
 	}
@@ -116,7 +95,7 @@ func (r *RouteGarbageCollector) reconcile(kluster *v1.Kluster, logger log.Logger
 		return fmt.Errorf("Failed to list servers: %s", err)
 	}
 
-	logger = log.With(logger, "router", routerID)
+	logger := log.With(w.logger, "router", routerID)
 
 	newRoutes := make([]routers.Route, 0, len(router.Routes))
 	for _, route := range router.Routes {
@@ -142,48 +121,6 @@ func (r *RouteGarbageCollector) reconcile(kluster *v1.Kluster, logger log.Logger
 	}
 	return nil
 
-}
-
-func (r *RouteGarbageCollector) klusterAdd(obj interface{}) {
-	//TODO: Don't start routegc watchloop for 1.11+ klusters
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		return
-	}
-	closeCh := make(chan struct{})
-	if _, alreadyStored := r.watchers.LoadOrStore(key, closeCh); alreadyStored {
-		return
-	}
-	go r.watchKluster(key, closeCh)
-}
-
-func (r *RouteGarbageCollector) watchKluster(key string, stop <-chan struct{}) {
-	reconcile := func() {
-		obj, exists, err := r.klusterIndex.GetByKey(key)
-		if !exists || err != nil {
-			return
-		}
-		kluster := obj.(*v1.Kluster)
-		logger := log.With(r.logger, "kluster", kluster.Name)
-		begin := time.Now()
-		err = r.reconcile(kluster, logger)
-		logger.Log("msg", "Reconciling", "took", time.Since(begin), "v", 5, "err", err)
-		if err != nil {
-			metrics.RouteGCFailedOperationsTotal.With(prometheus.Labels{}).Add(1)
-		}
-	}
-	wait.JitterUntil(reconcile, r.syncPeriod, 0.5, true, stop)
-}
-
-func (r *RouteGarbageCollector) klusterDelete(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		return
-	}
-	if stopCh, found := r.watchers.Load(key); found {
-		close(stopCh.(chan struct{}))
-		r.watchers.Delete(key)
-	}
 }
 
 //adapted from  k8s.io/pkg/controller/route


### PR DESCRIPTION
This PR adds a `hammertime` controller.

Here is a short video explaining what it does:

[![Stop Hammertime](https://img.youtube.com/vi/H0_ICNMbdzw/0.jpg)](https://www.youtube.com/watch?v=H0_ICNMbdzw)

It uses the nodeobservatory to monitor the nodes of all klusters.
If for a kluster no node has posted an update within 20 seconds it instructs the cluster to have a little hammer time.
In hammer time the controller manager is shutdown to avoid having the service controller remove all nodes from loadbalancer.

We do this to keep the payload running and accessible should a network problem between apiserver and kubelets prevent nodes from posting their status. This is especially usefully for our cross region setups.