### PR TITLE
Generalize Migrations

### DIFF
--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -18,8 +18,7 @@ const (
 )
 
 type MigrationReconciler struct {
-	config.Clients
-
+	Clients   config.Clients
 	Factories config.Factories
 	Recorder  record.EventRecorder
 	Logger    log.Logger
@@ -40,11 +39,11 @@ func (mr *MigrationReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {
 	//We only care about klusters with pending migrations
 	if !migration.MigrationsPending(kluster) {
 		// Ensure the kluster migration status is up to date
-		return false, util.UpdateKlusterMigrationStatus(mr.Kubernikus.Kubernikus(), kluster, false)
+		return false, util.UpdateKlusterMigrationStatus(mr.Clients.Kubernikus.Kubernikus(), kluster, false)
 	}
 
 	//Ensure pending migrations are reflected in the status
-	if err := util.UpdateKlusterMigrationStatus(mr.Kubernikus.Kubernikus(), kluster, true); err != nil {
+	if err := util.UpdateKlusterMigrationStatus(mr.Clients.Kubernikus.Kubernikus(), kluster, true); err != nil {
 		return false, err
 	}
 
@@ -53,7 +52,7 @@ func (mr *MigrationReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {
 		return false, nil
 	}
 
-	err := migration.Migrate(kluster, mr.Kubernetes, mr.Kubernikus, mr.Factories.Openstack)
+	err := migration.Migrate(kluster, mr.Clients, mr.Factories)
 	mr.Logger.Log(
 		"msg", "Migrating spec",
 		"kluster", kluster.Name,
@@ -67,7 +66,7 @@ func (mr *MigrationReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {
 		return false, err
 	}
 	//Clear the klusters migration status as migrations are applied successfully
-	util.UpdateKlusterMigrationStatus(mr.Kubernikus.Kubernikus(), kluster, false)
+	util.UpdateKlusterMigrationStatus(mr.Clients.Kubernikus.Kubernikus(), kluster, false)
 
 	return false, nil
 }

--- a/pkg/migration/1_init.go
+++ b/pkg/migration/1_init.go
@@ -1,13 +1,11 @@
 package migration
 
 import (
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
 )
 
 //Init is the first migration that only sets the SpecVersion to 1
-func Init(rawKluster []byte, current *v1.Kluster, client kubernetes.Interface, openstackFactory openstack.SharedOpenstackClientFactory) (err error) {
+func Init(rawKluster []byte, current *v1.Kluster, clients config.Clients, factories config.Factories) (err error) {
 	return nil
 }

--- a/pkg/migration/2_add_aggregation_layer_certificates.go
+++ b/pkg/migration/2_add_aggregation_layer_certificates.go
@@ -2,15 +2,15 @@ package migration
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"github.com/sapcc/kubernikus/pkg/util"
 )
 
-func AddAggregationLayerCertificates(rawKluster []byte, kluster *v1.Kluster, client kubernetes.Interface, openstackFactory openstack.SharedOpenstackClientFactory) (err error) {
-	apiSecret, err := client.CoreV1().Secrets(kluster.Namespace).Get(kluster.GetName(), metav1.GetOptions{})
+func AddAggregationLayerCertificates(rawKluster []byte, kluster *v1.Kluster, clients config.Clients, factories config.Factories) (err error) {
+
+	apiSecret, err := clients.Kubernetes.CoreV1().Secrets(kluster.Namespace).Get(kluster.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func AddAggregationLayerCertificates(rawKluster []byte, kluster *v1.Kluster, cli
 	}
 
 	apiSecret.Data = secretData
-	_, err = client.CoreV1().Secrets(kluster.Namespace).Update(apiSecret)
+	_, err = clients.Kubernetes.CoreV1().Secrets(kluster.Namespace).Update(apiSecret)
 
 	return err
 }

--- a/pkg/migration/3_etcdbr_create_storage_container.go
+++ b/pkg/migration/3_etcdbr_create_storage_container.go
@@ -4,15 +4,14 @@ import (
 	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
 	etcd_util "github.com/sapcc/kubernikus/pkg/util/etcd"
 )
 
-func CreateEtcdBackupStorageContainer(rawKluster []byte, current *v1.Kluster, client kubernetes.Interface, openstackFactory openstack.SharedOpenstackClientFactory) (err error) {
-	secret, err := client.CoreV1().Secrets(current.GetNamespace()).Get(current.GetName(), metav1.GetOptions{})
+func CreateEtcdBackupStorageContainer(rawKluster []byte, current *v1.Kluster, clients config.Clients, factories config.Factories) (err error) {
+	secret, err := clients.Kubernetes.CoreV1().Secrets(current.GetNamespace()).Get(current.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -27,7 +26,7 @@ func CreateEtcdBackupStorageContainer(rawKluster []byte, current *v1.Kluster, cl
 		return errors.New("openstack domain name secret not set")
 	}
 
-	adminClient, err := openstackFactory.AdminClient()
+	adminClient, err := factories.Openstack.AdminClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/migration/5_insert_avz_into_nodepools.go
+++ b/pkg/migration/5_insert_avz_into_nodepools.go
@@ -3,15 +3,13 @@ package migration
 import (
 	"fmt"
 
-	"k8s.io/client-go/kubernetes"
-
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
 	"github.com/sapcc/kubernikus/pkg/util"
 )
 
-func InsertAVZIntoNodePools(rawKluster []byte, current *v1.Kluster, client kubernetes.Interface, openstackFactory openstack.SharedOpenstackClientFactory) (err error) {
-	secret, err := util.KlusterSecret(client, current)
+func InsertAVZIntoNodePools(rawKluster []byte, current *v1.Kluster, clients config.Clients, factories config.Factories) (err error) {
+	secret, err := util.KlusterSecret(clients.Kubernetes, current)
 	if err != nil {
 		return err
 	}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -3,11 +3,8 @@ package migration
 import (
 	"fmt"
 
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-	"github.com/sapcc/kubernikus/pkg/client/openstack"
-	kubernikus "github.com/sapcc/kubernikus/pkg/generated/clientset"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
 	kubernikusfake "github.com/sapcc/kubernikus/pkg/generated/clientset/fake"
 )
 
@@ -18,7 +15,7 @@ var defaultRegistry Registry
 // The function is expected to modify the kluster accordingly, changed object is persisted
 // automatically after the handler returns with no error.
 // The kubernetes client can be used to modify other things (e.g. kluster secret)
-type Migration func(klusterRaw []byte, kluster *v1.Kluster, client kubernetes.Interface, openstack_factory openstack.SharedOpenstackClientFactory) (err error)
+type Migration func(klusterRaw []byte, kluster *v1.Kluster, clients config.Clients, factories config.Factories) (err error)
 
 //Latest returns to latest spec version available
 func Latest() int {
@@ -31,8 +28,8 @@ func MigrationsPending(kluster *v1.Kluster) bool {
 }
 
 //Migrate a kluster to the most recent spec version
-func Migrate(k *v1.Kluster, client kubernetes.Interface, kubernikus_client kubernikus.Interface, openstack_factory openstack.SharedOpenstackClientFactory) error {
-	return defaultRegistry.Migrate(k, client, kubernikus_client, openstack_factory)
+func Migrate(k *v1.Kluster, clients config.Clients, factories config.Factories) error {
+	return defaultRegistry.Migrate(k, clients, factories)
 }
 
 //Registry manages an ordered list of migration steps
@@ -53,7 +50,7 @@ func (r Registry) MigrationsPending(kluster *v1.Kluster) bool {
 	return int(kluster.Status.SpecVersion) < r.Latest()
 }
 
-func (r *Registry) Migrate(k *v1.Kluster, client kubernetes.Interface, kubernikus_client kubernikus.Interface, openstack_factory openstack.SharedOpenstackClientFactory) error {
+func (r *Registry) Migrate(k *v1.Kluster, clients config.Clients, factories config.Factories) error {
 	klusterVersion := int(k.Status.SpecVersion)
 	if klusterVersion >= r.Latest() {
 		return nil
@@ -64,28 +61,28 @@ func (r *Registry) Migrate(k *v1.Kluster, client kubernetes.Interface, kuberniku
 	for idx := klusterVersion; idx < r.Latest(); idx++ {
 		migration := r.migrations[idx]
 		version := idx + 1
-		if kluster, err = migrateKluster(kluster, version, migration, client, kubernikus_client, openstack_factory); err != nil {
+		if kluster, err = migrateKluster(kluster, version, migration, clients, factories); err != nil {
 			return fmt.Errorf("Error running migration %d: %s", version, err)
 		}
 	}
 	return nil
 }
 
-func migrateKluster(kluster *v1.Kluster, version int, migration Migration, client kubernetes.Interface, kubernikus_client kubernikus.Interface, openstack_factory openstack.SharedOpenstackClientFactory) (*v1.Kluster, error) {
+func migrateKluster(kluster *v1.Kluster, version int, migration Migration, clients config.Clients, factories config.Factories) (*v1.Kluster, error) {
 	var rawData []byte
 	var err error
 
 	//TODO: Don't import fake pkg outside of test code
-	if _, ok := kubernikus_client.(*kubernikusfake.Clientset); !ok {
-		request := kubernikus_client.Kubernikus().RESTClient().Get().Namespace(kluster.Namespace).Resource("klusters").Name(kluster.Name)
+	if _, ok := clients.Kubernikus.(*kubernikusfake.Clientset); !ok {
+		request := clients.Kubernikus.Kubernikus().RESTClient().Get().Namespace(kluster.Namespace).Resource("klusters").Name(kluster.Name)
 		if rawData, err = request.DoRaw(); err != nil {
 			return nil, err
 		}
 	}
 
-	if err = migration(rawData, kluster, client, openstack_factory); err != nil {
+	if err = migration(rawData, kluster, clients, factories); err != nil {
 		return nil, err
 	}
 	kluster.Status.SpecVersion = int64(version)
-	return kubernikus_client.Kubernikus().Klusters(kluster.Namespace).Update(kluster)
+	return clients.Kubernikus.Kubernikus().Klusters(kluster.Namespace).Update(kluster)
 }


### PR DESCRIPTION
This PR makes the migration mechanism more flexible. It passes the complete `config.Clients` and `config.Factories` structs.

This allows to use the full functionality of all clients. Concrete use is the seeding of StorageClasses or RBAC rules to already existing clusters.