### PR TITLE
Add per nodepool servergroup with soft-affinity

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-operator: bin/darwin/kubernikus operator --auth-username=$KS_USERNAME --auth-domain=$KS_USER_DOMAIN_NAME --auth-password="$KS_PASSWORD" --auth-project=$KS_PROJECT_NAME --auth-project-domain=$KS_PROJECT_DOMAIN_NAME --auth-url=$KS_AUTH_URL --namespace=$KS_NAMESPACE --context=$KS_CONTEXT --kubernikus-domain=$KS_DOMAIN --v=5
+operator: env NODEPOOL_AFFINITY=true bin/darwin/kubernikus operator --auth-username=$KS_USERNAME --auth-domain=$KS_USER_DOMAIN_NAME --auth-password="$KS_PASSWORD" --auth-project=$KS_PROJECT_NAME --auth-project-domain=$KS_PROJECT_DOMAIN_NAME --auth-url=$KS_AUTH_URL --namespace=$KS_NAMESPACE --context=$KS_CONTEXT --kubernikus-domain=$KS_DOMAIN --v=5
 api: bin/darwin/apiserver --context=$KS_CONTEXT --namespace=$KS_NAMESPACE --auth-url=$KS_AUTH_URL --v=5

--- a/charts/kubernikus/templates/operator.yaml
+++ b/charts/kubernikus/templates/operator.yaml
@@ -36,6 +36,9 @@ spec:
             - --namespace={{ default "kubernikus" .Values.namespace }}
             - --metric-port={{ default 9091 .Values.operator.metrics_port }}
             - --v={{ default 1 .Values.groundctl.log_level }}
+          env:
+            - name: NODEPOOL_AFFINITY
+              value: "true"
           ports:
             - name: metrics
               containerPort: {{ .Values.operator.metrics_port }}

--- a/pkg/client/openstack/factory.go
+++ b/pkg/client/openstack/factory.go
@@ -200,6 +200,7 @@ func (f *factory) serviceClientsFor(authOptions *tokens.AuthOptions, logger log.
 	}
 
 	compute, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{})
+	compute.Microversion = "2.25" // 2.25 is the maximum in mitaka. we need at least 2.15 to create `soft-affinity` server groups
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/client/openstack/kluster/client.go
+++ b/pkg/client/openstack/kluster/client.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	securitygroups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
@@ -24,6 +26,8 @@ type KlusterClient interface {
 	ListNodes(*models.NodePool) ([]Node, error)
 	SetSecurityGroup(nodeID string) error
 	EnsureKubernikusRuleInSecurityGroup() (bool, error)
+	EnsureServerGroup(name string) (string, error)
+	DeleteServerGroup(name string) error
 }
 
 type klusterClient struct {
@@ -83,15 +87,23 @@ func (c *klusterClient) CreateNode(pool *models.NodePool, name string, userData 
 		}
 	}
 
-	server, err := compute.Create(c.ComputeClient, servers.CreateOpts{
-		Name:           name,
-		FlavorName:     pool.Flavor,
-		ImageName:      pool.Image,
-		Networks:       networks,
-		UserData:       userData,
-		ServiceClient:  c.ComputeClient,
-		SecurityGroups: []string{c.Kluster.Spec.Openstack.SecurityGroupName},
-		ConfigDrive:    &configDrive,
+	serverGroupID, err := c.EnsureServerGroup(c.Kluster.Name + "/" + pool.Name)
+	if err != nil {
+		return "", err
+	}
+
+	server, err := compute.Create(c.ComputeClient, schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: servers.CreateOpts{
+			Name:           name,
+			FlavorName:     pool.Flavor,
+			ImageName:      pool.Image,
+			Networks:       networks,
+			UserData:       userData,
+			ServiceClient:  c.ComputeClient,
+			SecurityGroups: []string{c.Kluster.Spec.Openstack.SecurityGroupName},
+			ConfigDrive:    &configDrive,
+		},
+		SchedulerHints: schedulerhints.SchedulerHints{Group: serverGroupID},
 	}).Extract()
 
 	if err != nil {
@@ -226,6 +238,52 @@ func (c *klusterClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err
 	}
 
 	return !udp || !tcp || !icmp, nil
+}
+
+func (c *klusterClient) EnsureServerGroup(name string) (id string, err error) {
+	sg, err := c.serverGroupByName(name)
+	if err != nil {
+		return "", err
+	}
+	if sg != nil {
+		return sg.ID, nil
+	}
+	sg, err = servergroups.Create(c.ComputeClient, servergroups.CreateOpts{
+		Name:     name,
+		Policies: []string{"soft-affinity"},
+	}).Extract()
+	if err != nil {
+		return "", err
+	}
+	return sg.ID, nil
+}
+
+func (c *klusterClient) DeleteServerGroup(name string) error {
+	sg, err := c.serverGroupByName(name)
+	if err != nil {
+		return err
+	}
+	if sg != nil {
+		return servergroups.Delete(c.ComputeClient, sg.ID).ExtractErr()
+	}
+	return nil
+}
+
+func (c *klusterClient) serverGroupByName(name string) (*servergroups.ServerGroup, error) {
+	page, err := servergroups.List(c.ComputeClient).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	sgs, err := servergroups.ExtractServerGroups(page)
+	if err != nil {
+		return nil, err
+	}
+	for _, sg := range sgs {
+		if sg.Name == name {
+			return &sg, nil
+		}
+	}
+	return nil, nil
 }
 
 func ExtractServers(r pagination.Page) ([]Node, error) {

--- a/pkg/client/openstack/kluster/logging.go
+++ b/pkg/client/openstack/kluster/logging.go
@@ -83,3 +83,31 @@ func (c LoggingClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err 
 
 	return c.Client.EnsureKubernikusRuleInSecurityGroup()
 }
+
+func (c LoggingClient) DeleteServerGroup(name string) (err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "deleted servergroup",
+			"name", name,
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+	}(time.Now())
+
+	return c.Client.DeleteServerGroup(name)
+}
+
+func (c LoggingClient) EnsureServerGroup(name string) (id string, err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "ensure servergroup",
+			"name", name,
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+	}(time.Now())
+
+	return c.Client.EnsureServerGroup(name)
+}

--- a/pkg/controller/flight/reconciler_test.go
+++ b/pkg/controller/flight/reconciler_test.go
@@ -73,6 +73,16 @@ func (m *MockKlusterClient) EnsureKubernikusRuleInSecurityGroup() (created bool,
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockKlusterClient) EnsureServerGroup(name string) (id string, err error) {
+	args := m.Called(name)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockKlusterClient) DeleteServerGroup(name string) (err error) {
+	args := m.Called(name)
+	return args.Error(0)
+}
+
 func TestEnsureInstanceSecurityGroupAssignment(t *testing.T) {
 	kluster := &v1.Kluster{
 		Spec: models.KlusterSpec{

--- a/pkg/controller/launch/controller.go
+++ b/pkg/controller/launch/controller.go
@@ -128,6 +128,9 @@ func (lr *LaunchReconciler) terminatePool(kluster *v1.Kluster, pool *models.Node
 			return
 		}
 	}
+	if err = pm.DeletePool(); err != nil {
+		return
+	}
 
 	err = pm.SetStatus(status)
 	return

--- a/pkg/controller/launch/eventing.go
+++ b/pkg/controller/launch/eventing.go
@@ -45,3 +45,6 @@ func (epm *EventingPoolManager) DeleteNode(id string) (err error) {
 
 	return
 }
+func (epm *EventingPoolManager) DeletePool() error {
+	return epm.PoolManager.DeletePool()
+}

--- a/pkg/controller/launch/instrumenting.go
+++ b/pkg/controller/launch/instrumenting.go
@@ -124,3 +124,7 @@ func (pm *InstrumentingPoolManager) DeleteNode(id string) (err error) {
 
 	return pm.PoolManager.DeleteNode(id)
 }
+
+func (pm *InstrumentingPoolManager) DeletePool() (err error) {
+	return pm.DeletePool()
+}

--- a/pkg/controller/launch/instrumenting.go
+++ b/pkg/controller/launch/instrumenting.go
@@ -126,5 +126,5 @@ func (pm *InstrumentingPoolManager) DeleteNode(id string) (err error) {
 }
 
 func (pm *InstrumentingPoolManager) DeletePool() (err error) {
-	return pm.DeletePool()
+	return pm.PoolManager.DeletePool()
 }

--- a/pkg/controller/launch/logging.go
+++ b/pkg/controller/launch/logging.go
@@ -68,3 +68,14 @@ func (npm *LoggingPoolManager) DeleteNode(id string) (err error) {
 	}(time.Now())
 	return npm.PoolManager.DeleteNode(id)
 }
+
+func (npm *LoggingPoolManager) DeletePool() (err error) {
+	defer func(begin time.Time) {
+		npm.Logger.Log(
+			"msg", "deleted pool",
+			"took", time.Since(begin),
+			"err", err,
+		)
+	}(time.Now())
+	return npm.PoolManager.DeletePool()
+}

--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -24,6 +24,7 @@ type PoolManager interface {
 	SetStatus(*PoolStatus) error
 	CreateNode() (string, error)
 	DeleteNode(string) error
+	DeletePool() error
 }
 
 type PoolStatus struct {
@@ -208,6 +209,10 @@ func (cpm *ConcretePoolManager) DeleteNode(id string) (err error) {
 		return err
 	}
 	return nil
+}
+
+func (cpm *ConcretePoolManager) DeletePool() error {
+	return cpm.klusterClient.DeleteServerGroup(cpm.Kluster.Name + "/" + cpm.Pool.Name)
 }
 
 func (cpm *ConcretePoolManager) nodeIDs(nodes []openstack_kluster.Node) []string {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/doc.go
@@ -1,0 +1,76 @@
+/*
+Package schedulerhints extends the server create request with the ability to
+specify additional parameters which determine where the server will be
+created in the OpenStack cloud.
+
+Example to Add a Server to a Server Group
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		Group: "servergroup-uuid",
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Place Server B on a Different Host than Server A
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		DifferentHost: []string{
+			"server-a-uuid",
+		}
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Place Server B on the Same Host as Server A
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		SameHost: []string{
+			"server-a-uuid",
+		}
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package schedulerhints

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -1,0 +1,164 @@
+package schedulerhints
+
+import (
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+// SchedulerHints represents a set of scheduling hints that are passed to the
+// OpenStack scheduler.
+type SchedulerHints struct {
+	// Group specifies a Server Group to place the instance in.
+	Group string
+
+	// DifferentHost will place the instance on a compute node that does not
+	// host the given instances.
+	DifferentHost []string
+
+	// SameHost will place the instance on a compute node that hosts the given
+	// instances.
+	SameHost []string
+
+	// Query is a conditional statement that results in compute nodes able to
+	// host the instance.
+	Query []interface{}
+
+	// TargetCell specifies a cell name where the instance will be placed.
+	TargetCell string `json:"target_cell,omitempty"`
+
+	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
+	BuildNearHostIP string
+
+	// AdditionalProperies are arbitrary key/values that are not validated by nova.
+	AdditionalProperties map[string]interface{}
+}
+
+// CreateOptsBuilder builds the scheduler hints into a serializable format.
+type CreateOptsBuilder interface {
+	ToServerSchedulerHintsCreateMap() (map[string]interface{}, error)
+}
+
+// ToServerSchedulerHintsMap builds the scheduler hints into a serializable format.
+func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interface{}, error) {
+	sh := make(map[string]interface{})
+
+	uuidRegex, _ := regexp.Compile("^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$")
+
+	if opts.Group != "" {
+		if !uuidRegex.MatchString(opts.Group) {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Group"
+			err.Value = opts.Group
+			err.Info = "Group must be a UUID"
+			return nil, err
+		}
+		sh["group"] = opts.Group
+	}
+
+	if len(opts.DifferentHost) > 0 {
+		for _, diffHost := range opts.DifferentHost {
+			if !uuidRegex.MatchString(diffHost) {
+				err := gophercloud.ErrInvalidInput{}
+				err.Argument = "schedulerhints.SchedulerHints.DifferentHost"
+				err.Value = opts.DifferentHost
+				err.Info = "The hosts must be in UUID format."
+				return nil, err
+			}
+		}
+		sh["different_host"] = opts.DifferentHost
+	}
+
+	if len(opts.SameHost) > 0 {
+		for _, sameHost := range opts.SameHost {
+			if !uuidRegex.MatchString(sameHost) {
+				err := gophercloud.ErrInvalidInput{}
+				err.Argument = "schedulerhints.SchedulerHints.SameHost"
+				err.Value = opts.SameHost
+				err.Info = "The hosts must be in UUID format."
+				return nil, err
+			}
+		}
+		sh["same_host"] = opts.SameHost
+	}
+
+	/*
+		Query can be something simple like:
+			 [">=", "$free_ram_mb", 1024]
+
+			Or more complex like:
+				['and',
+					['>=', '$free_ram_mb', 1024],
+					['>=', '$free_disk_mb', 200 * 1024]
+				]
+
+		Because of the possible complexity, just make sure the length is a minimum of 3.
+	*/
+	if len(opts.Query) > 0 {
+		if len(opts.Query) < 3 {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Query"
+			err.Value = opts.Query
+			err.Info = "Must be a conditional statement in the format of [op,variable,value]"
+			return nil, err
+		}
+		sh["query"] = opts.Query
+	}
+
+	if opts.TargetCell != "" {
+		sh["target_cell"] = opts.TargetCell
+	}
+
+	if opts.BuildNearHostIP != "" {
+		if _, _, err := net.ParseCIDR(opts.BuildNearHostIP); err != nil {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.BuildNearHostIP"
+			err.Value = opts.BuildNearHostIP
+			err.Info = "Must be a valid subnet in the form 192.168.1.1/24"
+			return nil, err
+		}
+		ipParts := strings.Split(opts.BuildNearHostIP, "/")
+		sh["build_near_host_ip"] = ipParts[0]
+		sh["cidr"] = "/" + ipParts[1]
+	}
+
+	if opts.AdditionalProperties != nil {
+		for k, v := range opts.AdditionalProperties {
+			sh[k] = v
+		}
+	}
+
+	return sh, nil
+}
+
+// CreateOptsExt adds a SchedulerHints option to the base CreateOpts.
+type CreateOptsExt struct {
+	servers.CreateOptsBuilder
+
+	// SchedulerHints provides a set of hints to the scheduler.
+	SchedulerHints CreateOptsBuilder
+}
+
+// ToServerCreateMap adds the SchedulerHints option to the base server creation options.
+func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	schedulerHints, err := opts.SchedulerHints.ToServerSchedulerHintsCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(schedulerHints) == 0 {
+		return base, nil
+	}
+
+	base["os:scheduler_hints"] = schedulerHints
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/doc.go
@@ -1,0 +1,40 @@
+/*
+Package servergroups provides the ability to manage server groups.
+
+Example to List Server Groups
+
+	allpages, err := servergroups.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allServerGroups, err := servergroups.ExtractServerGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, sg := range allServerGroups {
+		fmt.Printf("%#v\n", sg)
+	}
+
+Example to Create a Server Group
+
+	createOpts := servergroups.CreateOpts{
+		Name:     "my_sg",
+		Policies: []string{"anti-affinity"},
+	}
+
+	sg, err := servergroups.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Server Group
+
+	sgID := "7a6f29ad-e34d-4368-951a-58a08f11cfb7"
+	err := servergroups.Delete(computeClient, sgID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package servergroups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/requests.go
@@ -1,0 +1,59 @@
+package servergroups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List returns a Pager that allows you to iterate over a collection of
+// ServerGroups.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return ServerGroupPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToServerGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies Server Group creation parameters.
+type CreateOpts struct {
+	// Name is the name of the server group
+	Name string `json:"name" required:"true"`
+
+	// Policies are the server group policies
+	Policies []string `json:"policies" required:"true"`
+}
+
+// ToServerGroupCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToServerGroupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "server_group")
+}
+
+// Create requests the creation of a new Server Group.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToServerGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get returns data about a previously created ServerGroup.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// Delete requests the deletion of a previously allocated ServerGroup.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
@@ -1,0 +1,87 @@
+package servergroups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// A ServerGroup creates a policy for instance placement in the cloud.
+type ServerGroup struct {
+	// ID is the unique ID of the Server Group.
+	ID string `json:"id"`
+
+	// Name is the common name of the server group.
+	Name string `json:"name"`
+
+	// Polices are the group policies.
+	//
+	// Normally a single policy is applied:
+	//
+	// "affinity" will place all servers within the server group on the
+	// same compute node.
+	//
+	// "anti-affinity" will place servers within the server group on different
+	// compute nodes.
+	Policies []string `json:"policies"`
+
+	// Members are the members of the server group.
+	Members []string `json:"members"`
+
+	// Metadata includes a list of all user-specified key-value pairs attached
+	// to the Server Group.
+	Metadata map[string]interface{}
+}
+
+// ServerGroupPage stores a single page of all ServerGroups results from a
+// List call.
+type ServerGroupPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a ServerGroupsPage is empty.
+func (page ServerGroupPage) IsEmpty() (bool, error) {
+	va, err := ExtractServerGroups(page)
+	return len(va) == 0, err
+}
+
+// ExtractServerGroups interprets a page of results as a slice of
+// ServerGroups.
+func ExtractServerGroups(r pagination.Page) ([]ServerGroup, error) {
+	var s struct {
+		ServerGroups []ServerGroup `json:"server_groups"`
+	}
+	err := (r.(ServerGroupPage)).ExtractInto(&s)
+	return s.ServerGroups, err
+}
+
+type ServerGroupResult struct {
+	gophercloud.Result
+}
+
+// Extract is a method that attempts to interpret any Server Group resource
+// response as a ServerGroup struct.
+func (r ServerGroupResult) Extract() (*ServerGroup, error) {
+	var s struct {
+		ServerGroup *ServerGroup `json:"server_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ServerGroup, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a ServerGroup.
+type CreateResult struct {
+	ServerGroupResult
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a ServerGroup.
+type GetResult struct {
+	ServerGroupResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/urls.go
@@ -1,0 +1,25 @@
+package servergroups
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "os-server-groups"
+
+func resourceURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return resourceURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return resourceURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return getURL(c, id)
+}


### PR DESCRIPTION
This PR creates an openstack server group for every node pool (named $KLUSTER/$NODEPOOL) with policy `soft-affinity`. This ensures that all instances of a node pool are placed within a single VMware building block.

For single node pool clusters this should fix our volume re-attachment problems. For multiple nodepools users need to be aware that volume attachments are guaranteed only to by fast within a node pool and they should use `nodeSelectors` accordingly.

One open quibble I have with this is that its pretty custom to our openstack deployment (using VMware) and probably should be behind a feature flag. In the kvm case this will place all instances of a node pool on a single hypervisor which is most certainly not wanted.

Fixes #309 
