### PR TITLE
fix cache bug in flightcontroller

### DIFF
--- a/pkg/client/openstack/factory.go
+++ b/pkg/client/openstack/factory.go
@@ -102,7 +102,7 @@ func (f *factory) KlusterClientFor(kluster *kubernikus_v1.Kluster) (openstack_kl
 	}
 
 	var client openstack_kluster.KlusterClient
-	client = openstack_kluster.NewKlusterClient(network, compute, identity, kluster)
+	client = openstack_kluster.NewKlusterClient(network, compute, identity)
 	client = &openstack_kluster.LoggingClient{Client: client, Logger: log.With(f.logger, "kluster", kluster.GetName(), "project", kluster.Account())}
 
 	f.klusterClients.Store(kluster.GetUID(), client)

--- a/pkg/client/openstack/kluster/client.go
+++ b/pkg/client/openstack/kluster/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
@@ -14,20 +13,19 @@ import (
 	securitygroups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/pagination"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/client/openstack/compute"
 	"github.com/sapcc/kubernikus/pkg/util/generator"
 )
 
 type KlusterClient interface {
-	CreateNode(*models.NodePool, string, []byte) (string, error)
+	CreateNode(*v1.Kluster, *models.NodePool, string, []byte) (string, error)
 	DeleteNode(string) error
-	ListNodes(*models.NodePool) ([]Node, error)
-	SetSecurityGroup(nodeID string) error
-	EnsureKubernikusRuleInSecurityGroup() (bool, error)
+	ListNodes(*v1.Kluster, *models.NodePool) ([]Node, error)
+	SetSecurityGroup(sgName, nodeID string) error
+	EnsureKubernikusRuleInSecurityGroup(*v1.Kluster) (bool, error)
 	EnsureServerGroup(name string) (string, error)
 	DeleteServerGroup(name string) error
 }
@@ -36,56 +34,37 @@ type klusterClient struct {
 	NetworkClient  *gophercloud.ServiceClient
 	ComputeClient  *gophercloud.ServiceClient
 	IdentityClient *gophercloud.ServiceClient
-
-	Kluster   *v1.Kluster
-	NodeStore cache.Store
 }
 
-type cachedNodesEntry struct {
-	Kluster *v1.Kluster
-	Pool    *models.NodePool
-	Nodes   []Node
-}
-
-func CachedNodesKeyFunc(obj interface{}) (string, error) {
-	entry, ok := obj.(cachedNodesEntry)
-	if !ok {
-		return "", fmt.Errorf("unexpected object in cache")
-	}
-	return fmt.Sprintf("%v-%v", entry.Kluster.Spec.Name, entry.Pool.Name), nil
-}
-
-func NewKlusterClient(network, compute, identity *gophercloud.ServiceClient, kluster *v1.Kluster) KlusterClient {
+func NewKlusterClient(network, compute, identity *gophercloud.ServiceClient) KlusterClient {
 	var client KlusterClient
 	client = &klusterClient{
 		NetworkClient:  network,
 		ComputeClient:  compute,
 		IdentityClient: identity,
-		Kluster:        kluster,
-		NodeStore:      cache.NewTTLStore(CachedNodesKeyFunc, 1*time.Minute),
 	}
 
 	return client
 }
 
-func (c *klusterClient) CreateNode(pool *models.NodePool, name string, userData []byte) (string, error) {
+func (c *klusterClient) CreateNode(kluster *v1.Kluster, pool *models.NodePool, name string, userData []byte) (string, error) {
 	configDrive := true
 
-	networks := []servers.Network{{UUID: c.Kluster.Spec.Openstack.NetworkID}}
+	networks := []servers.Network{{UUID: kluster.Spec.Openstack.NetworkID}}
 
 	if strings.HasPrefix(pool.Flavor, "zh") {
 		networks = []servers.Network{
-			{UUID: c.Kluster.Spec.Openstack.NetworkID},
-			{UUID: c.Kluster.Spec.Openstack.NetworkID},
-			{UUID: c.Kluster.Spec.Openstack.NetworkID},
-			{UUID: c.Kluster.Spec.Openstack.NetworkID},
+			{UUID: kluster.Spec.Openstack.NetworkID},
+			{UUID: kluster.Spec.Openstack.NetworkID},
+			{UUID: kluster.Spec.Openstack.NetworkID},
+			{UUID: kluster.Spec.Openstack.NetworkID},
 		}
 	}
 
 	if strings.HasPrefix(pool.Flavor, "zg") {
 		networks = []servers.Network{
-			{UUID: c.Kluster.Spec.Openstack.NetworkID},
-			{UUID: c.Kluster.Spec.Openstack.NetworkID},
+			{UUID: kluster.Spec.Openstack.NetworkID},
+			{UUID: kluster.Spec.Openstack.NetworkID},
 		}
 	}
 
@@ -97,12 +76,12 @@ func (c *klusterClient) CreateNode(pool *models.NodePool, name string, userData 
 		Networks:         networks,
 		UserData:         userData,
 		ServiceClient:    c.ComputeClient,
-		SecurityGroups:   []string{c.Kluster.Spec.Openstack.SecurityGroupName},
+		SecurityGroups:   []string{kluster.Spec.Openstack.SecurityGroupName},
 		ConfigDrive:      &configDrive,
 	}
 
 	if os.Getenv("NODEPOOL_AFFINITY") != "" {
-		serverGroupID, err := c.EnsureServerGroup(c.Kluster.Name + "/" + pool.Name)
+		serverGroupID, err := c.EnsureServerGroup(kluster.Name + "/" + pool.Name)
 		if err != nil {
 			return "", err
 		}
@@ -131,12 +110,12 @@ func (c *klusterClient) DeleteNode(id string) (err error) {
 	return nil
 }
 
-func (c *klusterClient) ListNodes(pool *models.NodePool) ([]Node, error) {
+func (c *klusterClient) ListNodes(k *v1.Kluster, pool *models.NodePool) ([]Node, error) {
 	var unfilteredNodes []Node
 	var filteredNodes []Node
 	var err error
 
-	prefix := fmt.Sprintf("%v-%v-", c.Kluster.Spec.Name, pool.Name)
+	prefix := fmt.Sprintf("%v-%v-", k.Spec.Name, pool.Name)
 	err = servers.List(c.ComputeClient, servers.ListOpts{Name: prefix}).EachPage(func(page pagination.Page) (bool, error) {
 		if page != nil {
 			unfilteredNodes, err = ExtractServers(page)
@@ -164,14 +143,15 @@ func (c *klusterClient) ListNodes(pool *models.NodePool) ([]Node, error) {
 	return filteredNodes, nil
 }
 
-func (c *klusterClient) SetSecurityGroup(nodeID string) (err error) {
-	return secgroups.AddServer(c.ComputeClient, nodeID, c.Kluster.Spec.Openstack.SecurityGroupName).ExtractErr()
+func (c *klusterClient) SetSecurityGroup(sgName, nodeID string) (err error) {
+	return secgroups.AddServer(c.ComputeClient, nodeID, sgName).ExtractErr()
 }
 
-func (c *klusterClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err error) {
-	page, err := securitygroups.List(c.NetworkClient, securitygroups.ListOpts{Name: c.Kluster.Spec.Openstack.SecurityGroupName}).AllPages()
+func (c *klusterClient) EnsureKubernikusRuleInSecurityGroup(kluster *v1.Kluster) (created bool, err error) {
+	sgName := kluster.Spec.Openstack.SecurityGroupName
+	page, err := securitygroups.List(c.NetworkClient, securitygroups.ListOpts{Name: sgName}).AllPages()
 	if err != nil {
-		return false, fmt.Errorf("SecurityGroup %v not found: %s", c.Kluster.Spec.Openstack.SecurityGroupName, err)
+		return false, fmt.Errorf("SecurityGroup %v not found: %s", sgName, err)
 	}
 
 	groups, err := securitygroups.ExtractGroups(page)
@@ -180,7 +160,7 @@ func (c *klusterClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err
 	}
 
 	if len(groups) != 1 {
-		return false, fmt.Errorf("More than one SecurityGroup with name %v found", c.Kluster.Spec.Openstack.SecurityGroupName)
+		return false, fmt.Errorf("More than one SecurityGroup with name %v found", sgName)
 	}
 
 	udp := false
@@ -195,7 +175,7 @@ func (c *klusterClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err
 			continue
 		}
 
-		if rule.RemoteIPPrefix != c.Kluster.Spec.ClusterCIDR {
+		if rule.RemoteIPPrefix != kluster.Spec.ClusterCIDR {
 			continue
 		}
 
@@ -223,7 +203,7 @@ func (c *klusterClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err
 		Direction:      rules.DirIngress,
 		EtherType:      rules.EtherType4,
 		SecGroupID:     groups[0].ID,
-		RemoteIPPrefix: c.Kluster.Spec.ClusterCIDR,
+		RemoteIPPrefix: kluster.Spec.ClusterCIDR,
 	}
 
 	if !udp {

--- a/pkg/client/openstack/kluster/logging.go
+++ b/pkg/client/openstack/kluster/logging.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/kit/log"
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 
 type LoggingClient struct {
@@ -27,7 +28,7 @@ func (c LoggingClient) DeleteNode(id string) (err error) {
 	return c.Client.DeleteNode(id)
 }
 
-func (c LoggingClient) CreateNode(pool *models.NodePool, nodeName string, userData []byte) (id string, err error) {
+func (c LoggingClient) CreateNode(kluster *v1.Kluster, pool *models.NodePool, nodeName string, userData []byte) (id string, err error) {
 	defer func(begin time.Time) {
 		c.Logger.Log(
 			"msg", "created node",
@@ -39,10 +40,10 @@ func (c LoggingClient) CreateNode(pool *models.NodePool, nodeName string, userDa
 		)
 	}(time.Now())
 
-	return c.Client.CreateNode(pool, nodeName, userData)
+	return c.Client.CreateNode(kluster, pool, nodeName, userData)
 }
 
-func (c LoggingClient) ListNodes(pool *models.NodePool) (nodes []Node, err error) {
+func (c LoggingClient) ListNodes(kluster *v1.Kluster, pool *models.NodePool) (nodes []Node, err error) {
 	defer func(begin time.Time) {
 		c.Logger.Log(
 			"msg", "listed nodes",
@@ -53,13 +54,14 @@ func (c LoggingClient) ListNodes(pool *models.NodePool) (nodes []Node, err error
 		)
 	}(time.Now())
 
-	return c.Client.ListNodes(pool)
+	return c.Client.ListNodes(kluster, pool)
 }
 
-func (c LoggingClient) SetSecurityGroup(nodeID string) (err error) {
+func (c LoggingClient) SetSecurityGroup(sgName, nodeID string) (err error) {
 	defer func(begin time.Time) {
 		c.Logger.Log(
 			"msg", "setting security group",
+			"group", sgName,
 			"node_id", nodeID,
 			"took", time.Since(begin),
 			"v", 2,
@@ -67,13 +69,14 @@ func (c LoggingClient) SetSecurityGroup(nodeID string) (err error) {
 		)
 	}(time.Now())
 
-	return c.Client.SetSecurityGroup(nodeID)
+	return c.Client.SetSecurityGroup(sgName, nodeID)
 }
 
-func (c LoggingClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err error) {
+func (c LoggingClient) EnsureKubernikusRuleInSecurityGroup(k *v1.Kluster) (created bool, err error) {
 	defer func(begin time.Time) {
 		c.Logger.Log(
 			"msg", "ensured securitygroup",
+			"group", k.Spec.Openstack.SecurityGroupName,
 			"created", created,
 			"took", time.Since(begin),
 			"v", 2,
@@ -81,7 +84,7 @@ func (c LoggingClient) EnsureKubernikusRuleInSecurityGroup() (created bool, err 
 		)
 	}(time.Now())
 
-	return c.Client.EnsureKubernikusRuleInSecurityGroup()
+	return c.Client.EnsureKubernikusRuleInSecurityGroup(k)
 }
 
 func (c LoggingClient) DeleteServerGroup(name string) (err error) {

--- a/pkg/controller/flight/factory.go
+++ b/pkg/controller/flight/factory.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/client/openstack"
 	openstack_kluster "github.com/sapcc/kubernikus/pkg/client/openstack/kluster"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
@@ -56,7 +56,7 @@ func (f *flightReconcilerFactory) FlightReconciler(kluster *v1.Kluster) (FlightR
 func (d *flightReconcilerFactory) getInstances(kluster *v1.Kluster, client openstack_kluster.KlusterClient) ([]Instance, error) {
 	instances := []Instance{}
 	for _, pool := range kluster.Spec.NodePools {
-		if poolNodes, err := client.ListNodes(&pool); err != nil {
+		if poolNodes, err := client.ListNodes(kluster, &pool); err != nil {
 			return nil, err
 		} else {
 			for _, n := range poolNodes {

--- a/pkg/controller/flight/reconciler.go
+++ b/pkg/controller/flight/reconciler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-kit/kit/log"
 	core_v1 "k8s.io/api/core/v1"
 
-	"github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	openstack_kluster "github.com/sapcc/kubernikus/pkg/client/openstack/kluster"
 )
 
@@ -44,9 +44,10 @@ func (f *flightReconciler) EnsureInstanceSecurityGroupAssignment() []string {
 			continue
 		}
 
-		if err := f.Client.SetSecurityGroup(instance.GetID()); err != nil {
+		if err := f.Client.SetSecurityGroup(f.Kluster.Spec.Openstack.SecurityGroupName, instance.GetID()); err != nil {
 			f.Logger.Log(
 				"msg", "couldn't set securitygroup",
+				"group", f.Kluster.Spec.Openstack.SecurityGroupName,
 				"instance", instance.GetID(),
 				"err", err)
 			continue
@@ -57,7 +58,7 @@ func (f *flightReconciler) EnsureInstanceSecurityGroupAssignment() []string {
 }
 
 func (f *flightReconciler) EnsureKubernikusRuleInSecurityGroup() bool {
-	ensured, err := f.Client.EnsureKubernikusRuleInSecurityGroup()
+	ensured, err := f.Client.EnsureKubernikusRuleInSecurityGroup(f.Kluster)
 	if err != nil {
 		f.Logger.Log(
 			"msg", "couldn't ensure security group rules",

--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -81,7 +81,7 @@ func (lr *LaunchReconciler) newPoolManager(kluster *v1.Kluster, pool *models.Nod
 func (cpm *ConcretePoolManager) GetStatus() (status *PoolStatus, err error) {
 	status = &PoolStatus{}
 
-	nodes, err := cpm.klusterClient.ListNodes(cpm.Pool)
+	nodes, err := cpm.klusterClient.ListNodes(cpm.Kluster, cpm.Pool)
 	if err != nil {
 		return status, err
 	}
@@ -208,7 +208,7 @@ func (cpm *ConcretePoolManager) CreateNode() (id string, err error) {
 	}
 
 	// add the AZ to this call
-	id, err = cpm.klusterClient.CreateNode(cpm.Pool, nodeName, userdata)
+	id, err = cpm.klusterClient.CreateNode(cpm.Kluster, cpm.Pool, nodeName, userdata)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This fixes an issue where our KlusterClient cached a specific version of the kluster object. This caused updates to the security group not to be reflected in the flight controller until the operator was restarted.

With this change the kluster object is not stored in the KlusterClient anymore but needs to be passed to the client functions.