### PR TITLE
Restore API Functionality by Adding Nodepool AVZ Validations and Defaults 

### DIFF
--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -39,7 +39,7 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 
 	metadata, err := fetchOpenstackMetadata(params.HTTPRequest, principal)
 	if err != nil {
-		return NewErrorResponse(&operations.CreateClusterDefault{}, 500, err.Error())
+		return NewErrorResponse(&operations.CreateClusterDefault{}, 500, "Failed to get OpenStack metadata: %s", err)
 	}
 
 	spec.Name = name

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -58,7 +58,7 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 			spec.NodePools[i].AvailabilityZone = avz
 		} else {
 			if err := validateAavailabilityZone(pool.AvailabilityZone, metadata); err != nil {
-				return NewErrorResponse(&operations.CreateClusterDefault{}, 409, "Availability Zone %s is invalid: %s", pool.AvailabilityZone, err)
+				return NewErrorResponse(&operations.CreateClusterDefault{}, 409, "Availability zone '%s' for pool '%s' is invalid: %s", pool.AvailabilityZone, pool.Name, err)
 			}
 		}
 	}

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -37,11 +37,6 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 		return NewErrorResponse(&operations.CreateClusterDefault{}, int(err.Code()), err.Error())
 	}
 
-	metadata, err := fetchOpenstackMetadata(params.HTTPRequest, principal)
-	if err != nil {
-		return NewErrorResponse(&operations.CreateClusterDefault{}, 500, "Failed to get OpenStack metadata: %s", err)
-	}
-
 	var metadata *models.OpenstackMetadata
 	spec.Name = name
 	for i, pool := range spec.NodePools {

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -53,7 +53,7 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 		if pool.AvailabilityZone == "" {
 			avz, err := getDefaultAvailabilityZone(metadata)
 			if err != nil {
-				return NewErrorResponse(&operations.CreateClusterDefault{}, 500, err.Error())
+				return NewErrorResponse(&operations.CreateClusterDefault{}, 500, "Failed to get default availability zones: %s", err)
 			}
 			spec.NodePools[i].AvailabilityZone = avz
 		} else {

--- a/pkg/api/handlers/get_openstack_metadata.go
+++ b/pkg/api/handlers/get_openstack_metadata.go
@@ -2,12 +2,10 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 
 	"github.com/sapcc/kubernikus/pkg/api"
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/rest/operations"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
 )
 
 func NewGetOpenstackMetadata(rt *api.Runtime) operations.GetOpenstackMetadataHandler {
@@ -19,23 +17,7 @@ type getOpenstackMetadata struct {
 }
 
 func (d *getOpenstackMetadata) Handle(params operations.GetOpenstackMetadataParams, principal *models.Principal) middleware.Responder {
-	tokenID := params.HTTPRequest.Header.Get("X-Auth-Token")
-
-	authOptions := &tokens.AuthOptions{
-		IdentityEndpoint: principal.AuthURL,
-		TokenID:          tokenID,
-		AllowReauth:      true,
-		Scope: tokens.Scope{
-			ProjectID: principal.Account,
-		},
-	}
-
-	client, err := openstack.NewSharedOpenstackClientFactory(nil, nil, nil, getTracingLogger(params.HTTPRequest)).ProjectClientFor(authOptions)
-	if err != nil {
-		return NewErrorResponse(&operations.GetOpenstackMetadataDefault{}, 500, err.Error())
-	}
-
-	openstackMetadata, err := client.GetMetadata()
+	openstackMetadata, err := fetchOpenstackMetadata(params.HTTPRequest, principal)
 	if err != nil {
 		return NewErrorResponse(&operations.GetOpenstackMetadataDefault{}, 500, err.Error())
 	}

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -119,7 +119,6 @@ func fetchOpenstackMetadata(request *http.Request, principal *models.Principal) 
 	authOptions := &tokens.AuthOptions{
 		IdentityEndpoint: principal.AuthURL,
 		TokenID:          tokenID,
-		AllowReauth:      true,
 		Scope: tokens.Scope{
 			ProjectID: principal.Account,
 		},

--- a/pkg/api/handlers/util.go
+++ b/pkg/api/handlers/util.go
@@ -4,15 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	kitlog "github.com/go-kit/kit/log"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/api/spec"
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/client/openstack"
 	kubernikusv1 "github.com/sapcc/kubernikus/pkg/generated/clientset/typed/kubernikus/v1"
 )
 
@@ -108,4 +111,43 @@ func nodePoolEqualsWithScaling(old, new models.NodePool) error {
 	}
 
 	return nil
+}
+
+func fetchOpenstackMetadata(request *http.Request, principal *models.Principal) (*models.OpenstackMetadata, error) {
+	tokenID := request.Header.Get("X-Auth-Token")
+
+	authOptions := &tokens.AuthOptions{
+		IdentityEndpoint: principal.AuthURL,
+		TokenID:          tokenID,
+		AllowReauth:      true,
+		Scope: tokens.Scope{
+			ProjectID: principal.Account,
+		},
+	}
+
+	client, err := openstack.NewSharedOpenstackClientFactory(nil, nil, nil, getTracingLogger(request)).ProjectClientFor(authOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.GetMetadata()
+}
+
+func getDefaultAvailabilityZone(metadata *models.OpenstackMetadata) (string, error) {
+	sort.Slice(metadata.AvailabilityZones, func(i, j int) bool { return metadata.AvailabilityZones[i].Name > metadata.AvailabilityZones[j].Name })
+	if len(metadata.AvailabilityZones) == 0 {
+		return "", errors.New("couldn't determine default availability zone")
+	}
+
+	return metadata.AvailabilityZones[0].Name, nil
+}
+
+func validateAavailabilityZone(avz string, metadata *models.OpenstackMetadata) error {
+	for _, a := range metadata.AvailabilityZones {
+		if a.Name == avz {
+			return nil
+		}
+	}
+
+	return errors.New("availability zone not found")
 }

--- a/pkg/api/models/node_pool.go
+++ b/pkg/api/models/node_pool.go
@@ -18,8 +18,7 @@ import (
 type NodePool struct {
 
 	// availability zone
-	// Required: true
-	AvailabilityZone string `json:"availabilityZone"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	// config
 	Config NodePoolConfig `json:"config,omitempty"`
@@ -47,10 +46,6 @@ type NodePool struct {
 func (m *NodePool) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAvailabilityZone(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateConfig(formats); err != nil {
 		res = append(res, err)
 	}
@@ -70,15 +65,6 @@ func (m *NodePool) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *NodePool) validateAvailabilityZone(formats strfmt.Registry) error {
-
-	if err := validate.RequiredString("availabilityZone", "body", string(m.AvailabilityZone)); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -489,8 +489,7 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "flavor",
-        "availabilityZone"
+        "flavor"
       ],
       "properties": {
         "availabilityZone": {
@@ -1261,8 +1260,7 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "flavor",
-        "availabilityZone"
+        "flavor"
       ],
       "properties": {
         "availabilityZone": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -407,7 +407,6 @@ definitions:
     required:
       - name
       - flavor
-      - availabilityZone
     properties:
       name:
         x-nullable: false


### PR DESCRIPTION
This PR restores the default behaviour of the `clusterCreate` API. It can now still be called without a required `availabilityZone` on the node pool.

A default AVZ is selected if non is provided. If an AVZ is provided it is validated against currently enabled AVZs.