### PR TITLE
Make it optional to run e2e tests in parallel

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -200,3 +200,11 @@ func TestRunner(t *testing.T) {
 		t.Run("Network", networkTests.Run)
 	})
 }
+
+func runParallel() bool {
+	if os.Getenv("RUN_PARALLEL") == "false" {
+		return false
+	}
+
+	return true
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -201,10 +201,8 @@ func TestRunner(t *testing.T) {
 	})
 }
 
-func runParallel() bool {
-	if os.Getenv("RUN_PARALLEL") == "false" {
-		return false
+func runParallel(t *testing.T) {
+	if os.Getenv("RUN_PARALLEL") != "false" {
+		t.Parallel()
 	}
-
-	return true
 }

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -41,9 +41,7 @@ type NetworkTests struct {
 }
 
 func (n *NetworkTests) Run(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	n.Namespace = util.SimpleNameGenerator.GenerateName("e2e-network-")
 
@@ -119,9 +117,7 @@ func (n *NetworkTests) CreatePods(t *testing.T) {
 }
 
 func (n *NetworkTests) WaitForPodsRunning(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"app": "serve-hostname"}))
 	_, err := n.Kubernetes.WaitForPodsWithLabelRunningReady(n.Namespace, label, len(n.Nodes.Items), TestWaitForPodsRunningTimeout)
@@ -129,9 +125,7 @@ func (n *NetworkTests) WaitForPodsRunning(t *testing.T) {
 }
 
 func (n *NetworkTests) WaitForKubeDNSRunning(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
 	_, err := n.Kubernetes.WaitForPodsWithLabelRunningReady("kube-system", label, 1, TestWaitForKubeDNSRunningTimeout)
@@ -173,9 +167,7 @@ func (n *NetworkTests) CreateServices(t *testing.T) {
 }
 
 func (n *NetworkTests) WaitForServiceEndpoints(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"service": "e2e"}))
 	_, err := n.Kubernetes.WaitForServiceEndpointsWithLabelNum(n.Namespace, label, 1, TestWaitForServiceEndpointsTimeout)
@@ -184,9 +176,7 @@ func (n *NetworkTests) WaitForServiceEndpoints(t *testing.T) {
 }
 
 func (n *NetworkTests) TestPods(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	pods, err := n.Kubernetes.ClientSet.CoreV1().Pods(n.Namespace).List(meta_v1.ListOptions{})
 	assert.NoError(t, err, "There should be no error while listing the kluster's pods")
@@ -218,9 +208,7 @@ func (n *NetworkTests) TestPods(t *testing.T) {
 }
 
 func (n *NetworkTests) TestServices(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	services, err := n.Kubernetes.ClientSet.CoreV1().Services(n.Namespace).List(meta_v1.ListOptions{})
 	assert.NoError(t, err, "There should be no error while listing services")
@@ -257,9 +245,7 @@ func (n *NetworkTests) TestServices(t *testing.T) {
 }
 
 func (n *NetworkTests) TestServicesWithDNS(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	services, err := n.Kubernetes.ClientSet.CoreV1().Services(n.Namespace).List(meta_v1.ListOptions{})
 	assert.NoError(t, err, "There should be no error while listing services")

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -41,7 +41,9 @@ type NetworkTests struct {
 }
 
 func (n *NetworkTests) Run(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	n.Namespace = util.SimpleNameGenerator.GenerateName("e2e-network-")
 
@@ -117,7 +119,9 @@ func (n *NetworkTests) CreatePods(t *testing.T) {
 }
 
 func (n *NetworkTests) WaitForPodsRunning(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"app": "serve-hostname"}))
 	_, err := n.Kubernetes.WaitForPodsWithLabelRunningReady(n.Namespace, label, len(n.Nodes.Items), TestWaitForPodsRunningTimeout)
@@ -125,7 +129,9 @@ func (n *NetworkTests) WaitForPodsRunning(t *testing.T) {
 }
 
 func (n *NetworkTests) WaitForKubeDNSRunning(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
 	_, err := n.Kubernetes.WaitForPodsWithLabelRunningReady("kube-system", label, 1, TestWaitForKubeDNSRunningTimeout)
@@ -167,7 +173,9 @@ func (n *NetworkTests) CreateServices(t *testing.T) {
 }
 
 func (n *NetworkTests) WaitForServiceEndpoints(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"service": "e2e"}))
 	_, err := n.Kubernetes.WaitForServiceEndpointsWithLabelNum(n.Namespace, label, 1, TestWaitForServiceEndpointsTimeout)
@@ -176,7 +184,9 @@ func (n *NetworkTests) WaitForServiceEndpoints(t *testing.T) {
 }
 
 func (n *NetworkTests) TestPods(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	pods, err := n.Kubernetes.ClientSet.CoreV1().Pods(n.Namespace).List(meta_v1.ListOptions{})
 	assert.NoError(t, err, "There should be no error while listing the kluster's pods")
@@ -208,7 +218,9 @@ func (n *NetworkTests) TestPods(t *testing.T) {
 }
 
 func (n *NetworkTests) TestServices(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	services, err := n.Kubernetes.ClientSet.CoreV1().Services(n.Namespace).List(meta_v1.ListOptions{})
 	assert.NoError(t, err, "There should be no error while listing services")
@@ -245,7 +257,9 @@ func (n *NetworkTests) TestServices(t *testing.T) {
 }
 
 func (n *NetworkTests) TestServicesWithDNS(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	services, err := n.Kubernetes.ClientSet.CoreV1().Services(n.Namespace).List(meta_v1.ListOptions{})
 	assert.NoError(t, err, "There should be no error while listing services")

--- a/test/e2e/volume_test.go
+++ b/test/e2e/volume_test.go
@@ -28,9 +28,7 @@ type VolumeTests struct {
 }
 
 func (v *VolumeTests) Run(t *testing.T) {
-	if runParallel() {
-		t.Parallel()
-	}
+	runParallel(t)
 
 	v.Namespace = util.SimpleNameGenerator.GenerateName("e2e-volumes-")
 

--- a/test/e2e/volume_test.go
+++ b/test/e2e/volume_test.go
@@ -28,7 +28,9 @@ type VolumeTests struct {
 }
 
 func (v *VolumeTests) Run(t *testing.T) {
-	t.Parallel()
+	if runParallel() {
+		t.Parallel()
+	}
 
 	v.Namespace = util.SimpleNameGenerator.GenerateName("e2e-volumes-")
 


### PR DESCRIPTION
Setting environment variable `RUN_PARALLEL` to `false` runs volume and network tests in series.