### PR TITLE
GPU node labels change

### DIFF
--- a/contrib/nvidia-gpu/device-plugin-damonset.yaml
+++ b/contrib/nvidia-gpu/device-plugin-damonset.yaml
@@ -23,7 +23,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: ccloud.sap.com/nvidia-gpu
+              - key: gpu
                 operator: Exists
       tolerations:
       - operator: "Exists"

--- a/contrib/nvidia-gpu/device-plugin.yaml
+++ b/contrib/nvidia-gpu/device-plugin.yaml
@@ -22,7 +22,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: ccloud.sap.com/nvidia-gpu
+              - key: gpu
                 operator: Exists
       tolerations:
       - operator: "Exists"

--- a/contrib/nvidia-gpu/driver-daemonset.yaml
+++ b/contrib/nvidia-gpu/driver-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: ccloud.sap.com/nvidia-gpu
+              - key: gpu
                 operator: Exists
       tolerations:
       - key: "nvidia.com/gpu"

--- a/pkg/controller/ground/bootstrap/gpu/manifest.go
+++ b/pkg/controller/ground/bootstrap/gpu/manifest.go
@@ -27,7 +27,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: ccloud.sap.com/nvidia-gpu
+              - key: gpu
                 operator: Exists
       tolerations:
       - operator: "Exists"
@@ -92,7 +92,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: ccloud.sap.com/nvidia-gpu
+              - key: gpu
                 operator: Exists
       tolerations:
       - key: "nvidia.com/gpu"

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -91,7 +91,7 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 	if pool != nil {
 		nodeLabels = append(nodeLabels, "ccloud.sap.com/nodepool="+pool.Name)
 		if strings.HasPrefix(pool.Flavor, "zg") {
-			nodeLabels = append(nodeLabels, "ccloud.sap.com/nvidia-gpu=nvidia-tesla-v100")
+			nodeLabels = append(nodeLabels, "gpu=nvidia-tesla-v100")
 		}
 	}
 

--- a/pkg/templates/ignition_test.go
+++ b/pkg/templates/ignition_test.go
@@ -89,6 +89,6 @@ func TestNodeLabels(t *testing.T) {
 	data, err = Ignition.GenerateNode(kluster, gpuPool, "test", &testKlusterSecret, log.NewNopLogger())
 	if assert.NoError(t, err, "Failed to generate node") {
 		//Ensure we rendered the expected template
-		assert.Contains(t, string(data), fmt.Sprintf("--node-labels=ccloud.sap.com/nodepool=%s,ccloud.sap.com/nvidia-gpu=nvidia-tesla-v100", pool.Name))
+		assert.Contains(t, string(data), fmt.Sprintf("--node-labels=ccloud.sap.com/nodepool=%s,gpu=nvidia-tesla-v100", pool.Name))
 	}
 }


### PR DESCRIPTION
Labels of the nodes with GPU are changed from `ccloud.sap.com/nvidia-gpu` to `gpu` to be consistent with the cloud providers (AWS, GCP)