### PR TITLE
Cleanup e2e test instances in pyrolisis

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"
 	_ "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	_ "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
+	_ "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	_ "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
 	_ "github.com/stretchr/testify/assert"
 	_ "github.com/stretchr/testify/mock"

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -7,7 +7,6 @@ import (
 	_ "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"
 	_ "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	_ "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
-	_ "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	_ "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
 	_ "github.com/stretchr/testify/assert"
 	_ "github.com/stretchr/testify/mock"


### PR DESCRIPTION
This PR cleans up instances that are left from previous failing E2E tests.