### PR TITLE
Change kublet startup options if calico daemonset is deployed

### DIFF
--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -195,7 +195,14 @@ func (cpm *ConcretePoolManager) CreateNode() (id string, err error) {
 
 	nodeName := generator.SimpleNameGenerator.GenerateName(fmt.Sprintf("%v-%v-", cpm.Kluster.Spec.Name, cpm.Pool.Name))
 
-	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, cpm.Pool, nodeName, secret, cpm.imageRegistry, cpm.Logger)
+	calicoNetworking := false
+	if client, err := cpm.Clients.Satellites.ClientFor(cpm.Kluster); err == nil {
+		if _, err := client.AppsV1().DaemonSets("kube-system").Get("calico-node", metav1.GetOptions{}); err == nil {
+			calicoNetworking = true
+		}
+	}
+
+	userdata, err := templates.Ignition.GenerateNode(cpm.Kluster, cpm.Pool, nodeName, secret, calicoNetworking, cpm.imageRegistry, cpm.Logger)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -40,7 +40,7 @@ func (i *ignition) getIgnitionTemplate(kluster *kubernikusv1.Kluster) string {
 	}
 }
 
-func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.NodePool, nodeName string, secret *kubernikusv1.Secret, imageRegistry version.ImageRegistry, logger log.Logger) ([]byte, error) {
+func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.NodePool, nodeName string, secret *kubernikusv1.Secret, calicoNetworking bool, imageRegistry version.ImageRegistry, logger log.Logger) ([]byte, error) {
 
 	ignition := i.getIgnitionTemplate(kluster)
 	tmpl, err := template.New("node").Funcs(sprig.TxtFuncMap()).Parse(ignition)
@@ -118,6 +118,7 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 		NodeName                           string
 		HyperkubeImage                     string
 		HyperkubeImageTag                  string
+		CalicoNetworking                   bool
 	}{
 		TLSCA:                              secret.TLSCACertificate,
 		KubeletClientsCA:                   secret.KubeletClientsCACertificate,
@@ -146,6 +147,7 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 		NodeName:                           nodeName,
 		HyperkubeImage:                     images.Hyperkube.Repository,
 		HyperkubeImageTag:                  images.Hyperkube.Tag,
+		CalicoNetworking:                   calicoNetworking,
 	}
 
 	var dataOut []byte

--- a/pkg/templates/ignition_test.go
+++ b/pkg/templates/ignition_test.go
@@ -82,7 +82,7 @@ func TestGenerateNode(t *testing.T) {
 
 	for version := range imageRegistry.Versions {
 		kluster.Spec.Version = version
-		data, err := Ignition.GenerateNode(kluster, nil, "test", &testKlusterSecret, imageRegistry, log.NewNopLogger())
+		data, err := Ignition.GenerateNode(kluster, nil, "test", &testKlusterSecret, false, imageRegistry, log.NewNopLogger())
 		if assert.NoError(t, err, "Failed to generate node for version %s", version) {
 			//Ensure we rendered the expected template
 			assert.Contains(t, string(data), fmt.Sprintf("KUBELET_IMAGE_TAG=v%s", version))
@@ -96,14 +96,14 @@ func TestNodeLabels(t *testing.T) {
 
 	pool := &models.NodePool{Name: "some-name"}
 
-	data, err := Ignition.GenerateNode(kluster, pool, "test", &testKlusterSecret, imageRegistry, log.NewNopLogger())
+	data, err := Ignition.GenerateNode(kluster, pool, "test", &testKlusterSecret, false, imageRegistry, log.NewNopLogger())
 	if assert.NoError(t, err, "Failed to generate node") {
 		//Ensure we rendered the expected template
 		assert.Contains(t, string(data), fmt.Sprintf("--node-labels=ccloud.sap.com/nodepool=%s", pool.Name))
 	}
 
 	gpuPool := &models.NodePool{Name: "some-name", Flavor: "zghuh"}
-	data, err = Ignition.GenerateNode(kluster, gpuPool, "test", &testKlusterSecret, imageRegistry, log.NewNopLogger())
+	data, err = Ignition.GenerateNode(kluster, gpuPool, "test", &testKlusterSecret, false, imageRegistry, log.NewNopLogger())
 	if assert.NoError(t, err, "Failed to generate node") {
 		//Ensure we rendered the expected template
 		assert.Contains(t, string(data), fmt.Sprintf("--node-labels=ccloud.sap.com/nodepool=%s,gpu=nvidia-tesla-v100", pool.Name))

--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -88,6 +88,14 @@ systemd:
           --mount volume=var-log,target=/var/log \
           --mount volume=etc-machine-id,target=/etc/machine-id \
           --mount volume=modprobe,target=/usr/sbin/modprobe \
+{{- if .CalicoNetworking }}
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
+          --volume etc-cni,kind=host,source=/etc/cni,readOnly=true \
+          --volume opt-cni,kind=host,source=/opt/cni,readOnly=true \
+          --mount volume=var-lib-calico,target=/var/lib/calico \
+          --mount volume=etc-cni,target=/etc/cni \
+          --mount volume=opt-cni,target=/opt/cni \
+{{- end }}
           --insecure-options=image"
         Environment="KUBELET_IMAGE_TAG={{ .HyperkubeImageTag }}"
         Environment="KUBELET_IMAGE_URL=docker://{{ .HyperkubeImage }}"
@@ -103,7 +111,11 @@ systemd:
           --config=/etc/kubernetes/kubelet/config \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap/kubeconfig \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
+{{- if .CalicoNetworking }}
+          --network-plugin=cni \
+{{- else }}
           --network-plugin=kubenet \
+{{- end }}
           --non-masquerade-cidr=0.0.0.0/0 \
           --lock-file=/var/run/lock/kubelet.lock \
           --pod-infra-container-image=sapcc/pause-amd64:3.1 \


### PR DESCRIPTION
This is a quick hack that allows us to selectively run calico in `policy-only` mode to support network policies without changing the kubernikus api.