### PR TITLE
Fix e2e test imports

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sapcc/kubernikus/pkg/util"
+	"github.com/sapcc/kubernikus/pkg/util/generator"
 	"github.com/sapcc/kubernikus/test/e2e/framework"
 )
 
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunner(t *testing.T) {
-	klusterName := util.SimpleNameGenerator.GenerateName("e2e-")
+	klusterName := generator.SimpleNameGenerator.GenerateName("e2e-")
 
 	if kluster != nil && *kluster != "" {
 		klusterName = *kluster

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sapcc/kubernikus/pkg/util"
+	"github.com/sapcc/kubernikus/pkg/util/generator"
 	"github.com/sapcc/kubernikus/test/e2e/framework"
 )
 
@@ -43,7 +43,7 @@ type NetworkTests struct {
 func (n *NetworkTests) Run(t *testing.T) {
 	runParallel(t)
 
-	n.Namespace = util.SimpleNameGenerator.GenerateName("e2e-network-")
+	n.Namespace = generator.SimpleNameGenerator.GenerateName("e2e-network-")
 
 	var err error
 	n.Nodes, err = n.Kubernetes.ClientSet.CoreV1().Nodes().List(meta_v1.ListOptions{})

--- a/test/e2e/volume_test.go
+++ b/test/e2e/volume_test.go
@@ -12,7 +12,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/sapcc/kubernikus/pkg/util"
+	"github.com/sapcc/kubernikus/pkg/util/generator"
 	"github.com/sapcc/kubernikus/test/e2e/framework"
 )
 
@@ -30,7 +30,7 @@ type VolumeTests struct {
 func (v *VolumeTests) Run(t *testing.T) {
 	runParallel(t)
 
-	v.Namespace = util.SimpleNameGenerator.GenerateName("e2e-volumes-")
+	v.Namespace = generator.SimpleNameGenerator.GenerateName("e2e-volumes-")
 
 	var err error
 	v.Nodes, err = v.Kubernetes.ClientSet.CoreV1().Nodes().List(meta_v1.ListOptions{})


### PR DESCRIPTION
Package renaming in https://github.com/sapcc/kubernikus/pull/338 is breaking e2e tests. This PR is fixing it.