### PR TITLE
randomize hourly etcd backup schedule

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -117,14 +117,14 @@ spec:
           command:
             - etcdbrctl
             - server
-            - --schedule={{ .Values.backup.config.schedule }}
-            - --max-backups={{ .Values.backup.config.maxBackups }}
+            - --schedule={{ .Values.backup.schedule }}
+            - --max-backups={{ .Values.backup.maxBackups }}
             - --data-dir=/var/lib/etcd/new.etcd
             - --insecure-transport=true
             - --storage-provider=Swift
-            - --delta-snapshot-period-seconds={{ .Values.backup.config.deltaSnapshotPeriod }}
-            - --garbage-collection-period-seconds={{ .Values.backup.config.garbageCollectionPeriod }}
-            - --garbage-collection-policy={{ .Values.backup.config.garbageCollectionPolicy }}
+            - --delta-snapshot-period-seconds={{ .Values.backup.deltaSnapshotPeriod }}
+            - --garbage-collection-period-seconds={{ .Values.backup.garbageCollectionPeriod }}
+            - --garbage-collection-policy={{ .Values.backup.garbageCollectionPolicy }}
           image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
           imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
           ports:

--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -25,17 +25,16 @@ backup:
     repository: sapcc/etcdbrctl
     tag: 0.5.2
     pullPolicy: IfNotPresent
-  config:
-    # do a full-backup every hour
-    schedule: "15 * * * *"
-    # keep backups for one week
-    maxBackups: 168
-    # delta-snapshot every 10 seconds
-    deltaSnapshotPeriod: 10
-    # clean-up old backups every 5 minutes
-    garbageCollectionPeriod: 300
-    # keep maxBackups
-    garbageCollectionPolicy: "LimitBased"
+  # do a full-backup every hour
+  schedule: "15 * * * *"
+  # keep backups for one week
+  maxBackups: 168
+  # delta-snapshot every 10 seconds
+  deltaSnapshotPeriod: 10
+  # clean-up old backups every 5 minutes
+  garbageCollectionPeriod: 300
+  # keep maxBackups
+  garbageCollectionPolicy: "LimitBased"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
This PR spreads our hourly full backups of etcd accross the entire hour by calculating a determintic value between 0-59 for each cluster based on the uid.