### PR TITLE
Fixes etcd backup reauth and migrates existing klusters

### DIFF
--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -22,7 +22,7 @@ resources:
 backup:
   image:
     repository: sapcc/etcdbrctl
-    tag: 0.3.1
+    tag: 0.4.1
     pullPolicy: IfNotPresent
   config:
     # do a full-backup every hour
@@ -40,5 +40,5 @@ backup:
       cpu: 100m
       memory: 128Mi
     limits:
-      cpu: 300m
-      memory: 1Gi
+      cpu: 500m
+      memory: 1536Mi

--- a/pkg/migration/4_etcdbr_image_update.go
+++ b/pkg/migration/4_etcdbr_image_update.go
@@ -1,0 +1,40 @@
+package migration
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/client/openstack"
+)
+
+func UpdateEtcdBackupContainerImage(rawKluster []byte, current *v1.Kluster, client kubernetes.Interface, openstackFactory openstack.SharedOpenstackClientFactory) (err error) {
+	deploymentsClient := client.Extensions().Deployments(current.Namespace)
+	deployment := fmt.Sprintf("%s-etcd", current.GetName())
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, err := deploymentsClient.Get(deployment, metav1.GetOptions{})
+
+		if err != nil {
+			return fmt.Errorf("Deployment %s/%s not found: %v", current.Namespace, deployment, err)
+		}
+
+		i := 0
+		for i < len(result.Spec.Template.Spec.Containers) {
+			if strings.Contains(result.Spec.Template.Spec.Containers[i].Image, "sapcc/etcdbrctl") {
+				result.Spec.Template.Spec.Containers[i].Image = "sapcc/etcdbrctl:0.4.1"
+				_, err = deploymentsClient.Update(result)
+				return err
+			}
+			i++
+		}
+
+		return nil
+	})
+
+	return err
+}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -71,10 +71,15 @@ func TestMigration(t *testing.T) {
 		return nil
 	})
 
+	registry.AddMigration(func(_ []byte, kluster *v1.Kluster, _ kubernetes.Interface, _ openstack.SharedOpenstackClientFactory) error {
+		kluster.Spec.Name = kluster.Spec.Name + "4"
+		return nil
+	})
+
 	if assert.NoError(t, registry.Migrate(kluster, cs, kcs, nil)) {
 		kluster, _ = kcs.Kubernikus().Klusters(NAMESPACE).Get("test", metav1.GetOptions{})
-		assert.Equal(t, 3, int(kluster.Status.SpecVersion))
-		assert.Equal(t, "23", kluster.Spec.Name)
+		assert.Equal(t, 4, int(kluster.Status.SpecVersion))
+		assert.Equal(t, "234", kluster.Spec.Name)
 	}
 }
 

--- a/pkg/migration/register.go
+++ b/pkg/migration/register.go
@@ -10,6 +10,7 @@ func init() {
 		Init,
 		AddAggregationLayerCertificates,
 		CreateEtcdBackupStorageContainer,
+		UpdateEtcdBackupContainerImage,
 		// <-- Insert new migrations at the end only!
 	}
 }


### PR DESCRIPTION
This PR updates etcd backup/restore to current version 0.4.1 to fix token reauth bug. It also migrates existing klusters to new version.