### PR TITLE
cli: refactor context handeling

### DIFF
--- a/pkg/cmd/kubernikusctl/auth/init.go
+++ b/pkg/cmd/kubernikusctl/auth/init.go
@@ -9,13 +9,10 @@ import (
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
 	"github.com/howeyc/gopass"
-	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	keyring "github.com/zalando/go-keyring"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
 )
@@ -29,8 +26,6 @@ type InitOptions struct {
 
 	openstack  *common.OpenstackClient
 	kubernikus *common.KubernikusClient
-
-	kubeconfig *clientcmdapi.Config
 }
 
 func NewInitCommand() *cobra.Command {
@@ -75,17 +70,6 @@ func (o *InitOptions) Validate(c *cobra.Command, args []string) (err error) {
 func (o *InitOptions) Complete(args []string) (err error) {
 	if err := o.openstack.Complete(args); err != nil {
 		return err
-	}
-
-	if o.kubeconfigPath != "" {
-		if err := o.loadKubeconfig(); err != nil {
-			return errors.Wrapf(err, "Loading the specified kubeconfig failed")
-		}
-	} else {
-		o.kubeconfig, err = clientcmd.NewDefaultPathOptions().GetStartingConfig()
-		if err != nil {
-			return errors.Wrapf(err, "Loading the default kubeconfig failed")
-		}
 	}
 
 	return nil
@@ -133,12 +117,16 @@ func (o *InitOptions) Run(c *cobra.Command) (err error) {
 		keyring.Set("kubernikus", strings.ToLower(o.openstack.Username), o.openstack.Password)
 	}
 
-	err = o.mergeAndPersist(kubeconfig)
+	ktx, err := common.NewKubernikusContext(o.kubeconfigPath, "")
 	if err != nil {
+		return errors.Wrapf(err, "Failed to load kubeconfig")
+	}
+
+	if err := ktx.MergeAndPersist(kubeconfig); err != nil {
 		return errors.Wrapf(err, "Couldn't merge existing kubeconfig with fetched credentials")
 	}
 
-	fmt.Println("Wrote merged kubeconfig")
+	fmt.Printf("Updated kubeconfig at %s\n", ktx.PathOptions.GetDefaultFilename())
 
 	return nil
 }
@@ -161,35 +149,5 @@ func (o *InitOptions) setup() error {
 	}
 
 	o.kubernikus = common.NewKubernikusClient(o.url, o.openstack.Provider.TokenID)
-	return nil
-}
-
-func (o *InitOptions) loadKubeconfig() (err error) {
-	if o.kubeconfig, err = clientcmd.LoadFromFile(o.kubeconfigPath); err != nil {
-		return errors.Wrapf(err, "Failed to load kubeconfig from %v", o.kubeconfigPath)
-	}
-	return nil
-}
-
-func (o *InitOptions) mergeAndPersist(rawConfig string) error {
-	config, err := clientcmd.Load([]byte(rawConfig))
-	if err != nil {
-		return errors.Wrapf(err, "Couldn't load kubernikus kubeconfig: %v", rawConfig)
-	}
-
-	if err := mergo.MergeWithOverwrite(o.kubeconfig, config); err != nil {
-		return errors.Wrap(err, "Couldn't merge kubeconfigs")
-	}
-
-	defaultPathOptions := clientcmd.NewDefaultPathOptions()
-	if o.kubeconfigPath != "" {
-		defaultPathOptions.LoadingRules.ExplicitPath = o.kubeconfigPath
-		defaultPathOptions.LoadingRules.Precedence = []string{o.kubeconfigPath}
-	}
-	glog.V(2).Infof("DefaultPathOptions: %v", defaultPathOptions)
-	if err = clientcmd.ModifyConfig(defaultPathOptions, *o.kubeconfig, false); err != nil {
-		return errors.Wrapf(err, "Couldn't merge Kubernikus config with kubeconfig")
-	}
-
 	return nil
 }

--- a/pkg/cmd/kubernikusctl/auth/refresh.go
+++ b/pkg/cmd/kubernikusctl/auth/refresh.go
@@ -1,25 +1,18 @@
 package auth
 
 import (
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/howeyc/gopass"
-	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	keyring "github.com/zalando/go-keyring"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/sapcc/kubernikus/pkg/cmd/kubernikusctl/common"
-	"github.com/sapcc/kubernikus/pkg/util"
 )
 
 type RefreshOptions struct {
@@ -31,8 +24,6 @@ type RefreshOptions struct {
 
 	openstack  *common.OpenstackClient
 	kubernikus *common.KubernikusClient
-
-	kubeconfig *clientcmdapi.Config
 }
 
 func NewRefreshCommand() *cobra.Command {
@@ -70,42 +61,23 @@ func (o *RefreshOptions) Complete(args []string) (err error) {
 		return err
 	}
 
-	if o.kubeconfigPath != "" {
-		if err := o.loadKubeconfig(); err != nil {
-			return errors.Wrapf(err, "Loading the specified kubeconfig failed")
-		}
-	} else {
-		o.kubeconfig, err = clientcmd.NewDefaultPathOptions().GetStartingConfig()
-		if err != nil {
-			return errors.Wrapf(err, "Loading the default kubeconfig failed")
-		}
-	}
-
-	if o.context == "" && o.kubeconfig.CurrentContext != "" {
-		o.context = o.kubeconfig.CurrentContext
-	}
-
-	if o.kubeconfig.Contexts[o.context] == nil {
-		return errors.Errorf("The context you provided does not exist")
-	}
-
 	return nil
 }
 
 func (o *RefreshOptions) Run(c *cobra.Command) error {
+
 	glog.V(2).Infof("Using context %v", o.context)
-	if isKubernikusContext, err := o.isKubernikusContext(); err != nil {
-		glog.V(2).Infof("Not a valid Kubernikus context: %v", err)
+	ktx, err := common.NewKubernikusContext(o.kubeconfigPath, o.context)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to load kubeconfig")
+	}
+	if isKubernikusCtx, err := ktx.IsKubernikusContext(); err != nil || !isKubernikusCtx {
+		glog.V(2).Infof("%s is not a valid Kubernikus context: %v", o.context, err)
 		return nil
-	} else {
-		if !isKubernikusContext {
-			glog.V(2).Infof("Not a valid Kubernikus context")
-			return nil
-		}
 	}
 
-	if ok, err := o.isCertificateValid(); err != nil {
-		return errors.Wrap(err, "Verification of certificates failed.")
+	if ok, err := ktx.UserCertificateValid(); err != nil {
+		return errors.Wrap(err, "Verification of certificate failed.")
 	} else {
 		if ok && !o.force {
 			glog.V(2).Infof("Certificates are good. Doing nothing.")
@@ -113,45 +85,44 @@ func (o *RefreshOptions) Run(c *cobra.Command) error {
 		}
 	}
 
-	if identityEndpoint, projectID, err := o.autoDetectKubernikusOpenstackMetadata(); err != nil {
-		return errors.Wrap(err, "Auto-Detection of Openstack auth endpoint failed.")
-	} else {
-		glog.V(2).Infof("Detected auth-url: %v", identityEndpoint)
-		o.openstack.IdentityEndpoint = identityEndpoint
-		glog.V(2).Infof("Detected authentication scope for project-id: %v", projectID)
-		o.openstack.Scope.ProjectID = projectID
-		//Ignore conflicting values from environment
-		o.openstack.Scope.ProjectName = ""
-		o.openstack.Scope.DomainID = ""
-		o.openstack.Scope.DomainName = ""
+	authURL, err := ktx.AuthURL()
+	if err != nil {
+		return errors.Wrap(err, "Couldn't get AuthURL")
+	}
+	projectID, err := ktx.ProjectID()
+	if err != nil {
+		return errors.Wrap(err, "Couldn't get project ID")
 	}
 
-	if kurl, err := o.autoDetectKubernikusURL(); err != nil {
-		return errors.Wrap(err, "Auto-Detection of Kubernikus URL caused an error")
-	} else {
-		glog.V(2).Infof("Detected Kubernikus URL: %v", kurl)
-		_url, err := url.Parse(kurl)
-		if err != nil {
-			return errors.Wrap(err, "Couldn't parse Kubernikus URL. Rerun init.")
-		}
-		o.url = _url
+	glog.V(2).Infof("Detected auth-url: %v", authURL)
+	o.openstack.IdentityEndpoint = authURL
+	glog.V(2).Infof("Detected authentication scope for project-id: %v", projectID)
+	o.openstack.Scope.ProjectID = projectID
+	//Ignore conflicting values from environment
+	o.openstack.Scope.ProjectName = ""
+	o.openstack.Scope.DomainID = ""
+	o.openstack.Scope.DomainName = ""
+
+	kurl, err := ktx.KubernikusURL()
+	if err != nil {
+		return errors.Wrap(err, "Couldn't get kubernikus URL from certificate")
+	}
+	glog.V(2).Infof("Detected Kubernikus URL: %v", kurl)
+	if o.url, err = url.Parse(kurl); err != nil {
+		return errors.Wrap(err, "Couldn't parse Kubernikus URL. Rerun init.")
 	}
 
-	if username, err := o.autoDetectUsername(); err != nil {
-		return errors.Wrap(err, "Auto-Detection of Username failed")
-	} else {
-		glog.V(2).Infof("Detected username: %v", username)
-		o.openstack.Username = username
-		o.openstack.UserID = "" //Ignore conflicting value from env environment
+	if o.openstack.Username, err = ktx.Username(); err != nil {
+		return errors.Wrap(err, "Failed to extract username from certificate")
 	}
+	glog.V(2).Infof("Detected username: %v", o.openstack.Username)
+	o.openstack.UserID = "" //Ignore conflicting value from env environment
 
-	if domainName, err := o.autoDetectUserDomainName(); err != nil {
-		return errors.Wrap(err, "Auto-Detection of user domain failed")
-	} else {
-		glog.V(2).Infof("Detected domain-name: %v", domainName)
-		o.openstack.DomainName = domainName
-		o.openstack.DomainID = "" //Ignore conflicting value from environment
+	if o.openstack.DomainName, err = ktx.UserDomainname(); err != nil {
+		return errors.Wrap(err, "Failed to extract user domain from certificate")
 	}
+	glog.V(2).Infof("Detected domain-name: %v", o.openstack.DomainName)
+	o.openstack.DomainID = "" //Ignore conflicting value from environment
 
 	storePasswordInKeyRing := false
 	if o.openstack.Password == "" {
@@ -184,12 +155,12 @@ func (o *RefreshOptions) Run(c *cobra.Command) error {
 		keyring.Set("kubernikus", strings.ToLower(o.openstack.Username), o.openstack.Password)
 	}
 
-	err = o.mergeAndPersist(kubeconfig)
+	err = ktx.MergeAndPersist(kubeconfig)
 	if err != nil {
 		return errors.Wrapf(err, "Couldn't merge existing kubeconfig with fetched credentials")
 	}
 
-	fmt.Printf("Wrote merged kubeconfig to %v\n", clientcmd.NewDefaultPathOptions().GetDefaultFilename())
+	fmt.Printf("Updated kubeconfig at %v\n", ktx.PathOptions.GetDefaultFilename())
 
 	return nil
 }
@@ -209,190 +180,4 @@ func (o *RefreshOptions) setupClients() error {
 	o.kubernikus = common.NewKubernikusClient(o.url, o.openstack.Provider.TokenID)
 
 	return nil
-}
-
-func (o *RefreshOptions) loadKubeconfig() (err error) {
-	if o.kubeconfig, err = clientcmd.LoadFromFile(o.kubeconfigPath); err != nil {
-		return errors.Wrapf(err, "Failed to load kubeconfig from %v", o.kubeconfigPath)
-	}
-	return nil
-}
-
-func (o *RefreshOptions) isKubernikusContext() (bool, error) {
-	caCert, err := o.getCACertificate()
-	if err != nil {
-		return false, err
-	}
-
-	if len(caCert.Subject.OrganizationalUnit) < 2 {
-		return false, nil
-	}
-
-	return caCert.Subject.OrganizationalUnit[0] == util.CA_ISSUER_KUBERNIKUS_IDENTIFIER_0 &&
-		caCert.Subject.OrganizationalUnit[1] == util.CA_ISSUER_KUBERNIKUS_IDENTIFIER_1, nil
-}
-
-func (o *RefreshOptions) autoDetectKubernikusOpenstackMetadata() (string, string, error) {
-	cert, err := o.getClientCertificate()
-	if err != nil {
-		return "", "", err
-	}
-	if len(cert.Subject.Province) < 2 {
-		return "", "", errors.Errorf("Client certificate didn't contain Kubernikus metadata")
-	}
-	return cert.Subject.Province[0], cert.Subject.Province[1], nil
-}
-
-func (o *RefreshOptions) autoDetectKubernikusClientMetadata() (string, string, error) {
-	cert, err := o.getClientCertificate()
-	if err != nil {
-		return "", "", err
-	}
-	if cert.Subject.CommonName == "" {
-		return "", "", errors.Errorf("Client certificate didn't contain username")
-	}
-
-	parts := strings.Split(cert.Subject.CommonName, "@")
-	if len(parts) != 2 {
-		return "", "", errors.Errorf("Couldn't extract username/domain from client certificate %v", parts)
-	}
-
-	return parts[0], parts[1], nil
-}
-
-func (o *RefreshOptions) autoDetectKubernikusURL() (string, error) {
-	cert, err := o.getClientCertificate()
-	if err != nil {
-		return "", err
-	}
-
-	if len(cert.Subject.Locality) == 0 {
-		return "", errors.Errorf("CA certificate didn't contain Kubernikus metadata")
-	}
-	return cert.Subject.Locality[0], nil
-}
-
-func (o *RefreshOptions) autoDetectUsername() (string, error) {
-	user, _, err := o.autoDetectKubernikusClientMetadata()
-	if err != nil {
-		return "", err
-	}
-	return user, nil
-}
-
-func (o *RefreshOptions) autoDetectUserDomainName() (string, error) {
-	_, domain, err := o.autoDetectKubernikusClientMetadata()
-	if err != nil {
-		return "", err
-	}
-	return domain, nil
-}
-
-func (o *RefreshOptions) getRawClientCertificate() ([]byte, error) {
-	context := o.kubeconfig.Contexts[o.context]
-	if context == nil {
-		return nil, errors.Errorf("Couldn't find context %v", o.context)
-	}
-
-	authInfo := o.kubeconfig.AuthInfos[context.AuthInfo]
-	if authInfo == nil {
-		return nil, errors.Errorf("Couldn't find auth-info %v for context %v", context.AuthInfo, o.context)
-	}
-
-	cluster := o.kubeconfig.Clusters[context.Cluster]
-	if cluster == nil {
-		return nil, errors.Errorf("Couldn't find cluster %v", context.Cluster)
-	}
-
-	certData := authInfo.ClientCertificateData
-	if certData == nil {
-		return nil, errors.Errorf("Couldn't find client certificate for auth-info %v", authInfo.Username)
-	}
-
-	return certData, nil
-}
-
-func (o *RefreshOptions) getRawCACertificate() ([]byte, error) {
-	context := o.kubeconfig.Contexts[o.context]
-	if context == nil {
-		return nil, errors.Errorf("Couldn't find context %v", o.context)
-	}
-
-	authInfo := o.kubeconfig.AuthInfos[context.AuthInfo]
-	if authInfo == nil {
-		return nil, errors.Errorf("Couldn't find auth-info %v for context %v", context.AuthInfo, o.context)
-	}
-
-	cluster := o.kubeconfig.Clusters[context.Cluster]
-	if cluster == nil {
-		return nil, errors.Errorf("Couldn't find cluster %v", context.Cluster)
-	}
-
-	certData := cluster.CertificateAuthorityData
-	if certData == nil {
-		return nil, errors.Errorf("Couldn't find CA certificate for cluster %v", context.Cluster)
-	}
-
-	return certData, nil
-}
-
-func (o *RefreshOptions) getCACertificate() (*x509.Certificate, error) {
-	data, err := o.getRawCACertificate()
-	if err != nil {
-		return nil, err
-	}
-	return parseRawPEM(data)
-}
-
-func (o *RefreshOptions) getClientCertificate() (*x509.Certificate, error) {
-	data, err := o.getRawClientCertificate()
-	if err != nil {
-		return nil, err
-	}
-	return parseRawPEM(data)
-}
-
-func (o *RefreshOptions) isCertificateValid() (bool, error) {
-	cert, err := o.getClientCertificate()
-	if err != nil {
-		return false, err
-	}
-
-	if time.Now().After(cert.NotAfter) || time.Now().Before(cert.NotBefore) {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func (o *RefreshOptions) mergeAndPersist(rawConfig string) error {
-	config, err := clientcmd.Load([]byte(rawConfig))
-	if err != nil {
-		return errors.Wrapf(err, "Couldn't load kubernikus kubeconfig: %v", rawConfig)
-	}
-
-	if err := mergo.MergeWithOverwrite(o.kubeconfig, config); err != nil {
-		return errors.Wrap(err, "Couldn't merge kubeconfigs")
-	}
-
-	defaultPathOptions := clientcmd.NewDefaultPathOptions()
-	if err = clientcmd.ModifyConfig(defaultPathOptions, *o.kubeconfig, false); err != nil {
-		return errors.Wrapf(err, "Couldn't merge Kubernikus config with kubeconfig at %v:", defaultPathOptions.GetDefaultFilename())
-	}
-
-	return nil
-}
-
-func parseRawPEM(data []byte) (*x509.Certificate, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, errors.New("Couldn't decode raw certificate")
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Couldn't parse certificate")
-	}
-
-	return cert, nil
 }

--- a/pkg/cmd/kubernikusctl/common/kubecontext.go
+++ b/pkg/cmd/kubernikusctl/common/kubecontext.go
@@ -1,0 +1,236 @@
+package common
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"time"
+
+	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/sapcc/kubernikus/pkg/util"
+)
+
+func NewKubernikusContext(kubeconfig, context string) (*KubernikusContext, error) {
+
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	pathOptions.LoadingRules.ExplicitPath = kubeconfig
+
+	config, err := pathOptions.GetStartingConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	ktx := &KubernikusContext{Config: config, PathOptions: pathOptions, context: context}
+
+	return ktx, err
+}
+
+type KubernikusContext struct {
+	PathOptions *clientcmd.PathOptions
+	Config      *clientcmdapi.Config
+	context     string
+	caCert      *x509.Certificate
+	clientCert  *x509.Certificate
+}
+
+func (ktx *KubernikusContext) IsKubernikusContext() (bool, error) {
+	caCert, err := ktx.getCACertificate()
+	if err != nil {
+		return false, err
+	}
+
+	if len(caCert.Subject.OrganizationalUnit) < 2 {
+		return false, nil
+	}
+
+	return caCert.Subject.OrganizationalUnit[0] == util.CA_ISSUER_KUBERNIKUS_IDENTIFIER_0 &&
+		caCert.Subject.OrganizationalUnit[1] == util.CA_ISSUER_KUBERNIKUS_IDENTIFIER_1, nil
+}
+
+func (ktx *KubernikusContext) UserCertificateValid() (bool, error) {
+	cert, err := ktx.getClientCertificate()
+	if err != nil {
+		return false, err
+	}
+
+	return time.Now().After(cert.NotBefore) && time.Now().Before(cert.NotAfter), nil
+}
+
+func (ktx *KubernikusContext) Username() (string, error) {
+	cert, err := ktx.getClientCertificate()
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(cert.Subject.CommonName, "@")
+	if len(parts) != 2 {
+		return "", errors.Errorf("Couldn't extract username/domain from client certificate %v", parts)
+	}
+	return parts[0], nil
+}
+
+func (ktx *KubernikusContext) UserDomainname() (string, error) {
+	cert, err := ktx.getClientCertificate()
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(cert.Subject.CommonName, "@")
+	if len(parts) != 2 {
+		return "", errors.Errorf("Couldn't extract username/domain from client certificate %v", parts)
+	}
+	return parts[1], nil
+}
+
+func (ktx *KubernikusContext) KubernikusURL() (string, error) {
+	cert, err := ktx.getClientCertificate()
+	if err != nil {
+		return "", err
+	}
+
+	if len(cert.Subject.Locality) == 0 {
+		return "", errors.Errorf("CA certificate didn't contain Kubernikus metadata")
+	}
+	return cert.Subject.Locality[0], nil
+}
+
+func (ktx *KubernikusContext) AuthURL() (string, error) {
+	cert, err := ktx.getClientCertificate()
+	if err != nil {
+		return "", err
+	}
+	if len(cert.Subject.Province) < 2 {
+		return "", errors.Errorf("Client certificate didn't contain OpenStack metadata")
+	}
+	return cert.Subject.Province[0], nil
+}
+
+func (ktx *KubernikusContext) ProjectID() (string, error) {
+	cert, err := ktx.getClientCertificate()
+	if err != nil {
+		return "", err
+	}
+	if len(cert.Subject.Province) < 2 {
+		return "", errors.Errorf("Client certificate didn't contain OpenStack metadata")
+	}
+	return cert.Subject.Province[1], nil
+}
+
+func (ktx *KubernikusContext) MergeAndPersist(rawConfig string) error {
+	config, err := clientcmd.Load([]byte(rawConfig))
+	if err != nil {
+		return errors.Wrapf(err, "Couldn't load kubernikus kubeconfig: %v", rawConfig)
+	}
+
+	//don't change the current context if there is already one set
+	if ktx.Config.CurrentContext != "" {
+		config.CurrentContext = ""
+	}
+	if err := mergo.MergeWithOverwrite(ktx.Config, config); err != nil {
+		return errors.Wrap(err, "Couldn't merge kubeconfigs")
+	}
+
+	if err = clientcmd.ModifyConfig(ktx.PathOptions, *ktx.Config, false); err != nil {
+		return errors.Wrapf(err, "Couldn't merge Kubernikus config with kubeconfig at %v:", ktx.PathOptions.GetDefaultFilename())
+	}
+
+	return nil
+}
+
+func (ktx *KubernikusContext) getCACertificate() (*x509.Certificate, error) {
+	if ktx.caCert != nil {
+		return ktx.caCert, nil
+	}
+	data, err := ktx.getRawCACertificate()
+	if err != nil {
+		return nil, err
+	}
+	c, err := parseRawPEM(data)
+	if err != nil {
+		return nil, err
+	}
+	ktx.caCert = c
+	return ktx.caCert, nil
+}
+
+func (ktx *KubernikusContext) getRawCACertificate() ([]byte, error) {
+	context := ktx.Config.Contexts[ktx.context]
+	if context == nil {
+		return nil, errors.Errorf("Couldn't find context %v", ktx.context)
+	}
+
+	authInfo := ktx.Config.AuthInfos[context.AuthInfo]
+	if authInfo == nil {
+		return nil, errors.Errorf("Couldn't find auth-info %v for context %v", context.AuthInfo, ktx.context)
+	}
+
+	cluster := ktx.Config.Clusters[context.Cluster]
+	if cluster == nil {
+		return nil, errors.Errorf("Couldn't find cluster %v", context.Cluster)
+	}
+
+	certData := cluster.CertificateAuthorityData
+	if certData == nil {
+		return nil, errors.Errorf("Couldn't find CA certificate for cluster %v", context.Cluster)
+	}
+
+	return certData, nil
+}
+
+func (ktx *KubernikusContext) getClientCertificate() (*x509.Certificate, error) {
+	if ktx.clientCert != nil {
+		return ktx.clientCert, nil
+	}
+	data, err := ktx.getRawClientCertificate()
+	if err != nil {
+		return nil, err
+	}
+	c, err := parseRawPEM(data)
+	if err != nil {
+		return nil, err
+	}
+	ktx.clientCert = c
+	return ktx.clientCert, nil
+}
+
+func (ktx *KubernikusContext) getRawClientCertificate() ([]byte, error) {
+	context := ktx.Config.Contexts[ktx.context]
+	if context == nil {
+		return nil, errors.Errorf("Couldn't find context %v", ktx.context)
+	}
+
+	authInfo := ktx.Config.AuthInfos[context.AuthInfo]
+	if authInfo == nil {
+		return nil, errors.Errorf("Couldn't find auth-info %v for context %v", context.AuthInfo, ktx.context)
+	}
+
+	cluster := ktx.Config.Clusters[context.Cluster]
+	if cluster == nil {
+		return nil, errors.Errorf("Couldn't find cluster %v", context.Cluster)
+	}
+
+	certData := authInfo.ClientCertificateData
+	if certData == nil {
+		return nil, errors.Errorf("Couldn't find client certificate for auth-info %v", authInfo.Username)
+	}
+
+	return certData, nil
+}
+
+func parseRawPEM(data []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("Couldn't decode raw certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Couldn't parse certificate")
+	}
+
+	return cert, nil
+}

--- a/pkg/cmd/kubernikusctl/common/kubecontext_test.go
+++ b/pkg/cmd/kubernikusctl/common/kubecontext_test.go
@@ -25,13 +25,13 @@ func TestKubernikusContext(t *testing.T) {
 
 	config := &clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"test": &clientcmdapi.Cluster{CertificateAuthorityData: []byte(certs.ApiserverClientsCACertifcate)},
+			"test": {CertificateAuthorityData: []byte(certs.ApiserverClientsCACertifcate)},
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"test": &clientcmdapi.AuthInfo{ClientCertificateData: certutil.EncodeCertPEM(bundle.Certificate)},
+			"test": {ClientCertificateData: certutil.EncodeCertPEM(bundle.Certificate)},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			"test": &clientcmdapi.Context{Cluster: "test", AuthInfo: "test"},
+			"test": {Cluster: "test", AuthInfo: "test"},
 		},
 	}
 

--- a/pkg/cmd/kubernikusctl/common/kubecontext_test.go
+++ b/pkg/cmd/kubernikusctl/common/kubecontext_test.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/sapcc/kubernikus/pkg/api/models"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/util"
+)
+
+func TestKubernikusContext(t *testing.T) {
+
+	kluster := &v1.Kluster{Spec: models.KlusterSpec{ServiceCIDR: "192.168.0.0/24", Openstack: models.OpenstackSpec{ProjectID: "12345678"}}}
+	certs := new(v1.Certificates)
+
+	factory := util.NewCertificateFactory(kluster, certs, "test.local")
+	require.NoError(t, factory.Ensure())
+	bundle, err := factory.UserCert(&models.Principal{Name: "exampleuser", Domain: "exampledomain", AuthURL: "http://auth.url"}, "http://kubernikus.url")
+	require.NoError(t, err)
+
+	config := &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": &clientcmdapi.Cluster{CertificateAuthorityData: []byte(certs.ApiserverClientsCACertifcate)},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"test": &clientcmdapi.AuthInfo{ClientCertificateData: certutil.EncodeCertPEM(bundle.Certificate)},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": &clientcmdapi.Context{Cluster: "test", AuthInfo: "test"},
+		},
+	}
+
+	ctx := KubernikusContext{Config: config, context: "test"}
+	b, err := ctx.IsKubernikusContext()
+	require.NoError(t, err, "IsKubernikusContext shouldn't error")
+	require.True(t, b, "IsKubernikusContext should be true")
+	b, err = ctx.UserCertificateValid()
+	assert.NoError(t, err, "UserCertificateExpired shouldn't error")
+	assert.True(t, b, "UserCertificateExpired should be true")
+
+	cases := []struct {
+		Name         string
+		Func         func() (string, error)
+		ResultString string
+	}{
+		{Name: "AuthURL", Func: ctx.AuthURL, ResultString: "http://auth.url"},
+		{Name: "Username", Func: ctx.Username, ResultString: "exampleuser"},
+		{Name: "UserDomainame", Func: ctx.UserDomainname, ResultString: "exampledomain"},
+		{Name: "ProjectID", Func: ctx.ProjectID, ResultString: "12345678"},
+		{Name: "KubernikusURL", Func: ctx.KubernikusURL, ResultString: "http://kubernikus.url"},
+	}
+
+	for _, c := range cases {
+		result, err := c.Func()
+		if assert.NoError(t, err, "Expected %s to not return an error", c.Name) {
+			assert.Equal(t, c.ResultString, result, "Expected %s to return %s", c.Name, c.ResultString)
+		}
+	}
+
+}


### PR DESCRIPTION
This PR extracts the kubecontext shenenegans that are happening in auth refresh and partly auth init into a library (with some basic tests).