### PR TITLE
Add server group/building block e2e tests

### DIFF
--- a/test/e2e/etcdbr_test.go
+++ b/test/e2e/etcdbr_test.go
@@ -53,7 +53,7 @@ func (e *EtcdBackupTests) WaitForBackupRestore(t *testing.T) {
 	rv := pod.GetResourceVersion()
 	require.NotEmpty(t, rv, "ResourceVersion should not be empty")
 
-	cmd := fmt.Sprintf("rm -rf %s/*", EtcdDataDir)
+	cmd := fmt.Sprintf("mv %s %s.bak", EtcdDataDir, EtcdDataDir)
 	_, _, err = e.KubernetesControlPlane.ExecCommandInContainerWithFullOutput(e.Namespace, podName, "backup", "/bin/sh", "-c", cmd)
 	require.NoError(t, err, "Deletion of etcd data failed: %s", err)
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -169,7 +169,7 @@ func TestRunner(t *testing.T) {
 	apiTests := &APITests{kubernikus, klusterName}
 	t.Run("API", apiTests.Run)
 
-	nodeTests := &NodeTests{kubernetes, kubernikus, SmokeTestNodeCount, klusterName}
+	nodeTests := &NodeTests{kubernetes, kubernikus, openstack, SmokeTestNodeCount, klusterName}
 	if !t.Run("Nodes", nodeTests.Run) {
 		return
 	}


### PR DESCRIPTION
This PR adds additional e2e tests:

- test if created nodes are on the same building block
- test if server groups got deleted