### PR TITLE
Clean-Up Errored Instances

### DIFF
--- a/pkg/client/openstack/kluster/node.go
+++ b/pkg/client/openstack/kluster/node.go
@@ -74,6 +74,14 @@ func (n *Node) Running() bool {
 	return false
 }
 
+func (n *Node) Erroring() bool {
+	if n.TaskState == "deleting" {
+		return false
+	}
+
+	return n.VMState == "error"
+}
+
 func (n *Node) GetID() string {
 	return n.ID
 }

--- a/pkg/controller/flight/controller.go
+++ b/pkg/controller/flight/controller.go
@@ -10,36 +10,53 @@ import (
 )
 
 // =================================================================================
-//   FlightControl
+// FlightControl
 // =================================================================================
 //
 // This controller takes care about Kluster health. It looks for obvious
 // problems and tries to repair them.
 //
-// Currently implemented are the following helpers. See docs/controllers.md for more
-// in depth explanation why these are required.
+// Currently implemented are the following helpers. See docs/controllers.md for
+// more in depth explanation why these are required.
 //
 //
 // Delete Incompletely Spawned Instances:
 //
-// It deletes Nodes that didn't manage to register within 10m after
-// initial creation. This is a workaround for DHCP/DVS (latency) issues.  In effect
-// it will delete the incompletely spawned node and launch control will ramp it
+// It deletes Nodes that didn't manage to register within 10m after initial
+// creation. This is a workaround for DHCP/DVS (latency) issues.  In effect it
+// will delete the incompletely spawned node and launch control will ramp it
 // back up.
+//
+//
+// Delete Errored Instances:
+//
+// It deletes Nodes that are in state "error". This can have various causes. It
+// frequently happens when instances are interrupted with another instance
+// action while being spawned. Most interesstingly a Node also goes into
+// "error" if the creation takes longer than the validity of the Keystone token
+// used to create the VM. Instance create is a sequence of actions that happen
+// sequentially in the same Nova request. If those take too long the next
+// action in line will fail with an authentication error. This sets the VM into
+// "error" state.
+// FlightControl will pick these up and delete them.  GroundControl on the
+// other hand ignores errored instances and just creates additional nodes. This
+// leads to quota exhaustion and left-over instances. This could be the ultimate
+// battle.
+//
 //
 // Ensure Pod-to-Pod Communication via Security Group Rules:
 //
 // It ensures tcp/udp/icmp rules exist in the security group defined during
-// kluster creation. The rules explicitly allow all pod-to-pod
-// communication. This is a workaround for Neutron missing the
-// side-channel security group events.
+// kluster creation. The rules explicitly allow all pod-to-pod communication.
+// This is a workaround for Neutron missing the side-channel security group
+// events.
 //
 //
 // Ensure Nodes belong to the security group:
 //
-// It ensures each Nodes is member of the security group defined in
-// the kluster spec. This ensures missing security groups due to whatever
-// reason are again added to the node.
+// It ensures each Nodes is member of the security group defined in the kluster
+// spec. This ensures missing security groups due to whatever reason are again
+// added to the node.
 
 type FlightController struct {
 	Factory FlightReconcilerFactory
@@ -66,6 +83,7 @@ func (d *FlightController) Reconcile(kluster *v1.Kluster) (bool, error) {
 	reconciler.EnsureKubernikusRuleInSecurityGroup()
 	reconciler.EnsureInstanceSecurityGroupAssignment()
 	reconciler.DeleteIncompletelySpawnedInstances()
+	reconciler.DeleteErroredInstances()
 
 	return false, nil
 }

--- a/pkg/controller/flight/controller_test.go
+++ b/pkg/controller/flight/controller_test.go
@@ -37,6 +37,11 @@ func (m *MockFlightReconciler) DeleteIncompletelySpawnedInstances() []string {
 	return args.Get(0).([]string)
 }
 
+func (m *MockFlightReconciler) DeleteErroredInstances() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}
+
 func TestReconcile(t *testing.T) {
 	kluster := &v1.Kluster{}
 
@@ -44,6 +49,7 @@ func TestReconcile(t *testing.T) {
 	reconciler.On("EnsureKubernikusRuleInSecurityGroup").Return(true)
 	reconciler.On("EnsureInstanceSecurityGroupAssignment").Return([]string{})
 	reconciler.On("DeleteIncompletelySpawnedInstances").Return([]string{})
+	reconciler.On("DeleteErroredInstances").Return([]string{})
 
 	factory := &MockFlightReconcilerFactory{}
 	factory.On("FlightReconciler", kluster).Return(reconciler, nil)
@@ -56,4 +62,5 @@ func TestReconcile(t *testing.T) {
 	reconciler.AssertCalled(t, "EnsureKubernikusRuleInSecurityGroup")
 	reconciler.AssertCalled(t, "EnsureInstanceSecurityGroupAssignment")
 	reconciler.AssertCalled(t, "DeleteIncompletelySpawnedInstances")
+	reconciler.AssertCalled(t, "DeleteErroredInstances")
 }

--- a/pkg/controller/flight/instance.go
+++ b/pkg/controller/flight/instance.go
@@ -7,4 +7,5 @@ type Instance interface {
 	GetName() string
 	GetSecurityGroupNames() []string
 	GetCreated() time.Time
+	Erroring() bool
 }

--- a/pkg/controller/flight/logging.go
+++ b/pkg/controller/flight/logging.go
@@ -35,6 +35,18 @@ func (f *LoggingFlightReconciler) DeleteIncompletelySpawnedInstances() []string 
 	return ids
 }
 
+func (f *LoggingFlightReconciler) DeleteErroredInstances() []string {
+	ids := f.Reconciler.DeleteErroredInstances()
+	if len(ids) > 0 {
+		f.Logger.Log(
+			"msg", "deleted errored instances",
+			"nodes", strings.Join(ids, ","),
+			"v", 2,
+		)
+	}
+	return ids
+}
+
 func (f *LoggingFlightReconciler) EnsureKubernikusRuleInSecurityGroup() bool {
 	ensured := f.Reconciler.EnsureKubernikusRuleInSecurityGroup()
 	if ensured {


### PR DESCRIPTION
This PR adds functionality to the flight controller that deletes
instances in Error state. Recreation works in tandem with launch control
which just ignores errored VMs.