### PR TITLE
Bump to oomkill-exporter 0.2.0, use rolling update in daemonset

### DIFF
--- a/charts/kubernikus-system/vendor/oomkill-exporter/templates/daemonset.yaml
+++ b/charts/kubernikus-system/vendor/oomkill-exporter/templates/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: {{ template "name" . }}
 spec:
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "name" . }}

--- a/charts/kubernikus-system/vendor/oomkill-exporter/values.yaml
+++ b/charts/kubernikus-system/vendor/oomkill-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sapcc/kubernetes-oomkill-exporter
-  tag: 0.1.0
+  tag: 0.2.0
   pullPolicy: IfNotPresent
 resources:
   limits:


### PR DESCRIPTION
This PR updates oomkill-exporter chart to version 0.2.0. It negotiates API version used to communicate with docker client. It also changes update strategy of daemonset to rolling update.