### PR TITLE
Use contrib tests image in e2e tests

### DIFF
--- a/ci/task_e2e_tests.yaml
+++ b/ci/task_e2e_tests.yaml
@@ -3,8 +3,8 @@ platform: 'linux'
 image_resource:
   type: docker-image
   source:
-    repository: golang
-    tag: 1.9.2-alpine3.6
+    repository: sapcc/kubernikus-tests
+    tag: latest
 
 inputs:
   - name: kubernikus.builds
@@ -17,11 +17,10 @@ run:
     - -c
     - |
       set -o pipefail
-      SENTRY_CLI=$PWD/cache/sentry-cli-1.37.0
+      SENTRY_CLI=/usr/local/bin/sentry-cli
       export GOPATH=$PWD/gopath
       cd gopath/src/github.com/sapcc/kubernikus
 
-      apk add --no-progress --no-cache make git curl
       export RUN_PARALLEL=false
       make test-e2e | tee test.output
       rc=$?
@@ -29,8 +28,6 @@ run:
         #Get the longest uniq (!) whitespace prefix of --- FAIL: lines
         ws_count=$(grep -- '--- FAIL:' test.output| grep -v -- '->'| awk '{ match($0, /^ */); printf("%d\n", RLENGTH, substr($0,RLENGTH+1)) }' | sort|uniq -u |tail -1)
         test_name=$(sed -n -E  "s/^ {$ws_count}--- FAIL: (.*) \([.0-9]*s\)$/\1/p" test.output)
-        curl -sLo $SENTRY_CLI -z $SENTRY_CLI https://github.com/getsentry/sentry-cli/releases/download/1.37.0/sentry-cli-Linux-x86_64
-        chmod +x $SENTRY_CLI
         unset http_proxy https_proxy no_proxy
         $SENTRY_CLI send-event -m "Failed to run $test_name" -E $OS_REGION_NAME --no-environ --logfile test.output
       fi

--- a/ci/task_e2e_tests.yaml
+++ b/ci/task_e2e_tests.yaml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: sapcc/kubernikus-tests
-    tag: 3963a930cb1e87826bbe8fb0886db76b8d6ed0ef
+    tag: 2c96f9427d962b9804caf15af2809d0b168e0624
 
 inputs:
   - name: kubernikus.builds

--- a/ci/task_e2e_tests.yaml
+++ b/ci/task_e2e_tests.yaml
@@ -4,13 +4,11 @@ image_resource:
   type: docker-image
   source:
     repository: sapcc/kubernikus-tests
-    tag: latest
+    tag: 3963a930cb1e87826bbe8fb0886db76b8d6ed0ef
 
 inputs:
   - name: kubernikus.builds
     path: gopath/src/github.com/sapcc/kubernikus
-caches:
-  - path: cache
 run:
   path: /bin/sh
   args:

--- a/contrib/kubernikus-tests/Dockerfile
+++ b/contrib/kubernikus-tests/Dockerfile
@@ -5,12 +5,13 @@ WORKDIR /go/src/github.com/sapcc/kubernikus/
 RUN apk add --no-cache make git curl bash
 
 RUN curl -Lf https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz \
-		| tar --strip-components=1 -C /usr/local/bin -zxv \
-		&& helm version -c
+		| tar --strip-components=1 -C /usr/local/bin -zxv
 
 RUN curl -Lf https://github.com/prometheus/prometheus/releases/download/v2.4.2/prometheus-2.4.2.linux-amd64.tar.gz \
-		| tar --strip-components=1 -C /usr/local/bin -zxv prometheus-2.4.2.linux-amd64/promtool \
-		&& promtool --version
+		| tar --strip-components=1 -C /usr/local/bin -zxv prometheus-2.4.2.linux-amd64/promtool
 
 RUN curl -Lfo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 \
 		&& chmod +x /usr/local/bin/yq
+
+RUN curl -Lfo /usr/local/bin/sentry-cli https://github.com/getsentry/sentry-cli/releases/download/1.37.0/sentry-cli-Linux-x86_64 \
+		&& chmod +x /usr/local/bin/sentry-cli

--- a/contrib/kubernikus-tests/Dockerfile
+++ b/contrib/kubernikus-tests/Dockerfile
@@ -5,13 +5,17 @@ WORKDIR /go/src/github.com/sapcc/kubernikus/
 RUN apk add --no-cache make git curl bash
 
 RUN curl -Lf https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz \
-		| tar --strip-components=1 -C /usr/local/bin -zxv
+		| tar --strip-components=1 -C /usr/local/bin -zxv \
+		&& helm version -c
 
 RUN curl -Lf https://github.com/prometheus/prometheus/releases/download/v2.4.2/prometheus-2.4.2.linux-amd64.tar.gz \
-		| tar --strip-components=1 -C /usr/local/bin -zxv prometheus-2.4.2.linux-amd64/promtool
+		| tar --strip-components=1 -C /usr/local/bin -zxv prometheus-2.4.2.linux-amd64/promtool \
+		&& promtool --version
 
 RUN curl -Lfo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 \
-		&& chmod +x /usr/local/bin/yq
+		&& chmod +x /usr/local/bin/yq \
+		&& yq --version
 
 RUN curl -Lfo /usr/local/bin/sentry-cli https://github.com/getsentry/sentry-cli/releases/download/1.37.0/sentry-cli-Linux-x86_64 \
-		&& chmod +x /usr/local/bin/sentry-cli
+		&& chmod +x /usr/local/bin/sentry-cli \
+		&& sentry-cli --version


### PR DESCRIPTION
Use contrib tests image in e2e tests instead of installing needed tools every time. This hopefully speeds up soak tests a bit.