### PR TITLE
Check for free space in object store on kluster creation

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b5352f4065108401065414f6627d608e24ede20945bfa73ceae444e839662136
-updated: 2018-08-31T10:21:40.690495+02:00
+hash: 8403bffa01058ce58c8c8b999d81014bbb28b5977cb7532a89ae1ad1bb25c93b
+updated: 2019-01-02T16:01:43.225938465+01:00
 imports:
 - name: github.com/ajeddeloh/yaml
   version: 1072abfea31191db507785e2e0c1b8d1440d35a5
@@ -150,11 +150,12 @@ imports:
   - compiler
   - extensions
 - name: github.com/gophercloud/gophercloud
-  version: 1ad7a96d69a2e8105920431ee428843b6d1ee4c3
+  version: 94924357ebf6c7d448c70d65082ff7ca6f78ddc5
   subpackages:
   - internal
   - openstack
   - openstack/blockstorage/extensions/quotasets
+  - openstack/blockstorage/v3/volumes
   - openstack/compute/v2/extensions/keypairs
   - openstack/compute/v2/extensions/quotasets
   - openstack/compute/v2/extensions/schedulerhints
@@ -177,6 +178,9 @@ imports:
   - openstack/networking/v2/networks
   - openstack/networking/v2/ports
   - openstack/networking/v2/subnets
+  - openstack/objectstorage/v1/accounts
+  - openstack/objectstorage/v1/containers
+  - openstack/objectstorage/v1/objects
   - openstack/utils
   - pagination
 - name: github.com/gregjones/httpcache

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,7 +31,7 @@ import:
   - log
 # overwrite gophercloud version given in k8s deps
 - package: github.com/gophercloud/gophercloud
-  version: 1ad7a96d69a2e8105920431ee428843b6d1ee4c3
+  version: 94924357ebf6c7d448c70d65082ff7ca6f78ddc5
 # Dependencies extracted from go-swagger 0.13.0
 - package: github.com/go-openapi/errors
   version: 03cfca65330da08a5a440053faf994a3c682b5bf

--- a/pkg/client/openstack/admin/client.go
+++ b/pkg/client/openstack/admin/client.go
@@ -281,7 +281,7 @@ func (c *adminClient) CreateStorageContainer(projectID, containerName, serviceUs
 		return err
 	}
 	if (accountHeader.BytesUsed + etcd_util.BackupStorageContainerMinimumFreeStorage) > *accountHeader.QuotaBytes {
-		return fmt.Errorf("There should be at least %v GB free space in object-store", (etcd_util.BackupStorageContainerMinimumFreeStorage / 1000000000))
+		return fmt.Errorf("There should be at least %v MB free space in object-store", (etcd_util.BackupStorageContainerMinimumFreeStorage / 1000000))
 	}
 
 	domainID, err := c.getDomainID(serviceUserDomainName)

--- a/pkg/util/etcd/etcd.go
+++ b/pkg/util/etcd/etcd.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	BackupStorageContainerBase = "kubernikus-etcd-backup"
+	BackupStorageContainerBase               = "kubernikus-etcd-backup"
+	BackupStorageContainerMinimumFreeStorage = 1000000000 // 1Gi
 )
 
 func DefaultStorageContainer(kluster *v1.Kluster) string {

--- a/pkg/util/etcd/etcd.go
+++ b/pkg/util/etcd/etcd.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	BackupStorageContainerBase               = "kubernikus-etcd-backup"
-	BackupStorageContainerMinimumFreeStorage = 1000000000 // 1Gi
+	BackupStorageContainerMinimumFreeStorage = 500000000 // 500MiB
 )
 
 func DefaultStorageContainer(kluster *v1.Kluster) string {

--- a/test/e2e/pyrolisis_test.go
+++ b/test/e2e/pyrolisis_test.go
@@ -137,7 +137,7 @@ func (p *PyrolisisTests) CleanupVolumes(t *testing.T) {
 	for _, vol := range allVolumes {
 		if strings.HasPrefix(vol.Name, "kubernetes-dynamic-pvc-") &&
 			strings.HasPrefix(vol.Metadata["kubernetes.io/created-for/pvc/namespace"], "e2e-volumes-") {
-			err := volumes.Delete(storageClient, vol.ID).ExtractErr()
+			err := volumes.Delete(storageClient, vol.ID, volumes.DeleteOpts{}).ExtractErr()
 			require.NoError(t, err, "There should be no error while deleting volume %s (%s)", vol.Name, vol.ID)
 		}
 	}

--- a/vendor/github.com/gophercloud/gophercloud/auth_options.go
+++ b/vendor/github.com/gophercloud/gophercloud/auth_options.go
@@ -84,6 +84,12 @@ type AuthOptions struct {
 
 	// Scope determines the scoping of the authentication request.
 	Scope *AuthScope `json:"-"`
+
+	// Authentication through Application Credentials requires supplying name, project and secret
+	// For project we can use TenantID
+	ApplicationCredentialID     string `json:"-"`
+	ApplicationCredentialName   string `json:"-"`
+	ApplicationCredentialSecret string `json:"-"`
 }
 
 // AuthScope allows a created token to be limited to a specific domain or project.
@@ -142,7 +148,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 	type userReq struct {
 		ID       *string    `json:"id,omitempty"`
 		Name     *string    `json:"name,omitempty"`
-		Password string     `json:"password"`
+		Password string     `json:"password,omitempty"`
 		Domain   *domainReq `json:"domain,omitempty"`
 	}
 
@@ -154,10 +160,18 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 		ID string `json:"id"`
 	}
 
+	type applicationCredentialReq struct {
+		ID     *string  `json:"id,omitempty"`
+		Name   *string  `json:"name,omitempty"`
+		User   *userReq `json:"user,omitempty"`
+		Secret *string  `json:"secret,omitempty"`
+	}
+
 	type identityReq struct {
-		Methods  []string     `json:"methods"`
-		Password *passwordReq `json:"password,omitempty"`
-		Token    *tokenReq    `json:"token,omitempty"`
+		Methods               []string                  `json:"methods"`
+		Password              *passwordReq              `json:"password,omitempty"`
+		Token                 *tokenReq                 `json:"token,omitempty"`
+		ApplicationCredential *applicationCredentialReq `json:"application_credential,omitempty"`
 	}
 
 	type authReq struct {
@@ -171,6 +185,7 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 	// Populate the request structure based on the provided arguments. Create and return an error
 	// if insufficient or incompatible information is present.
 	var req request
+	var userRequest userReq
 
 	if opts.Password == "" {
 		if opts.TokenID != "" {
@@ -194,8 +209,49 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 			req.Auth.Identity.Token = &tokenReq{
 				ID: opts.TokenID,
 			}
+
+		} else if opts.ApplicationCredentialID != "" {
+			// Configure the request for ApplicationCredentialID authentication.
+			// https://github.com/openstack/keystoneauth/blob/stable/rocky/keystoneauth1/identity/v3/application_credential.py#L48-L67
+			// There are three kinds of possible application_credential requests
+			// 1. application_credential id + secret
+			// 2. application_credential name + secret + user_id
+			// 3. application_credential name + secret + username + domain_id / domain_name
+			if opts.ApplicationCredentialSecret == "" {
+				return nil, ErrAppCredMissingSecret{}
+			}
+			req.Auth.Identity.Methods = []string{"application_credential"}
+			req.Auth.Identity.ApplicationCredential = &applicationCredentialReq{
+				ID:     &opts.ApplicationCredentialID,
+				Secret: &opts.ApplicationCredentialSecret,
+			}
+		} else if opts.ApplicationCredentialName != "" {
+			if opts.ApplicationCredentialSecret == "" {
+				return nil, ErrAppCredMissingSecret{}
+			}
+			// make sure that only one of DomainName or DomainID were provided
+			if opts.DomainID == "" && opts.DomainName == "" {
+				return nil, ErrDomainIDOrDomainName{}
+			}
+			req.Auth.Identity.Methods = []string{"application_credential"}
+			if opts.DomainID != "" {
+				userRequest = userReq{
+					Name:   &opts.Username,
+					Domain: &domainReq{ID: &opts.DomainID},
+				}
+			} else if opts.DomainName != "" {
+				userRequest = userReq{
+					Name:   &opts.Username,
+					Domain: &domainReq{Name: &opts.DomainName},
+				}
+			}
+			req.Auth.Identity.ApplicationCredential = &applicationCredentialReq{
+				Name:   &opts.ApplicationCredentialName,
+				User:   &userRequest,
+				Secret: &opts.ApplicationCredentialSecret,
+			}
 		} else {
-			// If no password or token ID are available, authentication can't continue.
+			// If no password or token ID or ApplicationCredential are available, authentication can't continue.
 			return nil, ErrMissingPassword{}
 		}
 	} else {

--- a/vendor/github.com/gophercloud/gophercloud/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/doc.go
@@ -41,7 +41,7 @@ pass in the parent provider, like so:
 
   opts := gophercloud.EndpointOpts{Region: "RegionOne"}
 
-  client := openstack.NewComputeV2(provider, opts)
+  client, err := openstack.NewComputeV2(provider, opts)
 
 Resources
 

--- a/vendor/github.com/gophercloud/gophercloud/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/errors.go
@@ -451,3 +451,10 @@ type ErrScopeEmpty struct{ BaseError }
 func (e ErrScopeEmpty) Error() string {
 	return "You must provide either a Project or Domain in a Scope"
 }
+
+// ErrAppCredMissingSecret indicates that no Application Credential Secret was provided with Application Credential ID or Name
+type ErrAppCredMissingSecret struct{ BaseError }
+
+func (e ErrAppCredMissingSecret) Error() string {
+	return "You must provide an Application Credential Secret"
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
@@ -38,6 +38,9 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	tenantName := os.Getenv("OS_TENANT_NAME")
 	domainID := os.Getenv("OS_DOMAIN_ID")
 	domainName := os.Getenv("OS_DOMAIN_NAME")
+	applicationCredentialID := os.Getenv("OS_APPLICATION_CREDENTIAL_ID")
+	applicationCredentialName := os.Getenv("OS_APPLICATION_CREDENTIAL_NAME")
+	applicationCredentialSecret := os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
 
 	// If OS_PROJECT_ID is set, overwrite tenantID with the value.
 	if v := os.Getenv("OS_PROJECT_ID"); v != "" {
@@ -63,22 +66,32 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		return nilOptions, err
 	}
 
-	if password == "" {
+	if password == "" && applicationCredentialID == "" && applicationCredentialName == "" {
 		err := gophercloud.ErrMissingEnvironmentVariable{
 			EnvironmentVariable: "OS_PASSWORD",
 		}
 		return nilOptions, err
 	}
 
+	if (applicationCredentialID != "" || applicationCredentialName != "") && applicationCredentialSecret == "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_APPLICATION_CREDENTIAL_SECRET",
+		}
+		return nilOptions, err
+	}
+
 	ao := gophercloud.AuthOptions{
-		IdentityEndpoint: authURL,
-		UserID:           userID,
-		Username:         username,
-		Password:         password,
-		TenantID:         tenantID,
-		TenantName:       tenantName,
-		DomainID:         domainID,
-		DomainName:       domainName,
+		IdentityEndpoint:            authURL,
+		UserID:                      userID,
+		Username:                    username,
+		Password:                    password,
+		TenantID:                    tenantID,
+		TenantName:                  tenantName,
+		DomainID:                    domainID,
+		DomainName:                  domainName,
+		ApplicationCredentialID:     applicationCredentialID,
+		ApplicationCredentialName:   applicationCredentialName,
+		ApplicationCredentialSecret: applicationCredentialSecret,
 	}
 
 	return ao, nil

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/doc.go
@@ -31,5 +31,12 @@ Example to Update a Quota Set
 	}
 
 	fmt.Printf("%+v\n", quotaset)
+
+Example to Delete a Quota Set
+
+	err := quotasets.Delete(blockStorageClient, "project-id").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package quotasets

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/results.go
@@ -157,3 +157,9 @@ func (r quotaUsageResult) Extract() (QuotaUsageSet, error) {
 	err := r.ExtractInto(&s)
 	return s.QuotaUsageSet, err
 }
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/urls.go
@@ -15,3 +15,7 @@ func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
 func updateURL(c *gophercloud.ServiceClient, projectID string) string {
 	return getURL(c, projectID)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, projectID string) string {
+	return getURL(c, projectID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -414,3 +414,14 @@ func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoint
 	sc.ResourceBase = sc.Endpoint + "v1/"
 	return sc, err
 }
+
+// NewContainerInfraV1 creates a ServiceClient that may be used with the v1 container infra management
+// package.
+func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "container-infra")
+}
+
+// NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
+func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "workflowv2")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/requests.go
@@ -23,18 +23,13 @@ func ListByServer(client *gophercloud.ServiceClient, serverID string) pagination
 	return commonList(client, listByServerURL(client, serverID))
 }
 
-// GroupOpts is the underlying struct responsible for creating or updating
-// security groups. It therefore represents the mutable attributes of a
-// security group.
-type GroupOpts struct {
+// CreateOpts is the struct responsible for creating a security group.
+type CreateOpts struct {
 	// the name of your security group.
 	Name string `json:"name" required:"true"`
 	// the description of your security group.
-	Description string `json:"description" required:"true"`
+	Description string `json:"description,omitempty"`
 }
-
-// CreateOpts is the struct responsible for creating a security group.
-type CreateOpts GroupOpts
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
@@ -61,7 +56,12 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r Create
 }
 
 // UpdateOpts is the struct responsible for updating an existing security group.
-type UpdateOpts GroupOpts
+type UpdateOpts struct {
+	// the name of your security group.
+	Name string `json:"name,omitempty"`
+	// the description of your security group.
+	Description *string `json:"description,omitempty"`
+}
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups/results.go
@@ -72,7 +72,7 @@ type Rule struct {
 	IPRange IPRange `json:"ip_range"`
 
 	// The security group ID to which this rule belongs.
-	ParentGroupID string `json:"parent_group_id"`
+	ParentGroupID string `json:"-"`
 
 	// Not documented.
 	Group Group

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/requests.go
@@ -52,6 +52,14 @@ type ListOpts struct {
 	MinDisk int `q:"minDisk"`
 	MinRAM  int `q:"minRam"`
 
+	// SortDir allows to select sort direction.
+	// It can be "asc" or "desc" (default).
+	SortDir string `q:"sort_dir"`
+
+	// SortKey allows to sort by one of the flavors attributes.
+	// Default is flavorid.
+	SortKey string `q:"sort_key"`
+
 	// Marker and Limit control paging.
 	// Marker instructs List where to start listing from.
 	Marker string `q:"marker"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/results.go
@@ -59,7 +59,7 @@ type Flavor struct {
 	RxTxFactor float64 `json:"rxtx_factor"`
 
 	// Swap is the amount of swap space, measured in MB.
-	Swap int `json:"swap"`
+	Swap int `json:"-"`
 
 	// VCPUs indicates how many (virtual) CPUs are available for this flavor.
 	VCPUs int `json:"vcpus"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -383,7 +383,7 @@ type RebootOpts struct {
 }
 
 // ToServerRebootMap builds a body for the reboot request.
-func (opts *RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
+func (opts RebootOpts) ToServerRebootMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(opts, "reboot")
 }
 
@@ -542,39 +542,6 @@ func ConfirmResize(client *gophercloud.ServiceClient, id string) (r ActionResult
 // See Resize() for more details.
 func RevertResize(client *gophercloud.ServiceClient, id string) (r ActionResult) {
 	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"revertResize": nil}, nil, nil)
-	return
-}
-
-// RescueOptsBuilder is an interface that allows extensions to override the
-// default structure of a Rescue request.
-type RescueOptsBuilder interface {
-	ToServerRescueMap() (map[string]interface{}, error)
-}
-
-// RescueOpts represents the configuration options used to control a Rescue
-// option.
-type RescueOpts struct {
-	// AdminPass is the desired administrative password for the instance in
-	// RESCUE mode. If it's left blank, the server will generate a password.
-	AdminPass string `json:"adminPass,omitempty"`
-}
-
-// ToServerRescueMap formats a RescueOpts as a map that can be used as a JSON
-// request body for the Rescue request.
-func (opts RescueOpts) ToServerRescueMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "rescue")
-}
-
-// Rescue instructs the provider to place the server into RESCUE mode.
-func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder) (r RescueResult) {
-	b, err := opts.ToServerRescueMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
-	})
 	return
 }
 
@@ -756,7 +723,12 @@ func CreateImage(client *gophercloud.ServiceClient, id string, opts CreateImageO
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	allPages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	allPages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/results.go
@@ -68,12 +68,6 @@ type ActionResult struct {
 	gophercloud.ErrResult
 }
 
-// RescueResult is the response from a Rescue operation. Call its ExtractErr
-// method to determine if the call succeeded or failed.
-type RescueResult struct {
-	ActionResult
-}
-
 // CreateImageResult is the response from a CreateImage operation. Call its
 // ExtractImageID method to retrieve the ID of the newly created image.
 type CreateImageResult struct {
@@ -147,15 +141,6 @@ func (r CreateImageResult) ExtractImageID() (string, error) {
 		return "", fmt.Errorf("Failed to parse the ID of newly created image: %s", u)
 	}
 	return imageID, nil
-}
-
-// Extract interprets any RescueResult as an AdminPass, if possible.
-func (r RescueResult) Extract() (string, error) {
-	var s struct {
-		AdminPass string `json:"adminPass"`
-	}
-	err := r.ExtractInto(&s)
-	return s.AdminPass, err
 }
 
 // Server represents a server/instance in the OpenStack cloud.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v2/tenants/requests.go
@@ -85,7 +85,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Description is the description of the tenant.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// Enabled sets the tenant status to enabled or disabled.
 	Enabled *bool `json:"enabled,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/groups/requests.go
@@ -133,7 +133,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Description is a description of the group.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// DomainID is the ID of the domain the group belongs to.
 	DomainID string `json:"domain_id,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/projects/requests.go
@@ -152,7 +152,7 @@ type UpdateOpts struct {
 	ParentID string `json:"parent_id,omitempty"`
 
 	// Description is the description of the project.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToUpdateCreateMap formats a UpdateOpts into an update request.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/requests.go
@@ -52,19 +52,28 @@ type AuthOptions struct {
 	// authentication token ID.
 	TokenID string `json:"-"`
 
+	// Authentication through Application Credentials requires supplying name, project and secret
+	// For project we can use TenantID
+	ApplicationCredentialID     string `json:"-"`
+	ApplicationCredentialName   string `json:"-"`
+	ApplicationCredentialSecret string `json:"-"`
+
 	Scope Scope `json:"-"`
 }
 
 // ToTokenV3CreateMap builds a request body from AuthOptions.
 func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[string]interface{}, error) {
 	gophercloudAuthOpts := gophercloud.AuthOptions{
-		Username:    opts.Username,
-		UserID:      opts.UserID,
-		Password:    opts.Password,
-		DomainID:    opts.DomainID,
-		DomainName:  opts.DomainName,
-		AllowReauth: opts.AllowReauth,
-		TokenID:     opts.TokenID,
+		Username:                    opts.Username,
+		UserID:                      opts.UserID,
+		Password:                    opts.Password,
+		DomainID:                    opts.DomainID,
+		DomainName:                  opts.DomainName,
+		AllowReauth:                 opts.AllowReauth,
+		TokenID:                     opts.TokenID,
+		ApplicationCredentialID:     opts.ApplicationCredentialID,
+		ApplicationCredentialName:   opts.ApplicationCredentialName,
+		ApplicationCredentialSecret: opts.ApplicationCredentialSecret,
 	}
 
 	return gophercloudAuthOpts.ToTokenV3CreateMap(scope)

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/users/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/users/requests.go
@@ -178,7 +178,7 @@ type UpdateOpts struct {
 	DefaultProjectID string `json:"default_project_id,omitempty"`
 
 	// Description is a description of the user.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// DomainID is the ID of the domain the user belongs to.
 	DomainID string `json:"domain_id,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -13,6 +13,7 @@ import (
 type ListOpts struct {
 	ID           string `q:"id"`
 	Name         string `q:"name"`
+	Description  string `q:"description"`
 	AdminStateUp *bool  `q:"admin_state_up"`
 	Distributed  *bool  `q:"distributed"`
 	Status       string `q:"status"`
@@ -22,6 +23,10 @@ type ListOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -51,6 +56,7 @@ type CreateOptsBuilder interface {
 // no required values.
 type CreateOpts struct {
 	Name                  string       `json:"name,omitempty"`
+	Description           string       `json:"description,omitempty"`
 	AdminStateUp          *bool        `json:"admin_state_up,omitempty"`
 	Distributed           *bool        `json:"distributed,omitempty"`
 	TenantID              string       `json:"tenant_id,omitempty"`
@@ -97,6 +103,7 @@ type UpdateOptsBuilder interface {
 // UpdateOpts contains the values used when updating a router.
 type UpdateOpts struct {
 	Name         string       `json:"name,omitempty"`
+	Description  *string      `json:"description,omitempty"`
 	AdminStateUp *bool        `json:"admin_state_up,omitempty"`
 	Distributed  *bool        `json:"distributed,omitempty"`
 	GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -51,6 +51,9 @@ type Router struct {
 	// unique.
 	Name string `json:"name"`
 
+	// Description for the router.
+	Description string `json:"description"`
+
 	// ID is the unique identifier for the router.
 	ID string `json:"id"`
 
@@ -67,6 +70,9 @@ type Router struct {
 	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
 	// Used to make network resources highly available.
 	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // RouterPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
@@ -11,14 +11,19 @@ import (
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID        string `q:"id"`
-	Name      string `q:"name"`
-	TenantID  string `q:"tenant_id"`
-	ProjectID string `q:"project_id"`
-	Limit     int    `q:"limit"`
-	Marker    string `q:"marker"`
-	SortKey   string `q:"sort_key"`
-	SortDir   string `q:"sort_dir"`
+	ID          string `q:"id"`
+	Name        string `q:"name"`
+	Description string `q:"description"`
+	TenantID    string `q:"tenant_id"`
+	ProjectID   string `q:"project_id"`
+	Limit       int    `q:"limit"`
+	Marker      string `q:"marker"`
+	SortKey     string `q:"sort_key"`
+	SortDir     string `q:"sort_dir"`
+	Tags        string `q:"tags"`
+	TagsAny     string `q:"tags-any"`
+	NotTags     string `q:"not-tags"`
+	NotTagsAny  string `q:"not-tags-any"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -88,7 +93,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Describes the security group.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToSecGroupUpdateMap builds a request body from UpdateOpts.
@@ -128,7 +133,12 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, ListOpts{}).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -27,6 +27,9 @@ type SecGroup struct {
 
 	// ProjectID is the project owner of the security group.
 	ProjectID string `json:"project_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // SecGroupPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -14,6 +14,7 @@ type ListOpts struct {
 	Direction      string `q:"direction"`
 	EtherType      string `q:"ethertype"`
 	ID             string `q:"id"`
+	Description    string `q:"description"`
 	PortRangeMax   int    `q:"port_range_max"`
 	PortRangeMin   int    `q:"port_range_min"`
 	Protocol       string `q:"protocol"`
@@ -87,6 +88,9 @@ type CreateOpts struct {
 	// Must be either "ingress" or "egress": the direction in which the security
 	// group rule is applied.
 	Direction RuleDirection `json:"direction" required:"true"`
+
+	// String description of each rule, optional
+	Description string `json:"description,omitempty"`
 
 	// Must be "IPv4" or "IPv6", and addresses represented in CIDR must match the
 	// ingress or egress rules.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -17,6 +17,9 @@ type SecGroupRule struct {
 	// instance. An egress rule is applied to traffic leaving the instance.
 	Direction string
 
+	// Descripton of the rule
+	Description string `json:"description"`
+
 	// Must be IPv4 or IPv6, and addresses represented in CIDR must match the
 	// ingress or egress rules.
 	EtherType string `json:"ethertype"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/requests.go
@@ -19,6 +19,7 @@ type ListOptsBuilder interface {
 type ListOpts struct {
 	Status       string `q:"status"`
 	Name         string `q:"name"`
+	Description  string `q:"description"`
 	AdminStateUp *bool  `q:"admin_state_up"`
 	TenantID     string `q:"tenant_id"`
 	ProjectID    string `q:"project_id"`
@@ -28,6 +29,10 @@ type ListOpts struct {
 	Limit        int    `q:"limit"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.
@@ -69,6 +74,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	AdminStateUp          *bool    `json:"admin_state_up,omitempty"`
 	Name                  string   `json:"name,omitempty"`
+	Description           string   `json:"description,omitempty"`
 	Shared                *bool    `json:"shared,omitempty"`
 	TenantID              string   `json:"tenant_id,omitempty"`
 	ProjectID             string   `json:"project_id,omitempty"`
@@ -105,9 +111,10 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents options used to update a network.
 type UpdateOpts struct {
-	AdminStateUp *bool  `json:"admin_state_up,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Shared       *bool  `json:"shared,omitempty"`
+	AdminStateUp *bool   `json:"admin_state_up,omitempty"`
+	Name         string  `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	Shared       *bool   `json:"shared,omitempty"`
 }
 
 // ToNetworkUpdateMap builds a request body from UpdateOpts.
@@ -140,7 +147,12 @@ func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/networks/results.go
@@ -52,6 +52,9 @@ type Network struct {
 	// Human-readable name for the network. Might not be unique.
 	Name string `json:"name"`
 
+	// Description for the network
+	Description string `json:"description"`
+
 	// The administrative state of network. If false (down), the network does not
 	// forward packets.
 	AdminStateUp bool `json:"admin_state_up"`
@@ -76,6 +79,9 @@ type Network struct {
 	// Availability zone hints groups network nodes that run services like DHCP, L3, FW, and others.
 	// Used to make network resources highly available.
 	AvailabilityZoneHints []string `json:"availability_zone_hints"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // NetworkPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -19,6 +19,7 @@ type ListOptsBuilder interface {
 type ListOpts struct {
 	Status       string `q:"status"`
 	Name         string `q:"name"`
+	Description  string `q:"description"`
 	AdminStateUp *bool  `q:"admin_state_up"`
 	NetworkID    string `q:"network_id"`
 	TenantID     string `q:"tenant_id"`
@@ -31,6 +32,10 @@ type ListOpts struct {
 	Marker       string `q:"marker"`
 	SortKey      string `q:"sort_key"`
 	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -76,6 +81,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	NetworkID           string        `json:"network_id" required:"true"`
 	Name                string        `json:"name,omitempty"`
+	Description         string        `json:"description,omitempty"`
 	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
 	MACAddress          string        `json:"mac_address,omitempty"`
 	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
@@ -112,11 +118,12 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents the attributes used when updating an existing port.
 type UpdateOpts struct {
-	Name                string         `json:"name,omitempty"`
+	Name                *string        `json:"name,omitempty"`
+	Description         *string        `json:"description,omitempty"`
 	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
 	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
-	DeviceID            string         `json:"device_id,omitempty"`
-	DeviceOwner         string         `json:"device_owner,omitempty"`
+	DeviceID            *string        `json:"device_id,omitempty"`
+	DeviceOwner         *string        `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
 }
@@ -151,7 +158,12 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
@@ -68,6 +68,9 @@ type Port struct {
 	// Human-readable name for the port. Might not be unique.
 	Name string `json:"name"`
 
+	// Describes the port.
+	Description string `json:"description"`
+
 	// Administrative state of port. If false (down), port does not forward
 	// packets.
 	AdminStateUp bool `json:"admin_state_up"`
@@ -101,6 +104,9 @@ type Port struct {
 
 	// Identifies the list of IP addresses the port will recognize/accept
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // PortPage is the page returned by a pager when traversing over a collection

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/requests.go
@@ -18,6 +18,7 @@ type ListOptsBuilder interface {
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	Name            string `q:"name"`
+	Description     string `q:"description"`
 	EnableDHCP      *bool  `q:"enable_dhcp"`
 	NetworkID       string `q:"network_id"`
 	TenantID        string `q:"tenant_id"`
@@ -33,6 +34,10 @@ type ListOpts struct {
 	Marker          string `q:"marker"`
 	SortKey         string `q:"sort_key"`
 	SortDir         string `q:"sort_dir"`
+	Tags            string `q:"tags"`
+	TagsAny         string `q:"tags-any"`
+	NotTags         string `q:"not-tags"`
+	NotTagsAny      string `q:"not-tags-any"`
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string.
@@ -84,6 +89,9 @@ type CreateOpts struct {
 
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`
+
+	// Description of the subnet.
+	Description string `json:"description,omitempty"`
 
 	// The UUID of the project who owns the Subnet. Only administrative users
 	// can specify a project UUID other than their own.
@@ -163,6 +171,9 @@ type UpdateOpts struct {
 	// Name is a human-readable name of the subnet.
 	Name string `json:"name,omitempty"`
 
+	// Description of the subnet.
+	Description *string `json:"description,omitempty"`
+
 	// AllocationPools are IP Address pools that will be available for DHCP.
 	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`
 
@@ -221,7 +232,12 @@ func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
 	count := 0
 	id := ""
-	pages, err := List(client, nil).AllPages()
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets/results.go
@@ -68,6 +68,9 @@ type Subnet struct {
 	// Human-readable name for the subnet. Might not be unique.
 	Name string `json:"name"`
 
+	// Description for the subnet.
+	Description string `json:"description"`
+
 	// IP version, either `4' or `6'.
 	IPVersion int `json:"ip_version"`
 
@@ -106,6 +109,9 @@ type Subnet struct {
 
 	// SubnetPoolID is the id of the subnet pool associated with the subnet.
 	SubnetPoolID string `json:"subnetpool_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
@@ -74,6 +74,7 @@ type CreateOpts struct {
 	DetectContentType bool   `h:"X-Detect-Content-Type"`
 	IfNoneMatch       string `h:"If-None-Match"`
 	VersionsLocation  string `h:"X-Versions-Location"`
+	HistoryLocation   string `h:"X-History-Location"`
 }
 
 // ToContainerCreateMap formats a CreateOpts into a map of headers.
@@ -137,6 +138,8 @@ type UpdateOpts struct {
 	DetectContentType      bool   `h:"X-Detect-Content-Type"`
 	RemoveVersionsLocation string `h:"X-Remove-Versions-Location"`
 	VersionsLocation       string `h:"X-Versions-Location"`
+	RemoveHistoryLocation  string `h:"X-Remove-History-Location"`
+	HistoryLocation        string `h:"X-History-Location"`
 }
 
 // ToContainerUpdateMap formats a UpdateOpts into a map of headers.
@@ -177,12 +180,41 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 	return
 }
 
+// GetOptsBuilder allows extensions to add additional parameters to the Get
+// request.
+type GetOptsBuilder interface {
+	ToContainerGetMap() (map[string]string, error)
+}
+
+// GetOpts is a structure that holds options for listing containers.
+type GetOpts struct {
+	Newest bool `h:"X-Newest"`
+}
+
+// ToContainerGetMap formats a GetOpts into a map of headers.
+func (opts GetOpts) ToContainerGetMap() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
 // Get is a function that retrieves the metadata of a container. To extract just
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
-func Get(c *gophercloud.ServiceClient, containerName string) (r GetResult) {
+func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder) (r GetResult) {
+	h := make(map[string]string)
+	if opts != nil {
+		headers, err := opts.ToContainerGetMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+
+		for k, v := range headers {
+			h[k] = v
+		}
+	}
 	resp, err := c.Head(getURL(c, containerName), &gophercloud.RequestOpts{
-		OkCodes: []int{200, 204},
+		MoreHeaders: h,
+		OkCodes:     []int{200, 204},
 	})
 	if resp != nil {
 		r.Header = resp.Header

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
@@ -100,6 +100,7 @@ type GetHeader struct {
 	Read             []string  `json:"-"`
 	TransID          string    `json:"X-Trans-Id"`
 	VersionsLocation string    `json:"X-Versions-Location"`
+	HistoryLocation  string    `json:"X-History-Location"`
 	Write            []string  `json:"-"`
 	StoragePolicy    string    `json:"X-Storage-Policy"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -85,6 +86,7 @@ type DownloadOpts struct {
 	IfModifiedSince   time.Time `h:"If-Modified-Since"`
 	IfNoneMatch       string    `h:"If-None-Match"`
 	IfUnmodifiedSince time.Time `h:"If-Unmodified-Since"`
+	Newest            bool      `h:"X-Newest"`
 	Range             string    `h:"Range"`
 	Expires           string    `q:"expires"`
 	MultipartManifest string    `q:"multipart-manifest"`
@@ -189,16 +191,28 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 		return opts.Content, h, q.String(), nil
 	}
 
+	// When we're dealing with big files an io.ReadSeeker allows us to efficiently calculate
+	// the md5 sum. An io.Reader is only readable once which means we have to copy the entire
+	// file content into memory first.
+	readSeeker, isReadSeeker := opts.Content.(io.ReadSeeker)
+	if !isReadSeeker {
+		data, err := ioutil.ReadAll(opts.Content)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		readSeeker = bytes.NewReader(data)
+	}
+
 	hash := md5.New()
-	buf := bytes.NewBuffer([]byte{})
-	_, err = io.Copy(io.MultiWriter(hash, buf), opts.Content)
-	if err != nil {
+	// io.Copy into md5 is very efficient as it's done in small chunks.
+	if _, err := io.Copy(hash, readSeeker); err != nil {
 		return nil, nil, "", err
 	}
-	localChecksum := fmt.Sprintf("%x", hash.Sum(nil))
-	h["ETag"] = localChecksum
+	readSeeker.Seek(0, io.SeekStart)
 
-	return buf, h, q.String(), nil
+	h["ETag"] = fmt.Sprintf("%x", hash.Sum(nil))
+
+	return readSeeker, h, q.String(), nil
 }
 
 // Create is a function that creates a new object or replaces an existing
@@ -325,20 +339,28 @@ func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts
 // GetOptsBuilder allows extensions to add additional parameters to the
 // Get request.
 type GetOptsBuilder interface {
-	ToObjectGetQuery() (string, error)
+	ToObjectGetParams() (map[string]string, string, error)
 }
 
 // GetOpts is a structure that holds parameters for getting an object's
 // metadata.
 type GetOpts struct {
+	Newest    bool   `h:"X-Newest"`
 	Expires   string `q:"expires"`
 	Signature string `q:"signature"`
 }
 
-// ToObjectGetQuery formats a GetOpts into a query string.
-func (opts GetOpts) ToObjectGetQuery() (string, error) {
+// ToObjectGetParams formats a GetOpts into a query string and a map of headers.
+func (opts GetOpts) ToObjectGetParams() (map[string]string, string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
-	return q.String(), err
+	if err != nil {
+		return nil, "", err
+	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, q.String(), err
+	}
+	return h, q.String(), nil
 }
 
 // Get is a function that retrieves the metadata of an object. To extract just
@@ -346,16 +368,22 @@ func (opts GetOpts) ToObjectGetQuery() (string, error) {
 // function.
 func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts GetOptsBuilder) (r GetResult) {
 	url := getURL(c, containerName, objectName)
+	h := make(map[string]string)
 	if opts != nil {
-		query, err := opts.ToObjectGetQuery()
+		headers, query, err := opts.ToObjectGetParams()
 		if err != nil {
 			r.Err = err
 			return
 		}
+		for k, v := range headers {
+			h[k] = v
+		}
 		url += query
 	}
+
 	resp, err := c.Head(url, &gophercloud.RequestOpts{
-		OkCodes: []int{200, 204},
+		MoreHeaders: h,
+		OkCodes:     []int{200, 204},
 	})
 	if resp != nil {
 		r.Header = resp.Header

--- a/vendor/github.com/gophercloud/gophercloud/openstack/utils/base_endpoint.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/utils/base_endpoint.go
@@ -9,21 +9,20 @@ import (
 // BaseEndpoint will return a URL without the /vX.Y
 // portion of the URL.
 func BaseEndpoint(endpoint string) (string, error) {
-	var base string
-
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return base, err
+		return "", err
 	}
 
 	u.RawQuery, u.Fragment = "", ""
 
+	path := u.Path
 	versionRe := regexp.MustCompile("v[0-9.]+/?")
-	if version := versionRe.FindString(u.Path); version != "" {
-		base = strings.Replace(u.String(), version, "", -1)
-	} else {
-		base = u.String()
+
+	if version := versionRe.FindString(path); version != "" {
+		versionIndex := strings.Index(path, version)
+		u.Path = path[:versionIndex]
 	}
 
-	return base, nil
+	return u.String(), nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/pagination/pager.go
+++ b/vendor/github.com/gophercloud/gophercloud/pagination/pager.go
@@ -41,6 +41,8 @@ type Pager struct {
 
 	createPage func(r PageResult) Page
 
+	firstPage Page
+
 	Err error
 
 	// Headers supplies additional HTTP headers to populate on each paged request.
@@ -89,9 +91,18 @@ func (p Pager) EachPage(handler func(Page) (bool, error)) error {
 	}
 	currentURL := p.initialURL
 	for {
-		currentPage, err := p.fetchNextPage(currentURL)
-		if err != nil {
-			return err
+		var currentPage Page
+
+		// if first page has already been fetched, no need to fetch it again
+		if p.firstPage != nil {
+			currentPage = p.firstPage
+			p.firstPage = nil
+		} else {
+			var err error
+			currentPage, err = p.fetchNextPage(currentURL)
+			if err != nil {
+				return err
+			}
 		}
 
 		empty, err := currentPage.IsEmpty()
@@ -128,23 +139,26 @@ func (p Pager) AllPages() (Page, error) {
 	// body will contain the final concatenated Page body.
 	var body reflect.Value
 
-	// Grab a test page to ascertain the page body type.
-	testPage, err := p.fetchNextPage(p.initialURL)
+	// Grab a first page to ascertain the page body type.
+	firstPage, err := p.fetchNextPage(p.initialURL)
 	if err != nil {
 		return nil, err
 	}
 	// Store the page type so we can use reflection to create a new mega-page of
 	// that type.
-	pageType := reflect.TypeOf(testPage)
+	pageType := reflect.TypeOf(firstPage)
 
-	// if it's a single page, just return the testPage (first page)
+	// if it's a single page, just return the firstPage (first page)
 	if _, found := pageType.FieldByName("SinglePageBase"); found {
-		return testPage, nil
+		return firstPage, nil
 	}
+
+	// store the first page to avoid getting it twice
+	p.firstPage = firstPage
 
 	// Switch on the page body type. Recognized types are `map[string]interface{}`,
 	// `[]byte`, and `[]interface{}`.
-	switch pb := testPage.GetBody().(type) {
+	switch pb := firstPage.GetBody().(type) {
 	case map[string]interface{}:
 		// key is the map key for the page body if the body type is `map[string]interface{}`.
 		var key string

--- a/vendor/github.com/gophercloud/gophercloud/params.go
+++ b/vendor/github.com/gophercloud/gophercloud/params.go
@@ -120,6 +120,22 @@ func BuildRequestBody(opts interface{}, parent string) (map[string]interface{}, 
 				continue
 			}
 
+			if v.Kind() == reflect.Slice || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Slice) {
+				sliceValue := v
+				if sliceValue.Kind() == reflect.Ptr {
+					sliceValue = sliceValue.Elem()
+				}
+
+				for i := 0; i < sliceValue.Len(); i++ {
+					element := sliceValue.Index(i)
+					if element.Kind() == reflect.Struct || (element.Kind() == reflect.Ptr && element.Elem().Kind() == reflect.Struct) {
+						_, err := BuildRequestBody(element.Interface(), "")
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+			}
 			if v.Kind() == reflect.Struct || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct) {
 				if zero {
 					//fmt.Printf("value before change: %+v\n", optsValue.Field(i))

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -126,11 +126,11 @@ func (client *ProviderClient) SetToken(t string) {
 	client.TokenID = t
 }
 
-//Reauthenticate calls client.ReauthFunc in a thread-safe way. If this is
-//called because of a 401 response, the caller may pass the previous token. In
-//this case, the reauthentication can be skipped if another thread has already
-//reauthenticated in the meantime. If no previous token is known, an empty
-//string should be passed instead to force unconditional reauthentication.
+// Reauthenticate calls client.ReauthFunc in a thread-safe way. If this is
+// called because of a 401 response, the caller may pass the previous token. In
+// this case, the reauthentication can be skipped if another thread has already
+// reauthenticated in the meantime. If no previous token is known, an empty
+// string should be passed instead to force unconditional reauthentication.
 func (client *ProviderClient) Reauthenticate(previousToken string) (err error) {
 	if client.ReauthFunc == nil {
 		return nil
@@ -378,7 +378,7 @@ func defaultOkCodes(method string) []int {
 	case method == "PUT":
 		return []int{201, 202}
 	case method == "PATCH":
-		return []int{200, 204}
+		return []int{200, 202, 204}
 	case method == "DELETE":
 		return []int{202, 204}
 	}

--- a/vendor/github.com/gophercloud/gophercloud/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/results.go
@@ -89,23 +89,47 @@ func (r Result) extractIntoPtr(to interface{}, label string) error {
 		if typeOfV.Kind() == reflect.Struct {
 			if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
 				newSlice := reflect.MakeSlice(reflect.SliceOf(typeOfV), 0, 0)
-				newType := reflect.New(typeOfV).Elem()
 
-				for _, v := range m[label].([]interface{}) {
-					b, err := json.Marshal(v)
-					if err != nil {
-						return err
-					}
+				if mSlice, ok := m[label].([]interface{}); ok {
+					for _, v := range mSlice {
+						// For each iteration of the slice, we create a new struct.
+						// This is to work around a bug where elements of a slice
+						// are reused and not overwritten when the same copy of the
+						// struct is used:
+						//
+						// https://github.com/golang/go/issues/21092
+						// https://github.com/golang/go/issues/24155
+						// https://play.golang.org/p/NHo3ywlPZli
+						newType := reflect.New(typeOfV).Elem()
 
-					for i := 0; i < newType.NumField(); i++ {
-						s := newType.Field(i).Addr().Interface()
-						err = json.NewDecoder(bytes.NewReader(b)).Decode(s)
+						b, err := json.Marshal(v)
 						if err != nil {
 							return err
 						}
+
+						// This is needed for structs with an UnmarshalJSON method.
+						// Technically this is just unmarshalling the response into
+						// a struct that is never used, but it's good enough to
+						// trigger the UnmarshalJSON method.
+						for i := 0; i < newType.NumField(); i++ {
+							s := newType.Field(i).Addr().Interface()
+
+							// Unmarshal is used rather than NewDecoder to also work
+							// around the above-mentioned bug.
+							err = json.Unmarshal(b, s)
+							if err != nil {
+								return err
+							}
+						}
+
+						newSlice = reflect.Append(newSlice, newType)
 					}
-					newSlice = reflect.Append(newSlice, newType)
 				}
+
+				// "to" should now be properly modeled to receive the
+				// JSON response body and unmarshal into all the correct
+				// fields of the struct or composed extension struct
+				// at the end of this method.
 				toValue.Set(newSlice)
 			}
 		}


### PR DESCRIPTION
This PR checks for free space in object store on kluster creation, object store is needed for etcd backup. It also updates gophercloud to a recent version to get quota details.