### PR TITLE
Fix local traffic only services

### DIFF
--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -441,7 +441,7 @@ storage:
           enableProfiling: false
           featureGates: {}
           healthzBindAddress: 0.0.0.0:10256
-          hostnameOverride: ""
+          hostnameOverride: {{ .NodeName }}
           iptables:
             masqueradeAll: false
             masqueradeBit: 14

--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -298,7 +298,7 @@ storage:
     - path: /var/lib/iptables/rules-save
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |
           *nat
           :PREROUTING ACCEPT [0:0]
@@ -318,7 +318,7 @@ storage:
     - path: /etc/kube-flannel/net-conf.json
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           {
             "Network": "{{ .ClusterCIDR }}",
@@ -329,27 +329,27 @@ storage:
     - path: /etc/kubernetes/environment
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           NODE_NAME={{ .NodeName }}
     - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .KubeletClientsCA | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .ApiserverClientsSystemKubeProxyKey | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
-{{ .ApiserverClientsSystemKubeProxy | indent 10 }}    
+{{ .ApiserverClientsSystemKubeProxy | indent 10 }}
     - path: /etc/kubernetes/certs/tls-ca.pem
       filesystem: root
       mode: 0644
@@ -359,7 +359,7 @@ storage:
     - path: /etc/kubernetes/bootstrap/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -369,19 +369,19 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                token: {{ .BootstrapToken }} 
+                token: {{ .BootstrapToken }}
     - path: /etc/kubernetes/kube-proxy/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -391,20 +391,20 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem 
-                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem 
+                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
+                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
     - path: /etc/kubernetes/kubelet/config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           kind: KubeletConfiguration
           apiVersion: kubelet.config.k8s.io/v1beta1
@@ -419,7 +419,7 @@ storage:
     - path: /etc/kubernetes/kube-proxy/config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: kubeproxy.config.k8s.io/v1alpha1
           kind: KubeProxyConfiguration
@@ -456,7 +456,7 @@ storage:
     - path: /etc/kubernetes/openstack/openstack.config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           [Global]
           auth-url = {{ .OpenstackAuthURL }}
@@ -468,7 +468,7 @@ storage:
           [LoadBalancer]
           lb-version=v2
           subnet-id = {{ .OpenstackLBSubnetID }}
-          floating-network-id = {{ .OpenstackLBFloatingNetworkID }} 
+          floating-network-id = {{ .OpenstackLBFloatingNetworkID }}
           create-monitor = yes
           monitor-delay = 1m
           monitor-timeout = 30s

--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -259,7 +259,7 @@ storage:
     - path: /var/lib/iptables/rules-save
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |
           *nat
           :PREROUTING ACCEPT [0:0]
@@ -283,21 +283,21 @@ storage:
     - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .KubeletClientsCA | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .ApiserverClientsSystemKubeProxyKey | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
-{{ .ApiserverClientsSystemKubeProxy | indent 10 }}    
+{{ .ApiserverClientsSystemKubeProxy | indent 10 }}
     - path: /etc/kubernetes/certs/tls-ca.pem
       filesystem: root
       mode: 0644
@@ -307,7 +307,7 @@ storage:
     - path: /etc/kubernetes/bootstrap/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -317,19 +317,19 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                token: {{ .BootstrapToken }} 
+                token: {{ .BootstrapToken }}
     - path: /etc/kubernetes/kube-proxy/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -339,20 +339,20 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem 
-                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem 
+                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
+                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
     - path: /etc/kubernetes/kube-proxy/config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: componentconfig/v1alpha1
           kind: KubeProxyConfiguration
@@ -389,7 +389,7 @@ storage:
     - path: /etc/kubernetes/openstack/openstack.config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           [Global]
           auth-url = {{ .OpenstackAuthURL }}

--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -374,7 +374,7 @@ storage:
           enableProfiling: false
           featureGates: ""
           healthzBindAddress: 0.0.0.0:10256
-          hostnameOverride: ""
+          hostnameOverride: {{ .NodeName }}
           iptables:
             masqueradeAll: false
             masqueradeBit: 14

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -259,7 +259,7 @@ storage:
     - path: /var/lib/iptables/rules-save
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |
           *nat
           :PREROUTING ACCEPT [0:0]
@@ -279,21 +279,21 @@ storage:
     - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .KubeletClientsCA | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .ApiserverClientsSystemKubeProxyKey | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
-{{ .ApiserverClientsSystemKubeProxy | indent 10 }}    
+{{ .ApiserverClientsSystemKubeProxy | indent 10 }}
     - path: /etc/kubernetes/certs/tls-ca.pem
       filesystem: root
       mode: 0644
@@ -303,7 +303,7 @@ storage:
     - path: /etc/kubernetes/bootstrap/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -313,19 +313,19 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                token: {{ .BootstrapToken }} 
+                token: {{ .BootstrapToken }}
     - path: /etc/kubernetes/kube-proxy/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -335,20 +335,20 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem 
-                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem 
+                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
+                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
     - path: /etc/kubernetes/kube-proxy/config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: componentconfig/v1alpha1
           kind: KubeProxyConfiguration
@@ -385,7 +385,7 @@ storage:
     - path: /etc/kubernetes/openstack/openstack.config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           [Global]
           auth-url = {{ .OpenstackAuthURL }}
@@ -397,7 +397,7 @@ storage:
           [LoadBalancer]
           lb-version=v2
           subnet-id = {{ .OpenstackLBSubnetID }}
-          floating-network-id = {{ .OpenstackLBFloatingNetworkID }} 
+          floating-network-id = {{ .OpenstackLBFloatingNetworkID }}
           create-monitor = yes
           monitor-delay = 1m
           monitor-timeout = 30s

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -370,7 +370,7 @@ storage:
           enableProfiling: false
           featureGates: ""
           healthzBindAddress: 0.0.0.0:10256
-          hostnameOverride: ""
+          hostnameOverride: {{ .NodeName }}
           iptables:
             masqueradeAll: false
             masqueradeBit: 14

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -370,7 +370,7 @@ storage:
           enableProfiling: false
           featureGates: ""
           healthzBindAddress: 0.0.0.0:10256
-          hostnameOverride: ""
+          hostnameOverride: {{ .NodeName }}
           iptables:
             masqueradeAll: false
             masqueradeBit: 14

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -259,7 +259,7 @@ storage:
     - path: /var/lib/iptables/rules-save
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |
           *nat
           :PREROUTING ACCEPT [0:0]
@@ -279,21 +279,21 @@ storage:
     - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .KubeletClientsCA | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
 {{ .ApiserverClientsSystemKubeProxyKey | indent 10 }}
     - path: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
-{{ .ApiserverClientsSystemKubeProxy | indent 10 }}    
+{{ .ApiserverClientsSystemKubeProxy | indent 10 }}
     - path: /etc/kubernetes/certs/tls-ca.pem
       filesystem: root
       mode: 0644
@@ -303,7 +303,7 @@ storage:
     - path: /etc/kubernetes/bootstrap/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -313,19 +313,19 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                token: {{ .BootstrapToken }} 
+                token: {{ .BootstrapToken }}
     - path: /etc/kubernetes/kube-proxy/kubeconfig
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: v1
           kind: Config
@@ -335,20 +335,20 @@ storage:
                  certificate-authority: /etc/kubernetes/certs/tls-ca.pem
                  server: {{ .ApiserverURL }}
           contexts:
-            - name: local 
+            - name: local
               context:
                 cluster: local
-                user: local 
+                user: local
           current-context: local
           users:
             - name: local
               user:
-                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem 
-                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem 
+                client-certificate: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy.pem
+                client-key: /etc/kubernetes/certs/apiserver-clients-system-kube-proxy-key.pem
     - path: /etc/kubernetes/kube-proxy/config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           apiVersion: kubeproxy.config.k8s.io/v1alpha1
           kind: KubeProxyConfiguration
@@ -385,7 +385,7 @@ storage:
     - path: /etc/kubernetes/openstack/openstack.config
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |-
           [Global]
           auth-url = {{ .OpenstackAuthURL }}
@@ -397,7 +397,7 @@ storage:
           [LoadBalancer]
           lb-version=v2
           subnet-id = {{ .OpenstackLBSubnetID }}
-          floating-network-id = {{ .OpenstackLBFloatingNetworkID }} 
+          floating-network-id = {{ .OpenstackLBFloatingNetworkID }}
           create-monitor = yes
           monitor-delay = 1m
           monitor-timeout = 30s


### PR DESCRIPTION
This PR ~hopefully~ fixes services with `externalTrafficPolicy=Local` in our setup.

See https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#services-with-externaltrafficpolicy-local-are-not-reachable for more details.

I'm waiting on positive feedback from the user that initially reported this problem that this change fixes the problem.

Note: I removed some trailing whitespaces in this PR as well. Look at the individual commits to see the actual changes.