### PR TITLE
Disable etcdbr readiness check, expose metrics

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
       labels:
         app: {{ include "fullname" . }}
         release: {{ .Release.Name }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
       volumes:
         - name: data
@@ -100,16 +103,16 @@ spec:
                 - /bin/sh
                 - -ec
                 - ETCDCTL_API=3 etcdctl get foo
+            initialDelaySeconds: 300
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - ETCDCTL_API=3 etcdctl get foo
             initialDelaySeconds: 15
             periodSeconds: 5
-          {{- if .Values.backup.enabled }}
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 15
-            periodSeconds: 10
-          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.backup.enabled }}

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
                 - /bin/sh
                 - -ec
                 - ETCDCTL_API=3 etcdctl get foo
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             periodSeconds: 5
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
+++ b/charts/kubernikus-system/charts/prometheus/kubernikus.alerts
@@ -126,3 +126,16 @@ groups:
     annotations:
       description: The kluster {{ $labels.kluster }} is generating errors while trying to apply pending migrations.
       summary: Migration errors for kluster {{ $labels.kluster }}
+
+  - alert: KubernikusEtcdBackupFailed
+    expr: increase(etcdbr_snapshot_latest_timestamp{kind="Full"}[3h]) == 0
+    for: 5m
+    labels:
+      tier: kks
+      service: kubernikus
+      severity: warning
+      context: kluster
+      meta: "Etcd backup for kluster {{ $labels.kluster }} failing"
+    annotations:
+      description: Backup of etcd is failing for kluster {{ $labels.kluster }}. There is no full backup created for at least 3h.
+      summary: Etcd backup error for kluster {{ $labels.kluster }}


### PR DESCRIPTION
This PR removes etcdbr readiness check and replaces it with testing etcd. This will ensure that etcd keeps running even if storage backend is failing. It also exposes metrics on backup status and alerts if backup is failing.