### PR TITLE
Fix eventexporter deployment api version

### DIFF
--- a/charts/kubernikus-system/vendor/eventexporter/templates/deployment.yaml
+++ b/charts/kubernikus-system/vendor/eventexporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "name" . }}


### PR DESCRIPTION
This PR fixes deployment API version in eventexporter chart for old clusters.