### PR TITLE
Turn off parallel e2e tests

### DIFF
--- a/ci/task_e2e_tests.yaml
+++ b/ci/task_e2e_tests.yaml
@@ -22,6 +22,7 @@ run:
       cd gopath/src/github.com/sapcc/kubernikus
 
       apk add --no-progress --no-cache make git curl
+      export RUN_PARALLEL=false
       make test-e2e | tee test.output
       rc=$?
       if [ "$SENTRY_DSN" != "" ] && [ $rc -ne 0 ] ; then


### PR DESCRIPTION
This PR turns off parallel execution of e2e smoke tests in pipeline. 