### PR TITLE
Have the kublet self label the nodes during registration

### DIFF
--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -190,7 +190,7 @@ func (cpm *ConcretePoolManager) CreateNode() (id string, err error) {
 
 	nodeName := util.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", cpm.Kluster.Spec.Name, cpm.Pool.Name))
 
-	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, nodeName, secret, cpm.Logger)
+	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, cpm.Pool, nodeName, secret, cpm.Logger)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/templates/ignition_test.go
+++ b/pkg/templates/ignition_test.go
@@ -14,14 +14,17 @@ import (
 	kubernikusv1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 
+var (
+	testKlusterSecret v1.Secret
+	testKluster       kubernikusv1.Kluster
+)
+
 func init() {
 	//speed up tests by lowering hash rounds during testing
 	passwordHashRounds = sha512_crypt.RoundsMin
-}
 
-func TestGenerateNode(t *testing.T) {
-
-	kluster := kubernikusv1.Kluster{
+	//test data
+	testKluster = kubernikusv1.Kluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
@@ -42,24 +45,50 @@ func TestGenerateNode(t *testing.T) {
 			Apiserver: "https://apiserver.somewhere",
 		},
 	}
+
 	secretData := make(map[string][]byte, len(Ignition.requiredNodeSecrets)+1)
 	for _, f := range Ignition.requiredNodeSecrets {
 		secretData[f] = []byte(fmt.Sprintf("[DATA for %s]", f))
 	}
 	secretData["node-password"] = []byte("password")
 
-	secret := v1.Secret{
-		ObjectMeta: kluster.ObjectMeta,
+	testKlusterSecret = v1.Secret{
+		ObjectMeta: testKluster.ObjectMeta,
 		Data:       secretData,
 	}
 
+}
+
+func TestGenerateNode(t *testing.T) {
+
+	kluster := testKluster.DeepCopy()
+
 	for _, version := range []string{"1.7", "1.8", "1.9", "1.10"} {
 		kluster.Spec.Version = version
-		data, err := Ignition.GenerateNode(&kluster, "test", &secret, log.NewNopLogger())
+		data, err := Ignition.GenerateNode(kluster, nil, "test", &testKlusterSecret, log.NewNopLogger())
 		if assert.NoError(t, err, "Failed to generate node for version %s", version) {
 			//Ensure we rendered the expected template
 			assert.Contains(t, string(data), fmt.Sprintf("KUBELET_IMAGE_TAG=v%s", version))
 		}
-		//fmt.Printf("data = %+v\n", string(data))
+	}
+}
+
+func TestNodeLabels(t *testing.T) {
+	kluster := testKluster.DeepCopy()
+	kluster.Spec.Version = "1.10"
+
+	pool := &models.NodePool{Name: "some-name"}
+
+	data, err := Ignition.GenerateNode(kluster, pool, "test", &testKlusterSecret, log.NewNopLogger())
+	if assert.NoError(t, err, "Failed to generate node") {
+		//Ensure we rendered the expected template
+		assert.Contains(t, string(data), fmt.Sprintf("--node-labels=ccloud.sap.com/nodepool=%s", pool.Name))
+	}
+
+	gpuPool := &models.NodePool{Name: "some-name", Flavor: "zghuh"}
+	data, err = Ignition.GenerateNode(kluster, gpuPool, "test", &testKlusterSecret, log.NewNopLogger())
+	if assert.NoError(t, err, "Failed to generate node") {
+		//Ensure we rendered the expected template
+		assert.Contains(t, string(data), fmt.Sprintf("--node-labels=ccloud.sap.com/nodepool=%s,ccloud.sap.com/nvidia-gpu=nvidia-tesla-v100", pool.Name))
 	}
 }

--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -104,7 +104,10 @@ systemd:
           --network-plugin=kubenet \
           --non-masquerade-cidr=0.0.0.0/0 \
           --lock-file=/var/run/lock/kubelet.lock \
-          --exit-on-lock-contention 
+{{- if .NodeLabels }}
+          --node-labels={{ .NodeLabels | join "," }} \
+{{- end }}
+          --exit-on-lock-contention
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -42,6 +42,7 @@ func (k *NodeTests) Run(t *testing.T) {
 		t.Run("NetworkUnavailable", k.ConditionNetworkUnavailable) &&
 		t.Run("Healthy", k.StateHealthy) &&
 		t.Run("Ready", k.ConditionReady) &&
+		t.Run("Labeled", k.Labeled) &&
 		t.Run("Sufficient", k.Sufficient)
 }
 
@@ -79,6 +80,16 @@ func (k *NodeTests) ConditionReady(t *testing.T) {
 	count, err := k.checkCondition(t, v1.NodeReady, v1.ConditionTrue, ConditionReadyTimeout)
 	assert.NoError(t, err)
 	assert.Equal(t, k.ExpectedNodeCount, count)
+}
+
+func (k *NodeTests) Labeled(t *testing.T) {
+	nodeList, err := k.Kubernetes.ClientSet.CoreV1().Nodes().List(meta_v1.ListOptions{})
+	require.NoError(t, err, "There must be no error while listing the kluster's nodes")
+
+	for _, node := range nodeList.Items {
+		assert.Contains(t, node.Labels, "ccloud.sap.com/nodepool", "node %s is missing the ccloud.sap.com/nodepool label", node.Name)
+	}
+
 }
 
 func (k *NodeTests) Registered(t *testing.T) {


### PR DESCRIPTION
This always adds a node label `ccloud.sap.com/nodepool` and for nodes with flavour zg* it also adds `ccloud.sap.com/nvidia-gpu`.


Fixes #305

Note: This is using the kubelet flag `--node-labels` which is still alpha and potentially will change in the future: https://github.com/kubernetes/community/pull/911.

I still went with this approach as its considerable less effort for now and as I understand it from various GitHub comments, gke is using the same flag for their gpu nodes as of now.

I modified the integration test to ensure the nodepool label is present, so that we catch any changes to the node-labels flag with future kubernetes versions