### PR TITLE
Fix node listing for multiple node pools with similar names

### DIFF
--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -13,6 +13,7 @@ import (
 	kubernikus_listers "github.com/sapcc/kubernikus/pkg/generated/listers/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/templates"
 	"github.com/sapcc/kubernikus/pkg/util"
+	"github.com/sapcc/kubernikus/pkg/util/generator"
 
 	"github.com/go-kit/kit/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -189,7 +190,7 @@ func (cpm *ConcretePoolManager) CreateNode() (id string, err error) {
 		return "", err
 	}
 
-	nodeName := util.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", cpm.Kluster.Spec.Name, cpm.Pool.Name))
+	nodeName := generator.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", cpm.Kluster.Spec.Name, cpm.Pool.Name))
 
 	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, cpm.Pool, nodeName, secret, cpm.Logger)
 	if err != nil {

--- a/pkg/util/generator/namegenerator.go
+++ b/pkg/util/generator/namegenerator.go
@@ -1,4 +1,4 @@
-package util
+package generator
 
 import (
 	"fmt"
@@ -12,6 +12,9 @@ type NameGenerator interface {
 	// the base. If base is valid, the returned name must also be valid. The generator is
 	// responsible for knowing the maximum valid name length.
 	GenerateName(base string) string
+
+	//Prefix generates a valid static prefix without the random suffix
+	Prefix(base string) string
 }
 
 // simpleNameGenerator generates random names.
@@ -24,14 +27,18 @@ var SimpleNameGenerator NameGenerator = simpleNameGenerator{}
 
 const (
 	// TODO: make this flexible for non-core resources with alternate naming rules.
-	maxNameLength          = 63
-	randomLength           = 5
-	maxGeneratedNameLength = maxNameLength - randomLength
+	MaxNameLength          = 63
+	RandomLength           = 5
+	MaxGeneratedNameLength = MaxNameLength - RandomLength
 )
 
-func (simpleNameGenerator) GenerateName(base string) string {
-	if len(base) > maxGeneratedNameLength {
-		base = base[:maxGeneratedNameLength]
+func (simpleNameGenerator) Prefix(base string) string {
+	if len(base) > MaxGeneratedNameLength {
+		base = base[:MaxGeneratedNameLength]
 	}
-	return strings.ToLower(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	return base
+}
+
+func (s simpleNameGenerator) GenerateName(base string) string {
+	return strings.ToLower(fmt.Sprintf("%s%s", s.Prefix(base), utilrand.String(RandomLength)))
 }


### PR DESCRIPTION
This fixes an edge case when one node pool is a prefix of another node pool.
In that case the two pool managers would fight over nodes constantly deleting and terminating nodes.

Two users ran into this, time to fix it.