### PR TITLE
Update eventexporter chart and config

### DIFF
--- a/charts/kubernikus-system/vendor/eventexporter/templates/clusterrole.yaml
+++ b/charts/kubernikus-system/vendor/eventexporter/templates/clusterrole.yaml
@@ -6,3 +6,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]

--- a/charts/kubernikus-system/vendor/eventexporter/templates/deployment.yaml
+++ b/charts/kubernikus-system/vendor/eventexporter/templates/deployment.yaml
@@ -24,14 +24,17 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+        - -discard=60s
         - -logtostderr
         - -listen-address=:{{ default 9102 .Values.metrics.port }}
+        - -v=0
         volumeMounts:
         - name: config-volume
           mountPath: /etc/eventexporter
         ports:
         - name: metrics
           containerPort: {{ default 9102 .Values.metrics.port }}
+{{ toYaml .Values.resources | indent 8 }}
       serviceAccount: {{ template "name" . }}
       volumes:
       - name: config-volume

--- a/charts/kubernikus-system/vendor/eventexporter/values.yaml
+++ b/charts/kubernikus-system/vendor/eventexporter/values.yaml
@@ -1,7 +1,15 @@
 image:
   repository: sapcc/kubernetes-eventexporter
-  tag: 0.1.0
+  tag: 0.2.0
   pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 20Mi
+  limits:
+    cpu: 200m
+    memory: 100Mi
 
 metrics:
   port: "9102"
@@ -12,14 +20,14 @@ metrics:
         event_matcher:
         - key: InvolvedObject.Kind
           expr: Pod
-        - key: Message
-          expr: Unable to mount volumes for pod.*
         - key: Reason
-          expr: FailedMount
+          expr: FailedAttachVolume
         - key: Type
           expr: Warning
+        - key: Source.Component
+          expr: attachdetach.*
         labels:
-          node: Source.Host
+          node: Object.Spec.NodeName
       - name: volume_mount_success_total
         event_matcher:
         - key: InvolvedObject.Kind


### PR DESCRIPTION
This PR updates eventexporter which looks up pod data and discards old events. It also introduces resource limits. 