### PR TITLE
Bump to Kubernetes v1.10.11

### DIFF
--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: sapcc/hyperkube
-  tag: v1.10.8
+  tag: v1.10.11
   pullPolicy: IfNotPresent
 
 # Settings for the openstack cloudprovider

--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -87,7 +87,7 @@ systemd:
           --mount volume=var-log,target=/var/log \
           --mount volume=etc-machine-id,target=/etc/machine-id \
           --insecure-options=image"
-        Environment="KUBELET_IMAGE_TAG=v1.10.8"
+        Environment="KUBELET_IMAGE_TAG=v1.10.11"
         Environment="KUBELET_IMAGE_URL=docker://sapcc/hyperkube"
         Environment="KUBELET_IMAGE_ARGS=--name=kubelet --exec=/kubelet"
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
@@ -168,7 +168,7 @@ systemd:
           --mount volume=lib-modules,target=/lib/modules \
           --stage1-from-dir=stage1-fly.aci \
           --insecure-options=image \
-          docker://sapcc/hyperkube:v1.10.8 \
+          docker://sapcc/hyperkube:v1.10.11 \
           --name kube-proxy \
           --exec=/hyperkube \
           -- \

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -5,5 +5,5 @@ const (
 	CA_ISSUER_KUBERNIKUS_IDENTIFIER_1 = "Kubernikus"
 
 	// This is the default Kubernetes version that clusters are created in
-	DEFAULT_KUBERNETES_VERSION = "1.10.8"
+	DEFAULT_KUBERNETES_VERSION = "1.10.11"
 )


### PR DESCRIPTION
This bumps the k8s version to v1.10.11 which includes the fix for CVE-2018-1002105.
https://github.com/kubernetes/kubernetes/issues/71411