### PR TITLE
Allow Deletion of Node Pools

### DIFF
--- a/pkg/api/handlers/terminate_cluster.go
+++ b/pkg/api/handlers/terminate_cluster.go
@@ -31,9 +31,11 @@ func (d *terminateCluster) Handle(params operations.TerminateClusterParams, prin
 		return NewErrorResponse(&operations.TerminateClusterDefault{}, 500, err.Error())
 	}
 
-	_, err = editCluster(kluster, principal, params.Name, func(kluster *v1.Kluster) {
+	_, err = editCluster(kluster, principal, params.Name, func(kluster *v1.Kluster) error {
 		kluster.Status.Phase = models.KlusterPhaseTerminating
 		kluster.Status.Message = "Cluster terminating"
+
+		return nil
 	})
 	if err != nil {
 		return NewErrorResponse(&operations.TerminateClusterDefault{}, 500, err.Error())

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -1,10 +1,8 @@
 package handlers
 
 import (
-	"fmt"
-
 	"errors"
-
+	"fmt"
 	"net/http"
 	"strings"
 

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"net/http"

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"net/http"
 	"strings"

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
+
 	"net/http"
 	"strings"
 
@@ -31,13 +33,16 @@ func qualifiedName(name string, accountId string) string {
 	return fmt.Sprintf("%s-%s", name, accountId)
 }
 
-func editCluster(client kubernikusv1.KlusterInterface, principal *models.Principal, name string, updateFunc func(k *v1.Kluster)) (*v1.Kluster, error) {
+func editCluster(client kubernikusv1.KlusterInterface, principal *models.Principal, name string, updateFunc func(k *v1.Kluster) error) (*v1.Kluster, error) {
 	kluster, err := client.Get(qualifiedName(name, principal.Account), metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	updateFunc(kluster)
+	err = updateFunc(kluster)
+	if err != nil {
+		return nil, err
+	}
 
 	updatedCluster, err := client.Update(kluster)
 	if err != nil {
@@ -61,4 +66,47 @@ func getTracingLogger(request *http.Request) kitlog.Logger {
 		logger = kitlog.NewNopLogger()
 	}
 	return logger
+}
+
+// detectNodePoolChanges checks for the changes between node pool lists
+func detectNodePoolChanges(oldNodePools, newNodePools []models.NodePool) (nodePoolsToDelete []string, err error) {
+
+	nodePoolsToDelete = make([]string, 0)
+
+	// For each old node pool
+	for _, old := range oldNodePools {
+		foundInNew := false
+		// For each new node pool
+		for _, new := range newNodePools {
+			// Found in both!
+			if old.Name == new.Name {
+				foundInNew = true
+
+				err := nodePoolEqualsWithScaling(old, new)
+				if err != nil {
+					return nodePoolsToDelete, err
+				}
+			}
+		}
+		if !foundInNew {
+			if old.Size != 0 {
+				return nodePoolsToDelete, errors.New("nodepool with size larger than 0 cannot be deleted: " + old.Name)
+			} else {
+				nodePoolsToDelete = append(nodePoolsToDelete, old.Name)
+			}
+
+		}
+	}
+
+	return nodePoolsToDelete, nil
+}
+
+// nodePoolEqualsWithScaling checks whether the node pool is only scaled without any changes
+func nodePoolEqualsWithScaling(old, new models.NodePool) error {
+
+	if old.Flavor != new.Flavor || old.Image != new.Image || old.Name != new.Name {
+		return errors.New("nodepool data cannot be changed except size: " + old.Name)
+	}
+
+	return nil
 }

--- a/pkg/api/handlers/util_test.go
+++ b/pkg/api/handlers/util_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
+)
+
+func TestDetectNodePoolChanges(t *testing.T) {
+
+	np := models.NodePool{Name: "pool", Size: 0, Image: "image", Flavor: "flavor"}
+	npScaled := models.NodePool{Name: "pool", Size: 5, Image: "image", Flavor: "flavor"}
+	npChanged := models.NodePool{Name: "pool", Size: 0, Image: "image:v2", Flavor: "flavor"}
+	npNew := models.NodePool{Name: "pool_new", Size: 0, Image: "image", Flavor: "flavor"}
+
+	nodePoolListOriginal := []models.NodePool{np, npNew}
+	nodePoolListScaled := []models.NodePool{npScaled, npNew}
+	nodePoolListRemoved := []models.NodePool{np}
+	nodePoolListChanged := []models.NodePool{npChanged}
+
+	deleteList, err := detectNodePoolChanges(nodePoolListOriginal, nodePoolListScaled)
+	assert.Len(t, deleteList, 0)
+	assert.Nil(t, err)
+
+	deleteList, err = detectNodePoolChanges(nodePoolListOriginal, nodePoolListRemoved)
+	assert.Len(t, deleteList, 1)
+	assert.Nil(t, err)
+
+	deleteList, err = detectNodePoolChanges(nodePoolListOriginal, nodePoolListChanged)
+	assert.Len(t, deleteList, 0)
+	assert.NotNil(t, err)
+
+}
+
+func TestNodePoolEqualsWithScaling(t *testing.T) {
+
+	np := models.NodePool{Name: "pool", Size: 0, Image: "image", Flavor: "flavor"}
+	npScaled := models.NodePool{Name: "pool", Size: 5, Image: "image", Flavor: "flavor"}
+	npChanged := models.NodePool{Name: "pool", Size: 0, Image: "image:v2", Flavor: "flavor"}
+
+	assert.Nil(t, nodePoolEqualsWithScaling(np, npScaled))
+	assert.NotNil(t, nodePoolEqualsWithScaling(np, npChanged))
+
+}

--- a/pkg/api/rest/api_test.go
+++ b/pkg/api/rest/api_test.go
@@ -213,6 +213,12 @@ func TestClusterUpdate(t *testing.T) {
 			},
 			NodePools: []models.NodePool{
 				{
+					Flavor: "flavour",
+					Image:  "image",
+					Name:   "poolname",
+					Size:   5,
+				},
+				{
 					Flavor: "newflavour",
 					Image:  "newimage",
 					Name:   "newpoolname",


### PR DESCRIPTION
This PR solves #303 for Kubernikus API:

- Only allow the changing size of `nodePool` instances during the update
- Do not allow deletion of `nodePool` if the size is larger than 0
- If the size is 0 and `nodePool` is deleted, clear from `spec.nodePools` and `status.nodePools`

When this PR is merged, we can allow deletion of `nodePools` from Elektra UI. /cc @edda