### PR TITLE
Add manual versioning to fluent-bit

### DIFF
--- a/charts/kubernikus-system/values.yaml
+++ b/charts/kubernikus-system/values.yaml
@@ -3256,7 +3256,9 @@ fluent-bit:
 
   env: []
 
-  podAnnotations: {}
+  podAnnotations:
+    # manual versioning, raise if configmap changes
+    versioning: 1
 
   existingConfigMap: fluent-bit-config
 


### PR DESCRIPTION
This PR adds manual versioning to daemonset in chart to address configmap changes.