### PR TITLE
Lower-Case Node Name for Openstack

### DIFF
--- a/pkg/util/namegenerator.go
+++ b/pkg/util/namegenerator.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
@@ -32,5 +33,5 @@ func (simpleNameGenerator) GenerateName(base string) string {
 	if len(base) > maxGeneratedNameLength {
 		base = base[:maxGeneratedNameLength]
 	}
-	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
+	return strings.ToLower(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
 }


### PR DESCRIPTION
Apparently, the cloud-provider in v1.10 became case-sensitive when it comes to node names. It infers the node's name via the hostname provided through the metadata service. A hostname is always lowercase.  Not so much the node names in Nova.

It was possible to create node pools with uppercase letters, which in turn creates nodes like `kluster-Pool-xyz123` their hostname is then `kluster-pool-xyz123`. The Kubelet can't register that node anymore.