### PR TITLE
Fix fluent-bit config

### DIFF
--- a/charts/kubernikus-system/requirements.lock
+++ b/charts/kubernikus-system/requirements.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.16.3
-digest: sha256:68e7833ea7849cfd2022b0d837a7d1066f128bf40d58dfef48b450611e5829f0
-generated: 2018-12-12T11:26:21.467928357+01:00
+digest: sha256:514d79144c98135353a816479dac18edaf7d754a2122b403a9a6d7a2af1b9fca
+generated: 2018-12-13T08:25:25.42064407+01:00

--- a/charts/kubernikus-system/requirements.yaml
+++ b/charts/kubernikus-system/requirements.yaml
@@ -23,4 +23,4 @@ dependencies:
   - name: fluent-bit
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: 0.16.3
-    condition: fluent-bit.backend.es.host
+    condition: fluent-bit.backend.es.host,fluent-bit.backend.es.http_user,fluent-bit.backend.es.http_passwd

--- a/charts/kubernikus-system/templates/fluent-bit-configmap.yaml
+++ b/charts/kubernikus-system/templates/fluent-bit-configmap.yaml
@@ -20,7 +20,7 @@ data:
           Tag              kube.*
           Refresh_Interval 5
           Mem_Buf_Limit    5MB
-          Skip_Long_Lines  On
+          Skip_Long_Lines  Off
 
       [INPUT]
           Name          systemd
@@ -49,12 +49,17 @@ data:
           Rename _HOSTNAME hostname
 
       [FILTER]
+          Name       record_modifier
+          Match      kube.*
+          Remove_key time
+
+      [FILTER]
           Name               kubernetes
           Match              kube.*
           Kube_URL           https://kubernetes.default.svc:443
+          tls.verify         Off
           Kube_CA_File       /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           Kube_Token_File    /var/run/secrets/kubernetes.io/serviceaccount/token
-          K8S-Logging.Parser On
 
 {{ if index .Values "fluent-bit" "filter" "additionalValues" }}
       [FILTER]


### PR DESCRIPTION
This PR removes duplicate time value and turns off tls verification to API server. Used tls lib in fluent-bit can't use IP addresses as subject alternative name in certificates and we don't have kubernetes.default.svc in all certificates. Also check for user/password in chart condition.