### PR TITLE
Configurable taints and labels per nodepool

### DIFF
--- a/pkg/api/models/node_pool.go
+++ b/pkg/api/models/node_pool.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"strconv"
+
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -30,6 +32,9 @@ type NodePool struct {
 	// image
 	Image string `json:"image,omitempty"`
 
+	// labels
+	Labels []string `json:"labels"`
+
 	// name
 	// Required: true
 	// Max Length: 20
@@ -40,6 +45,9 @@ type NodePool struct {
 	// Maximum: 127
 	// Minimum: 0
 	Size int64 `json:"size"`
+
+	// taints
+	Taints []string `json:"taints"`
 }
 
 // Validate validates this node pool
@@ -54,11 +62,19 @@ func (m *NodePool) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateLabels(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateName(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateSize(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTaints(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -93,6 +109,23 @@ func (m *NodePool) validateFlavor(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *NodePool) validateLabels(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Labels) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Labels); i++ {
+
+		if err := validate.Pattern("labels"+"."+strconv.Itoa(i), "body", string(m.Labels[i]), `^([a-z0-9]([-a-z0-9]*[a-z0-9])(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}$`); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
 func (m *NodePool) validateName(formats strfmt.Registry) error {
 
 	if err := validate.RequiredString("name", "body", string(m.Name)); err != nil {
@@ -122,6 +155,23 @@ func (m *NodePool) validateSize(formats strfmt.Registry) error {
 
 	if err := validate.MaximumInt("size", "body", int64(m.Size), 127, false); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *NodePool) validateTaints(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Taints) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Taints); i++ {
+
+		if err := validate.Pattern("taints"+"."+strconv.Itoa(i), "body", string(m.Taints[i]), `^([a-z0-9]([-a-z0-9]*[a-z0-9])(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}:(NoSchedule|NoExecute|PreferNoSchedule)$`); err != nil {
+			return err
+		}
+
 	}
 
 	return nil

--- a/pkg/api/models/node_pool.go
+++ b/pkg/api/models/node_pool.go
@@ -32,7 +32,7 @@ type NodePool struct {
 	// image
 	Image string `json:"image,omitempty"`
 
-	// labels
+	// The specified labels will be added to members of this pool once during initial registration of the node
 	Labels []string `json:"labels"`
 
 	// name
@@ -46,7 +46,7 @@ type NodePool struct {
 	// Minimum: 0
 	Size int64 `json:"size"`
 
-	// taints
+	// The specified taints will be added to members of this pool once during initial registration of the node
 	Taints []string `json:"taints"`
 }
 

--- a/pkg/api/models/node_pool_test.go
+++ b/pkg/api/models/node_pool_test.go
@@ -27,3 +27,71 @@ func TestNodePoolValidation(t *testing.T) {
 	}
 	assert.Error(t, pool.Validate(strfmt.Default))
 }
+
+func TestNodePoolTaintValidation(t *testing.T) {
+	cases := []struct {
+		Taint string
+		Valid bool
+	}{
+		{"valid=taint:NoSchedule", true},
+		{"sap.com/valid=taint:NoSchedule", true},
+		{"sap.com/valid=taint:NoExecute", true},
+		{"sap.com/valid=taint:NoExecute1", false},
+		{"sap.com/invalid=taint:InvalidAction", false},
+		{"sap._com/invalid=taint:NoSchedule", false},
+		{"sap.com/in&valid=taint:NoSchedule", false},
+		{".com/in&valid=taint.:NoSchedule", false},
+		{"tolongvalue=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab:NoSchedule", false},
+	}
+
+	for _, c := range cases {
+		pool := NodePool{
+			AvailabilityZone: "something",
+			Name:             "test",
+			Flavor:           "nase",
+			Size:             0,
+			Taints:           []string{c.Taint},
+		}
+
+		err := pool.Validate(strfmt.Default)
+		if c.Valid {
+			assert.NoError(t, err, "expected taint %s to be valid", c.Taint)
+		} else {
+			assert.Error(t, err, "expected taint %s to be invalid", c.Taint)
+		}
+	}
+
+}
+
+func TestNodePoolLabelValidation(t *testing.T) {
+	cases := []struct {
+		Label string
+		Valid bool
+	}{
+		{"valid=label", true},
+		{"sap.com/val-id=label", true},
+		{"sap.com/invalid=label:NoExecute", false},
+		{"sap._com/invalid=label", false},
+		{"sap.com/in&valid=label", false},
+		{"sap.com/.invalid=", false},
+		{"tolongvalue=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", false},
+	}
+
+	for _, c := range cases {
+		pool := NodePool{
+			AvailabilityZone: "something",
+			Name:             "test",
+			Flavor:           "nase",
+			Size:             0,
+			Labels:           []string{c.Label},
+		}
+
+		err := pool.Validate(strfmt.Default)
+		if c.Valid {
+			assert.NoError(t, err, "expected label %s to be valid", c.Label)
+		} else {
+			assert.Error(t, err, "expected label %s to be invalid", c.Label)
+		}
+	}
+
+}

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -557,6 +557,7 @@ func init() {
           "x-nullable": false
         },
         "labels": {
+          "description": "The specified labels will be added to members of this pool once during initial registration of the node",
           "type": "array",
           "items": {
             "type": "string",
@@ -576,6 +577,7 @@ func init() {
           "x-nullable": false
         },
         "taints": {
+          "description": "The specified taints will be added to members of this pool once during initial registration of the node",
           "type": "array",
           "items": {
             "type": "string",
@@ -1391,6 +1393,7 @@ func init() {
           "x-nullable": false
         },
         "labels": {
+          "description": "The specified labels will be added to members of this pool once during initial registration of the node",
           "type": "array",
           "items": {
             "type": "string",
@@ -1411,6 +1414,7 @@ func init() {
           "x-nullable": false
         },
         "taints": {
+          "description": "The specified taints will be added to members of this pool once during initial registration of the node",
           "type": "array",
           "items": {
             "type": "string",

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -556,6 +556,13 @@ func init() {
           "default": "coreos-stable-amd64",
           "x-nullable": false
         },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])(\\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}$"
+          }
+        },
         "name": {
           "type": "string",
           "maxLength": 20,
@@ -567,6 +574,13 @@ func init() {
           "default": 0,
           "maximum": 127,
           "x-nullable": false
+        },
+        "taints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])(\\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}:(NoSchedule|NoExecute|PreferNoSchedule)$"
+          }
         }
       },
       "x-nullable": false
@@ -1376,6 +1390,13 @@ func init() {
           "default": "coreos-stable-amd64",
           "x-nullable": false
         },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])(\\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}$"
+          }
+        },
         "name": {
           "type": "string",
           "maxLength": 20,
@@ -1388,6 +1409,13 @@ func init() {
           "maximum": 127,
           "minimum": 0,
           "x-nullable": false
+        },
+        "taints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])(\\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}:(NoSchedule|NoExecute|PreferNoSchedule)$"
+          }
         }
       },
       "x-nullable": false

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -68,16 +68,21 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 		}
 	}
 	var nodeLabels []string
+	var nodeTaints []string
 	if pool != nil {
 		nodeLabels = append(nodeLabels, "ccloud.sap.com/nodepool="+pool.Name)
 		if strings.HasPrefix(pool.Flavor, "zg") {
 			nodeLabels = append(nodeLabels, "gpu=nvidia-tesla-v100")
 		}
-	}
-
-	var nodeTaints []string
-	if pool != nil && strings.HasPrefix(pool.Flavor, "zg") {
-		nodeTaints = append(nodeTaints, "nvidia.com/gpu=present:NoSchedule")
+		if strings.HasPrefix(pool.Flavor, "zg") {
+			nodeTaints = append(nodeTaints, "nvidia.com/gpu=present:NoSchedule")
+		}
+		for _, userTaint := range pool.Taints {
+			nodeTaints = append(nodeTaints, userTaint)
+		}
+		for _, userLabel := range pool.Labels {
+			nodeLabels = append(nodeLabels, userLabel)
+		}
 	}
 
 	data := struct {

--- a/swagger.yml
+++ b/swagger.yml
@@ -455,6 +455,18 @@ definitions:
       availabilityZone:
         type: string
         x-nullable: false
+      taints:
+        type: array
+        items:
+          type: string
+          # validate [valid label name]=[valid label value]:[valid effect]
+          pattern: '^([a-z0-9]([-a-z0-9]*[a-z0-9])(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}:(NoSchedule|NoExecute|PreferNoSchedule)$'
+      labels:
+        type: array
+        items:
+          type: string
+          # validate [valid label name]=[valid label value]
+          pattern: '^([a-z0-9]([-a-z0-9]*[a-z0-9])(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}$'
       config:
         $ref: '#/definitions/NodePoolConfig'
   NodePoolConfig:

--- a/swagger.yml
+++ b/swagger.yml
@@ -456,12 +456,14 @@ definitions:
         type: string
         x-nullable: false
       taints:
+        description: The specified taints will be added to members of this pool once during initial registration of the node
         type: array
         items:
           type: string
           # validate [valid label name]=[valid label value]:[valid effect]
           pattern: '^([a-z0-9]([-a-z0-9]*[a-z0-9])(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*/)?[A-Za-z0-9][-A-Za-z0-9_.]{0,62}=[A-Za-z0-9][-A-Za-z0-9_.]{0,62}:(NoSchedule|NoExecute|PreferNoSchedule)$'
       labels:
+        description: The specified labels will be added to members of this pool once during initial registration of the node
         type: array
         items:
           type: string


### PR DESCRIPTION
This PR amends the api and allows to specify and array of labels and taints for each node pool.

The provided labels/taints are added by the kublet once during initial registration.

As a next step the flight controller should periodically reconcile to ensure changes are reflected on existing nodes.
