### PR TITLE
Bump etcdbrctl to version 0.5.0

### DIFF
--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -22,7 +22,7 @@ resources:
 backup:
   image:
     repository: sapcc/etcdbrctl
-    tag: 0.4.1
+    tag: 0.5.0
     pullPolicy: IfNotPresent
   config:
     # do a full-backup every hour
@@ -40,5 +40,5 @@ backup:
       cpu: 100m
       memory: 128Mi
     limits:
-      cpu: 300m
-      memory: 1Gi
+      cpu: 500m
+      memory: 1.5Gi


### PR DESCRIPTION
This PR updates etcd backup restore sidecar to version 0.5.0, this fixes a memory leak. It also changes resource limits to gardener defaults.