### PR TITLE
Use rkt’s —name flag for hyperkube images

### DIFF
--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -89,6 +89,7 @@ systemd:
           --insecure-options=image"
         Environment="KUBELET_IMAGE_TAG=v1.10.1"
         Environment="KUBELET_IMAGE_URL=docker://sapcc/hyperkube"
+        Environment="KUBELET_IMAGE_ARGS=--name=kubelet --exec=/kubelet"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -161,6 +162,7 @@ systemd:
           --stage1-from-dir=stage1-fly.aci \
           --insecure-options=image \
           docker://sapcc/hyperkube:v1.10.1 \
+          --name kube-proxy \
           --exec=/hyperkube \
           -- \
           proxy \

--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -53,6 +53,7 @@ systemd:
           --mount volume=etc-machine-id,target=/etc/machine-id
         Environment="KUBELET_IMAGE_TAG=v1.7.5_coreos.0"
         Environment="KUBELET_IMAGE_URL=quay.io/coreos/hyperkube"
+        Environment="KUBELET_IMAGE_ARGS=--name=kubelet --exec=/kubelet"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -129,6 +130,7 @@ systemd:
           --mount volume=lib-modules,target=/lib/modules \
           --stage1-from-dir=stage1-fly.aci \
           quay.io/coreos/hyperkube:v1.7.5_coreos.0 \
+          --name=kube-proxy \
           --exec=hyperkube \
           -- \
           proxy \

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -53,6 +53,7 @@ systemd:
           --mount volume=etc-machine-id,target=/etc/machine-id
         Environment="KUBELET_IMAGE_TAG=v1.8.5_coreos.0"
         Environment="KUBELET_IMAGE_URL=quay.io/coreos/hyperkube"
+        Environment="KUBELET_IMAGE_ARGS=--name=kubelet --exec=/kubelet"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -129,6 +130,7 @@ systemd:
           --mount volume=lib-modules,target=/lib/modules \
           --stage1-from-dir=stage1-fly.aci \
           quay.io/coreos/hyperkube:v1.8.5_coreos.0 \
+          --name=kube-proxy \
           --exec=hyperkube \
           -- \
           proxy \

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -53,6 +53,7 @@ systemd:
           --mount volume=etc-machine-id,target=/etc/machine-id
         Environment="KUBELET_IMAGE_TAG=v1.9.0_coreos.0"
         Environment="KUBELET_IMAGE_URL=quay.io/coreos/hyperkube"
+        Environment="KUBELET_IMAGE_ARGS=--name=kubelet --exec=/kubelet"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -129,6 +130,7 @@ systemd:
           --mount volume=lib-modules,target=/lib/modules \
           --stage1-from-dir=stage1-fly.aci \
           quay.io/coreos/hyperkube:v1.9.0_coreos.0 \
+          --name=kube-proxy \
           --exec=hyperkube \
           -- \
           proxy \


### PR DESCRIPTION
This PR turns this:
```
$> rkt list
UUID		APP		IMAGE NAME									STATE	CREATED		STARTED		NETWORKS
33aa0547	kubernikus	registry-1.docker.io/sapcc/kubernikus:d306dd418df1c394f06680f674865343bb73cd9f	running	7 hours ago	7 hours ago
38100424	flannel		quay.io/coreos/flannel:v0.10.0							running	7 hours ago	7 hours ago
72ffa539	hyperkube	registry-1.docker.io/sapcc/hyperkube:v1.10.1					running	7 hours ago	7 hours ago
9bbc96e3	hyperkube	registry-1.docker.io/sapcc/hyperkube:v1.10.1					running	7 hours ago	7 hours ago
```

into this
```
$> rkt list
UUID		APP		IMAGE NAME									STATE	CREATED		STARTED		NETWORKS
01932b8a	kubernikus	registry-1.docker.io/sapcc/kubernikus:d306dd418df1c394f06680f674865343bb73cd9f	running	3 hours ago	3 hours ago
d461e1d0	flannel		quay.io/coreos/flannel:v0.10.0							running	3 hours ago	3 hours ago
e22d0fb0	kube-proxy	registry-1.docker.io/sapcc/hyperkube:v1.10.1					running	6 minutes ago	6 minutes ago
fd37e3aa	kubelet		registry-1.docker.io/sapcc/hyperkube:v1.10.1					running	1 hour ago	1 hour ago
```