### PR TITLE
alert on many klusters pending

### DIFF
--- a/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
+++ b/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
@@ -2,7 +2,7 @@ groups:
 - name: kubernikus.alerts
   rules:
   - alert: KubernikusKlusterStuck
-    expr: kubernikus_kluster_status_phase{phase!="Running"} == 1
+    expr: kubernikus_kluster_status_phase{phase!~"Running|Pending"} == 1
     for: 1h
     labels:
       tier: kubernikus
@@ -12,6 +12,18 @@ groups:
     annotations:
       description: Kluster {{ $labels.kluster_id }} is stuck in {{ $labels.phase }} for 1h
       summary: Kluster stuck in phase {{ $labels.phase }}
+
+  - alert: KubernikusManyKlusterStuckInPending
+    expr: round((count(kubernikus_kluster_status_phase{phase="Pending"} == 1)) / count(kubernikus_kluster_info) * 100) >= 20
+    for: 1h
+    labels:
+      tier: kubernikus
+      service: k8s
+      severity: warning
+      context: kluster
+    annotations:
+      description: More than {{ $labels.value }} percent of klusters are stuck in pending for at least 1h
+      summary: Many klusters stuck in pending
 
   - alert: KubernikusAPIDown
     expr: count by (instance) (probe_success{kubernetes_name="kubernikus-api"} != 1) >= count by (instance) (probe_success{kubernetes_name="kubernikus-api"} == 1)


### PR DESCRIPTION
Currently we trigger an alert if a kluster is stuck in `phase!="Running`, which means we get an alert i f a kluster is stuck in `pending`. In most cases due to a project-specific configuration error. Nothing todo from our side. Also it's not an indication that kubernikus did something wrong.

Proposal: Alert only if more than 20% of the klusters are in pending, as this might indicate a more general problem.

[] Yes
[] No
[] Maybe

@BugRoger @databus23 