### PR TITLE
detect OOM killed pods via NPD

### DIFF
--- a/charts/kubernikus-system/charts/node-problem-detector/Chart.yaml
+++ b/charts/kubernikus-system/charts/node-problem-detector/Chart.yaml
@@ -1,0 +1,3 @@
+description: Node Problem Detector for Kubernetes
+name: node-problem-detector
+version: 0.5.0

--- a/charts/kubernikus-system/charts/node-problem-detector/plugins/kernel-monitor.json
+++ b/charts/kubernikus-system/charts/node-problem-detector/plugins/kernel-monitor.json
@@ -1,0 +1,68 @@
+{
+  "plugin": "journald",
+  "pluginConfig": {
+    "source": "kernel"
+  },
+  "logPath": "/var/log/journal",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "kernel-monitor",
+  "conditions": [
+    {
+      "type": "KernelDeadlock",
+      "reason": "KernelHasNoDeadlock",
+      "message": "kernel has no deadlock"
+    },
+    {
+      "type": "PodOOMKilling",
+      "reason": "NoPodOOMKilling",
+      "message": "no pods were killed after being OOM"
+    }
+  ],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "OOMKilling",
+      "pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB"
+    },
+    {
+      "type": "temporary",
+      "condition": "PodOOMKilling",
+      "reason": "PodOOMKilling",
+      "pattern": "\\w+ cgroup out of memory: Kill process \\d+ (.+) score \\d+ or sacrifice child"
+    },
+    {
+      "type": "temporary",
+      "reason": "TaskHung",
+      "pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
+    },
+    {
+      "type": "permanent",
+      "condition": "KernelDeadlock",
+      "reason": "UnregisterNetDevice",
+      "pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
+    },
+    {
+      "type": "permanent",
+      "condition": "KernelDeadlock",
+      "reason": "AUFSUmountHung",
+      "pattern": "task umount\\.aufs:\\w+ blocked for more than \\w+ seconds\\."
+    },
+    {
+      "type": "permanent",
+      "condition": "KernelDeadlock",
+      "reason": "DockerHung",
+      "pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+    }
+  ]
+}

--- a/charts/kubernikus-system/charts/node-problem-detector/templates/config.yaml
+++ b/charts/kubernikus-system/charts/node-problem-detector/templates/config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-problem-detector-config
+
+data:
+{{- range $path, $bytes := .Files.Glob "plugins/*.json" }}
+{{ printf "%s" $path | trimPrefix "plugins/" | indent 2 }}: |
+{{ printf "%s" $bytes | indent 4 }}
+{{ end -}}

--- a/charts/kubernikus-system/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/kubernikus-system/charts/node-problem-detector/templates/daemonset.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-problem-detector
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: node-problem-detector
+    spec:
+      tolerations:
+      - key: "species"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: node-problem-detector
+        command:
+        - /node-problem-detector
+        - --logtostderr
+        - --v=0
+        - --system-log-monitors={{ .Values.logMonitors }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "100Mi"
+          requests:
+            cpu: "20m"
+            memory: "20Mi"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: log
+          mountPath: /var/log
+          readOnly: true
+        # Make sure node problem detector is in the same timezone
+        # with the host.
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
+        - name: config
+          mountPath: /config
+          readOnly: true
+        ports:
+          - name: healthz
+            containerPort: 10256
+      volumes:
+      - name: log
+        # Config `log` to your system log directory
+        hostPath:
+          path: /var/log/
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: config
+        configMap:
+          name: node-problem-detector-config

--- a/charts/kubernikus-system/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/kubernikus-system/charts/node-problem-detector/templates/daemonset.yaml
@@ -10,10 +10,6 @@ spec:
       labels:
         app: node-problem-detector
     spec:
-      tolerations:
-      - key: "species"
-        operator: "Exists"
-        effect: "NoSchedule"
       containers:
       - name: node-problem-detector
         command:

--- a/charts/kubernikus-system/charts/node-problem-detector/values.yaml
+++ b/charts/kubernikus-system/charts/node-problem-detector/values.yaml
@@ -1,0 +1,5 @@
+image:
+  repository: sapcc/node-problem-detector
+  tag: v0.5.0
+
+logMonitors: "/config/kernel-monitor.json"

--- a/charts/kubernikus-system/charts/prometheus/kubernetes.alerts
+++ b/charts/kubernikus-system/charts/prometheus/kubernetes.alerts
@@ -81,12 +81,12 @@ groups:
       summary: "PVC stuck in phase {{ $labels.phase }}"
 
   - alert: KubernetesNodeContainerOOMKilled
-    expr: sum by (kubernetes_io_hostname) (increase(node_vmstat_oom_kill[10m])) > 0
+    expr: sum by (instance) (increase(node_vmstat_oom_kill[10m])) > 0
     labels:
-      tier: kubernetes
+      tier: kubernikus
       service: node
       severity: info
       context: memory
     annotations:
-      description: Container was OOM
-      summary:  A container on {{ $labels.kubernetes_io_hostname }} was killed after being out of memory
+      summary: Container was OOM
+      description: A container on {{ $labels.instance }} was killed after being out of memory

--- a/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
+++ b/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
@@ -9,6 +9,7 @@ groups:
       service: k8s
       severity: warning
       context: kluster
+      meta: "{{ $labels.kluster_id }} stuck in {{ $labels.phase }}"
     annotations:
       description: Kluster {{ $labels.kluster_id }} is stuck in {{ $labels.phase }} for 1h
       summary: Kluster stuck in phase {{ $labels.phase }}
@@ -33,6 +34,7 @@ groups:
       service: kubernikus
       severity: warning
       context: kluster
+      meta: "{{ $labels.kubernetes_name }} is unavailable"
     annotations:
       description: "{{ $labels.kubernetes_name }} is unavailable"
       summary: "{{ $labels.kubernetes_name }} is unavailable"


### PR DESCRIPTION
introduce node-problem-detector (NPD) to grep kernel log for oom killed pods.
will rollout, test and introduce an alert later. meanwhile you'll see the status condition on the node as well as the event
```
$ k describe node <node>
Events:
  Type     Reason         Age   From                                     Message
  ----     ------         ----  ----                                     -------
  Warning  PodOOMKilling  2m    kernel-monitor, <node>  Memory cgroup out of memory: Kill process 25169 (hyperkube) score 2109 or sacrifice child
```
LGTY @databus23?