### PR TITLE
Updates etcd to version 3.3.10

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -40,7 +40,6 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name }}
-
 spec:
   replicas: 1
   selector:
@@ -79,6 +78,20 @@ spec:
               name: data
             - mountPath: /bootstrap
               name: bootstrap
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - ETCDCTL_API=3 etcdctl get foo
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         - name: backup

--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: sapcc/etcd
-  tag: 3.1.12
+  tag: v3.3.10
   pullPolicy: IfNotPresent
 ## Persist data to a persitent volume
 persistence:


### PR DESCRIPTION
This PR updates etcd to version 3.3.10 to make etcd backup/restore working. It also adds specific liveness/readiness probes to etcd deployment. 