### PR TITLE
Backward compatibility for node pool name validation

### DIFF
--- a/pkg/api/models/node_pool.go
+++ b/pkg/api/models/node_pool.go
@@ -33,7 +33,7 @@ type NodePool struct {
 	// name
 	// Required: true
 	// Max Length: 20
-	// Pattern: ^[a-z]([a-z0-9]*)?$
+	// Pattern: ^[a-z0-9]([-\.a-z0-9]*)?$
 	Name string `json:"name"`
 
 	// size
@@ -103,7 +103,7 @@ func (m *NodePool) validateName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("name", "body", string(m.Name), `^[a-z]([a-z0-9]*)?$`); err != nil {
+	if err := validate.Pattern("name", "body", string(m.Name), `^[a-z0-9]([-\.a-z0-9]*)?$`); err != nil {
 		return err
 	}
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -511,7 +511,7 @@ func init() {
         "name": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[a-z]([a-z0-9]*)?$",
+          "pattern": "^[a-z0-9]([-\\.a-z0-9]*)?$",
           "x-nullable": false
         },
         "size": {
@@ -1282,7 +1282,7 @@ func init() {
         "name": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[a-z]([a-z0-9]*)?$",
+          "pattern": "^[a-z0-9]([-\\.a-z0-9]*)?$",
           "x-nullable": false
         },
         "size": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -411,7 +411,7 @@ definitions:
       name:
         x-nullable: false
         type: string
-        pattern: '^[a-z]([a-z0-9]*)?$'
+        pattern: '^[a-z0-9]([-\.a-z0-9]*)?$'
         maxLength: 20
       size:
         x-nullable: false


### PR DESCRIPTION
This PR allows the following in addition to be backward compatible:
- digits as the first character in node pool name
- "." and "-" in the node pool name
