### PR TITLE
Add annotation to protect from accidential kluster deletion 

### DIFF
--- a/pkg/apis/kubernikus/v1/kluster.go
+++ b/pkg/apis/kubernikus/v1/kluster.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var TerminationProtectionAnnotationKey = "kubernikus.cloud.sap/termination-protection"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -96,4 +98,8 @@ func (k *Kluster) RemoveFinalizer(finalizer string) {
 
 func (k *Kluster) Disabled() bool {
 	return k.Status.MigrationsPending
+}
+
+func (k *Kluster) TerminationProtection() bool {
+	return k.Annotations[TerminationProtectionAnnotationKey] != ""
 }

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -315,7 +315,7 @@ func (op *GroundControl) handler(key string) error {
 				// There's a "soft" agreement that Finalizers are executed in order from
 				// first to last. Here we check that Groundctl is the last remaining one and
 				// spare us the trouble to maintain a ordered list.
-				if !(len(kluster.Finalizers) == 1 && kluster.Finalizers[0] == GroundctlFinalizer) {
+				if kluster.TerminationProtection() || !(len(kluster.Finalizers) == 1 && kluster.Finalizers[0] == GroundctlFinalizer) {
 					return nil
 				}
 

--- a/pkg/controller/launch/controller.go
+++ b/pkg/controller/launch/controller.go
@@ -83,6 +83,9 @@ func (lr *LaunchReconciler) Reconcile(kluster *v1.Kluster) (requeue bool, err er
 	case models.KlusterPhaseRunning:
 		return lr.reconcilePools(kluster)
 	case models.KlusterPhaseTerminating:
+		if kluster.TerminationProtection() {
+			return false, nil
+		}
 		return lr.terminatePools(kluster)
 	}
 


### PR DESCRIPTION
This protects from deletion via kubernikus api and also adds a safeguard to `groundctl` and `launchctl` that even if the kluster crd is deleted/edited via kubernetes api the kluster will not be terminated.

To protect a kluster from deletion to:
```
kubectl annotation kluster $RESOURCE_NAME kubernikus.cloud.sap/termination-protection=yes
```