### PR TITLE
Fix debug logging in kubernikusctl

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b5352f4065108401065414f6627d608e24ede20945bfa73ceae444e839662136
-updated: 2018-08-31T10:21:40.690495+02:00
+hash: f36f7508dc3c68fd52059531ebf85d404e7c05dfb17be7e2c0dfd707bd54b3f2
+updated: 2019-02-26T08:50:21.042819+01:00
 imports:
 - name: github.com/ajeddeloh/yaml
   version: 1072abfea31191db507785e2e0c1b8d1440d35a5
@@ -125,7 +125,7 @@ imports:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: abbb4165c64123c8932f94a4de5ef6f36db7b66b
+  version: 58f2bb154920fd79224b172cdac6a00d642a420a
   repo: https://github.com/bugroger/glognomore
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
@@ -155,6 +155,8 @@ imports:
   - internal
   - openstack
   - openstack/blockstorage/extensions/quotasets
+  - openstack/blockstorage/v3/volumes
+  - openstack/compute/v2/extensions/availabilityzones
   - openstack/compute/v2/extensions/keypairs
   - openstack/compute/v2/extensions/quotasets
   - openstack/compute/v2/extensions/schedulerhints
@@ -177,6 +179,9 @@ imports:
   - openstack/networking/v2/networks
   - openstack/networking/v2/ports
   - openstack/networking/v2/subnets
+  - openstack/objectstorage/v1/accounts
+  - openstack/objectstorage/v1/containers
+  - openstack/objectstorage/v1/objects
   - openstack/utils
   - pagination
 - name: github.com/gregjones/httpcache
@@ -285,8 +290,6 @@ imports:
   - user/crypt
   - user/crypt/common
   - user/crypt/sha512_crypt
-- name: github.com/tylerb/graceful
-  version: d72b0151351a13d0421b763b88f791469c4f5dc7
 - name: github.com/vincent-petithory/dataurl
   version: 9a301d65acbb728fcc3ace14f45f511a4cfeea9c
 - name: github.com/zalando/go-keyring
@@ -305,8 +308,6 @@ imports:
   - bpf
   - context
   - context/ctxhttp
-  - html
-  - html/atom
   - http2
   - http2/hpack
   - icmp
@@ -317,6 +318,7 @@ imports:
   - ipv4
   - ipv6
   - lex/httplex
+  - netutil
   - trace
 - name: golang.org/x/sys
   version: 95c6576299259db960f6c5b9b69ea52422860fce

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/sapcc/kubernikus
 import:
 - package: github.com/golang/glog
   repo: https://github.com/bugroger/glognomore
-  version: abbb4165c64123c8932f94a4de5ef6f36db7b66b 
+  version: 58f2bb154920fd79224b172cdac6a00d642a420a
 - package: github.com/stretchr/testify
   version: ^1.1.0
   subpackages:

--- a/pkg/cmd/kubernikusctl/auth/init.go
+++ b/pkg/cmd/kubernikusctl/auth/init.go
@@ -44,6 +44,7 @@ func NewInitCommand() *cobra.Command {
 		Use:   "init",
 		Short: "Prepares kubeconfig with Kubernikus credentials",
 		Run: func(c *cobra.Command, args []string) {
+			common.SetupLogger()
 			common.CheckError(o.Validate(c, args))
 			common.CheckError(o.Complete(args))
 			common.CheckError(o.Run(c))
@@ -57,6 +58,7 @@ func NewInitCommand() *cobra.Command {
 
 func (o *InitOptions) BindFlags(flags *pflag.FlagSet) {
 	o.openstack.BindFlags(flags)
+	common.BindLogFlags(flags)
 
 	flags.StringVar(&o._url, "url", o._url, "URL for Kubernikus API")
 	flags.StringVar(&o.name, "name", o.name, "Cluster Name")

--- a/pkg/cmd/kubernikusctl/auth/refresh.go
+++ b/pkg/cmd/kubernikusctl/auth/refresh.go
@@ -44,6 +44,7 @@ func NewRefreshCommand() *cobra.Command {
 		Use:   "refresh",
 		Short: "Refreshes already existing credentials in kubeconfig",
 		Run: func(c *cobra.Command, args []string) {
+			common.SetupLogger()
 			common.CheckError(o.Validate(c, args))
 			common.CheckError(o.Complete(args))
 			common.CheckError(o.Run(c))
@@ -55,7 +56,8 @@ func NewRefreshCommand() *cobra.Command {
 }
 
 func (o *RefreshOptions) BindFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&o.openstack.Password, "password", o.openstack.Password, "User password [OS_PASSWORD]")
+	common.BindLogFlags(flags)
+	flags.StringVar(&o.openstack.Password, "password", "", "User password [OS_PASSWORD]")
 	flags.StringVar(&o.kubeconfigPath, "kubeconfig", o.kubeconfigPath, "Overwrites kubeconfig auto-detection with explicit path")
 	flags.StringVar(&o.context, "context", o.context, "Overwrites current-context in kubeconfig")
 	flags.BoolVar(&o.force, "force", o.force, "Force refresh")

--- a/pkg/cmd/kubernikusctl/common/log.go
+++ b/pkg/cmd/kubernikusctl/common/log.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"os"
+
+	kitLog "github.com/go-kit/kit/log"
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+
+	"github.com/sapcc/kubernikus/pkg/util/log"
+)
+
+var (
+	logLevel int
+)
+
+func BindLogFlags(flags *pflag.FlagSet) {
+	flags.IntVarP(&logLevel, "debug", "v", 0, "")
+}
+
+func SetupLogger() {
+	logger := kitLog.NewLogfmtLogger(kitLog.NewSyncWriter(os.Stderr))
+	logger = log.NewTrailingNilFilter(logger)
+	//logger = log.NewLevelFilter(logLevel, logger)
+	logger = kitLog.With(logger, "ts", kitLog.DefaultTimestampUTC, "caller", log.Caller(4))
+	glog.SetLogger(logger, int32(logLevel))
+
+}

--- a/pkg/cmd/kubernikusctl/create/common.go
+++ b/pkg/cmd/kubernikusctl/create/common.go
@@ -22,6 +22,7 @@ type CreateOptions struct {
 }
 
 func (o *CreateOptions) PersistentPreRun(c *cobra.Command, args []string) {
+	common.SetupLogger()
 	cmd.CheckError(o.Openstack.Validate(c, args))
 	cmd.CheckError(o.Openstack.Setup())
 	cmd.CheckError(o.Openstack.Authenticate())
@@ -29,6 +30,7 @@ func (o *CreateOptions) PersistentPreRun(c *cobra.Command, args []string) {
 
 func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	o.Openstack.BindFlags(flags)
+	common.BindLogFlags(flags)
 
 	flags.StringVar(&o._url, "url", o._url, "URL for Kubernikus API")
 }

--- a/pkg/cmd/kubernikusctl/delete/common.go
+++ b/pkg/cmd/kubernikusctl/delete/common.go
@@ -21,6 +21,7 @@ type DeleteOptions struct {
 }
 
 func (o *DeleteOptions) PersistentPreRun(c *cobra.Command, args []string) {
+	common.SetupLogger()
 	cmd.CheckError(o.Openstack.Validate(c, args))
 	cmd.CheckError(o.Openstack.Setup())
 	cmd.CheckError(o.Openstack.Authenticate())
@@ -28,6 +29,7 @@ func (o *DeleteOptions) PersistentPreRun(c *cobra.Command, args []string) {
 
 func (o *DeleteOptions) BindFlags(flags *pflag.FlagSet) {
 	o.Openstack.BindFlags(flags)
+	common.BindLogFlags(flags)
 
 	flags.StringVar(&o._url, "url", o._url, "URL for Kubernikus API")
 }

--- a/pkg/cmd/kubernikusctl/get/common.go
+++ b/pkg/cmd/kubernikusctl/get/common.go
@@ -22,15 +22,15 @@ type GetOptions struct {
 
 func (o *GetOptions) BindFlags(flags *pflag.FlagSet) {
 	o.Openstack.BindFlags(flags)
+	common.BindLogFlags(flags)
 	flags.StringVar(&o._url, "url", o._url, "URL for Kubernikus API")
 }
 
 func (o *GetOptions) PersistentPreRun(c *cobra.Command, args []string) {
-	glog.V(2).Infof("Get PPR: %v", o)
+	common.SetupLogger()
 	cmd.CheckError(o.Openstack.Validate(c, args))
 	cmd.CheckError(o.Openstack.Setup())
 	cmd.CheckError(o.Openstack.Authenticate())
-	glog.V(2).Infof("Get PPR out: %v", o)
 }
 
 func (o *GetOptions) SetupKubernikusClient() error {

--- a/pkg/util/log/levelfilter.go
+++ b/pkg/util/log/levelfilter.go
@@ -22,13 +22,21 @@ func NewLevelFilter(level int, logger kitlog.Logger) kitlog.Logger {
 func (l levelFilter) Log(keyvals ...interface{}) error {
 	for i := len(keyvals) - 2; i >= 0; i -= 2 {
 		if keyvals[i] == levelKey {
-			if lvl, ok := keyvals[i+1].(int); ok {
-				if lvl <= l.threshold {
-					l.next.Log(keyvals...)
-				}
-				return nil // filter log message
+			var lvl int
+			switch n := keyvals[i+1].(type) {
+			case int:
+				lvl = n
+			case int32:
+				lvl = int(n)
+			case int64:
+				lvl = int(n)
+			default:
+				return errors.New("Level value is not of expected type (int)")
 			}
-			return errors.New("Level value is not of expected type (int)")
+			if lvl <= l.threshold {
+				return l.next.Log(keyvals...)
+			}
+			return nil // filter log message
 		}
 	}
 	//ALways log lines without a level

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -32,31 +32,37 @@ func V(level Level) Verbose {
 }
 
 func (v Verbose) Info(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "v", c)
-	pairs = append(pairs, "glog", "Info")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
+	if v {
+		var pairs []interface{}
+		pairs = append(pairs, "v", c)
+		pairs = append(pairs, "glog", "Info")
+		for key, value := range args {
+			pairs = append(pairs, key, value)
+		}
+		logger.Log(pairs...)
 	}
-	logger.Log(pairs...)
 }
 
 func (v Verbose) Infoln(args ...interface{}) {
-	var pairs []interface{}
-	pairs = append(pairs, "v", c)
-	pairs = append(pairs, "glog", "Infoln")
-	for key, value := range args {
-		pairs = append(pairs, key, value)
+	if v {
+		var pairs []interface{}
+		pairs = append(pairs, "v", c)
+		pairs = append(pairs, "glog", "Infoln")
+		for key, value := range args {
+			pairs = append(pairs, key, value)
+		}
+		logger.Log(pairs...)
 	}
-	logger.Log(pairs...)
 }
 
 func (v Verbose) Infof(format string, args ...interface{}) {
-	logger.Log(
-		"v", c,
-		"glog", "Infof",
-		"msg", fmt.Sprintf(format, args...),
-	)
+	if v {
+		logger.Log(
+			"v", c,
+			"glog", "Infof",
+			"msg", fmt.Sprintf(format, args...),
+		)
+	}
 }
 
 func Info(args ...interface{}) {


### PR DESCRIPTION
With the move to glognomore we lost the glog based debug logging in kubernikusctl. This commit restored the --debug/-v flag for cli command