### PR TITLE
Deorbit fix

### DIFF
--- a/pkg/controller/deorbit/controller.go
+++ b/pkg/controller/deorbit/controller.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/controller/base"
 	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"github.com/sapcc/kubernikus/pkg/controller/metrics"
@@ -127,12 +127,12 @@ func (d *DeorbitReconciler) doDeorbit(deorbiter Deorbiter) (err error) {
 	return nil
 }
 
-func (d *DeorbitReconciler) doSelfDestruct(deorbiter Deorbiter, outer error) (err error) {
+func (d *DeorbitReconciler) doSelfDestruct(deorbiter Deorbiter, err error) error {
 	// If for some reason communication with the Kluster's apiserver is not possible,
 	// we retry until a timeout is reached. Then self-destruct and accept debris.
-	if errors.IsUnexpectedServerError(outer) || errors.IsServerTimeout(outer) {
+	if errors.IsUnexpectedServerError(err) || errors.IsServerTimeout(err) {
 		if deorbiter.IsAPIUnavailableTimeout() {
-			err = deorbiter.SelfDestruct(APIUnavailable)
+			return deorbiter.SelfDestruct(APIUnavailable)
 		}
 	}
 
@@ -142,7 +142,7 @@ func (d *DeorbitReconciler) doSelfDestruct(deorbiter Deorbiter, outer error) (er
 	// Kluster automatically without human interaction. It frees up the Kluster with
 	// the downside of potential debris in the customer's project.
 	if deorbiter.IsDeorbitHangingTimeout() {
-		err = deorbiter.SelfDestruct(DeorbitHanging)
+		return deorbiter.SelfDestruct(DeorbitHanging)
 	}
 
 	return err

--- a/pkg/controller/deorbit/events.go
+++ b/pkg/controller/deorbit/events.go
@@ -23,7 +23,7 @@ func (d *EventingDeorbiter) DeletePersistentVolumeClaims() (deletedPVCs []core_v
 		if err == nil || i < len(deletedPVCs)-1 {
 			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeNormal, events.SuccessfulDeorbitPVC, "Successfully deleted persistent volume: %v", fmt.Sprintf("%v/%v", pvc.Namespace, pvc.Name))
 		} else {
-			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeWarning, events.FailedDeorbitPVC, "Failed to delete persistent volume (%v): %v", err)
+			d.Recorder.Eventf(d.Kluster, core_v1.EventTypeWarning, events.FailedDeorbitPVC, "Failed to delete persistent volume (%v): %v", pvc.Name, err)
 		}
 	}
 


### PR DESCRIPTION
This PR fixing to things in the Deorbiter

* Add `kluster` log key to deorbiter messages
* Fix bug where any error during deorbiting caused the deorbiter to exit prematurely leaving debris and even inconsistent open stack objects (because the service user is deleted to soon)