### PR TITLE
Adds suppository migration style. Fixes Root Certificate

### DIFF
--- a/pkg/migration/8_fix_certificate.go
+++ b/pkg/migration/8_fix_certificate.go
@@ -1,0 +1,66 @@
+package migration
+
+import (
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
+)
+
+const (
+	fixRootCertificateScript = `#!/bin/bash
+
+cat <<EOF > /etc/ssl/certs/SAPNetCA_G2.pem
+-----BEGIN CERTIFICATE-----
+MIIGPTCCBCWgAwIBAgIKYQ4GNwAAAAAADDANBgkqhkiG9w0BAQsFADBOMQswCQYD
+VQQGEwJERTERMA8GA1UEBwwIV2FsbGRvcmYxDzANBgNVBAoMBlNBUCBBRzEbMBkG
+A1UEAwwSU0FQIEdsb2JhbCBSb290IENBMB4XDTE1MDMxNzA5MjQ1MVoXDTI1MDMx
+NzA5MzQ1MVowRDELMAkGA1UEBhMCREUxETAPBgNVBAcMCFdhbGxkb3JmMQwwCgYD
+VQQKDANTQVAxFDASBgNVBAMMC1NBUE5ldENBX0cyMIICIjANBgkqhkiG9w0BAQEF
+AAOCAg8AMIICCgKCAgEAjuP7Hj/1nVWfsCr8M/JX90s88IhdTLaoekrxpLNJ1W27
+ECUQogQF6HCu/RFD4uIoanH0oGItbmp2p8I0XVevHXnisxQGxBdkjz+a6ZyOcEVk
+cEGTcXev1i0R+MxM8Y2WW/LGDKKkYOoVRvA5ChhTLtX2UXnBLcRdf2lMMvEHd/nn
+KWEQ47ENC+uXd6UPxzE+JqVSVaVN+NNbXBJrI1ddNdEE3/++PSAmhF7BSeNWscs7
+w0MoPwHAGMvMHe9pas1xD3RsRFQkV01XiJqqUbf1OTdYAoUoXo9orPPrO7FMfXjZ
+RbzwzFtdKRlAFnKZOVf95MKlSo8WzhffKf7pQmuabGSLqSSXzIuCpxuPlNy7kwCX
+j5m8U1xGN7L2vlalKEG27rCLx/n6ctXAaKmQo3FM+cHim3ko/mOy+9GDwGIgToX3
+5SQPnmCSR19H3nYscT06ff5lgWfBzSQmBdv//rjYkk2ZeLnTMqDNXsgT7ac6LJlj
+WXAdfdK2+gvHruf7jskio29hYRb2//ti5jD3NM6LLyovo1GOVl0uJ0NYLsmjDUAJ
+dqqNzBocy/eV3L2Ky1L6DvtcQ1otmyvroqsL5JxziP0/gRTj/t170GC/aTxjUnhs
+7vDebVOT5nffxFsZwmolzTIeOsvM4rAnMu5Gf4Mna/SsMi9w/oeXFFc/b1We1a0C
+AwEAAaOCASUwggEhMAsGA1UdDwQEAwIBBjAdBgNVHQ4EFgQUOCSvjXUS/Dg/N4MQ
+r5A8/BshWv8wHwYDVR0jBBgwFoAUg8dB/Q4mTynBuHmOhnrhv7XXagMwSwYDVR0f
+BEQwQjBAoD6gPIY6aHR0cDovL2NkcC5wa2kuY28uc2FwLmNvbS9jZHAvU0FQJTIw
+R2xvYmFsJTIwUm9vdCUyMENBLmNybDBWBggrBgEFBQcBAQRKMEgwRgYIKwYBBQUH
+MAKGOmh0dHA6Ly9haWEucGtpLmNvLnNhcC5jb20vYWlhL1NBUCUyMEdsb2JhbCUy
+MFJvb3QlMjBDQS5jcnQwGQYJKwYBBAGCNxQCBAweCgBTAHUAYgBDAEEwEgYDVR0T
+AQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQsFAAOCAgEAGdBNALO509FQxcPhMCwE
+/eymAe9f2u6hXq0hMlQAuuRbpnxr0+57lcw/1eVFsT4slceh7+CHGCTCVHK1ELAd
+XQeibeQovsVx80BkugEG9PstCJpHnOAoWGjlZS2uWz89Y4O9nla+L9SCuK7tWI5Y
++QuVhyGCD6FDIUCMlVADOLQV8Ffcm458q5S6eGViVa8Y7PNpvMyFfuUTLcUIhrZv
+eh4yjPSpz5uvQs7p/BJLXilEf3VsyXX5Q4ssibTS2aH2z7uF8gghfMvbLi7sS7oj
+XBEylxyaegwOBLtlmcbII8PoUAEAGJzdZ4kFCYjqZBMgXK9754LMpvkXDTVzy4OP
+emK5Il+t+B0VOV73T4yLamXG73qqt8QZndJ3ii7NGutv4SWhVYQ4s7MfjRwbFYlB
+z/N5eH3veBx9lJbV6uXHuNX3liGS8pNVNKPycfwlaGEbD2qZE0aZRU8OetuH1kVp
+jGqvWloPjj45iCGSCbG7FcY1gPVTEAreLjyINVH0pPve1HXcrnCV4PALT6HvoZoF
+bCuBKVgkSSoGgmasxjjjVIfMiOhkevDya52E5m0WnM1LD3ZoZzavsDSYguBP6MOV
+ViWNsVHocptphbEgdwvt3B75CDN4kf6MNZg2/t8bRhEQyK1FRy8NMeBnbRFnnEPe
+7HJNBB1ZTjnrxJAgCQgNBIQ=
+-----END CERTIFICATE-----
+EOF
+
+cat <<EOF > /etc/coreos/update.conf
+REBOOT_STRATEGY="off"
+EOF
+
+/usr/sbin/update-ca-certificates
+/usr/bin/update_engine_client -check_for_update
+`
+)
+
+func FixRootCertificate(rawKluster []byte, current *v1.Kluster, clients config.Clients, factories config.Factories) (err error) {
+	client, err := clients.Satellites.ClientFor(current)
+	if err != nil {
+		return err
+	}
+
+	return ApplySuppository(fixRootCertificateScript, client)
+}

--- a/pkg/migration/register.go
+++ b/pkg/migration/register.go
@@ -14,6 +14,7 @@ func init() {
 		InsertAVZIntoNodePools,
 		SeedCinderStorageClasses,
 		SeedAllowAPIServerToAccessKubelet,
+		FixRootCertificate,
 		// <-- Insert new migrations at the end only!
 	}
 }

--- a/pkg/migration/suppository.go
+++ b/pkg/migration/suppository.go
@@ -1,0 +1,184 @@
+package migration
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/pkg/errors"
+	core "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	rbac "k8s.io/api/rbac/v1beta1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	image = "alpine:latest"
+	pause = "gcr.io/google-containers/pause:latest"
+
+	chrootScript = `set -x
+cp /usr/local/scripts/migration.sh /host/tmp/
+chmod +x /host/tmp/migration.sh
+chroot /host /tmp/migration.sh
+rm /host/tmp/migration.sh`
+)
+
+// ApplySuppository runs a script as a daemonset on each node. Then it self-destructs
+func ApplySuppository(script string, client kubernetes.Interface) error {
+	namespaceSpec := &core.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			GenerateName: "kubernikus-suppository-",
+		},
+	}
+
+	namespace, err := client.CoreV1().Namespaces().Create(namespaceSpec)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create namespace")
+	}
+
+	defer func() {
+		client.CoreV1().Namespaces().Delete(namespace.Name, &meta.DeleteOptions{})
+	}()
+
+	clusterRoleBinding := &rbac.ClusterRoleBinding{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "kubernikus:suppository",
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind:      rbac.ServiceAccountKind,
+				Name:      "default",
+				Namespace: namespace.Name,
+			},
+		},
+	}
+
+	if _, err := client.RbacV1beta1().ClusterRoleBindings().Create(clusterRoleBinding); err != nil {
+		return errors.Wrap(err, "Failed to create ClusterRoleBinding")
+	}
+	defer func() {
+		client.RbacV1beta1().ClusterRoleBindings().Delete("kubernikus:suppository", &meta.DeleteOptions{})
+	}()
+
+	configMap := &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "scripts",
+		},
+		Data: map[string]string{
+			"migration.sh": script,
+		},
+	}
+
+	if _, err := client.CoreV1().ConfigMaps(namespace.Name).Create(configMap); err != nil {
+		return errors.Wrap(err, "Failed to create ConfigMap")
+	}
+
+	null := int64(0)
+	yes := true
+	daemonset := &extensions.DaemonSet{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "kubernikus-suppository",
+		},
+		Spec: extensions.DaemonSetSpec{
+			Selector: &meta.LabelSelector{
+				MatchLabels: map[string]string{"app": "kubernikus-suppository"},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "kubernikus-suppository",
+					Namespace: namespace.Name,
+					Labels:    map[string]string{"app": "kubernikus-suppository"},
+				},
+				Spec: core.PodSpec{
+					TerminationGracePeriodSeconds: &null,
+					InitContainers: []core.Container{
+						core.Container{
+							Name:  "init",
+							Image: image,
+							SecurityContext: &core.SecurityContext{
+								Privileged: &yes,
+							},
+							Command: []string{"/bin/sh", "-c", chrootScript},
+							VolumeMounts: []core.VolumeMount{
+								core.VolumeMount{
+									Name:      "host",
+									MountPath: "/host",
+								},
+								core.VolumeMount{
+									Name:      "scripts",
+									MountPath: "/usr/local/scripts",
+								},
+							},
+						},
+					},
+					Containers: []core.Container{
+						core.Container{
+							Name:  "pause",
+							Image: pause,
+						},
+					},
+					Volumes: []core.Volume{
+						core.Volume{
+							Name: "host",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: "/",
+								},
+							},
+						},
+						core.Volume{
+							Name: "scripts",
+							VolumeSource: core.VolumeSource{
+								ConfigMap: &core.ConfigMapVolumeSource{
+									LocalObjectReference: core.LocalObjectReference{
+										Name: "scripts",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := client.ExtensionsV1beta1().DaemonSets(namespace.Name).Create(daemonset); err != nil {
+		return errors.Wrap(err, "Failed to create Daemonset")
+	}
+
+	pods := informers.NewFilteredSharedInformerFactory(client, 1*time.Minute, namespace.Name, nil).Core().V1().Pods().Lister()
+
+	ok := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (done bool, err error) {
+		pods, err := pods.List(labels.Everything())
+		if err != nil {
+			return false, err
+		}
+
+		running := 0
+		for _, pod := range pods {
+			switch pod.Status.Phase {
+			case core.PodRunning:
+				running++
+			case core.PodFailed:
+				return false, fmt.Errorf("Failed to create a Pod: %v", pod.Status.Reason)
+			}
+		}
+
+		return running == len(pods), nil
+	})
+
+	if ok != nil {
+		return errors.Wrap(ok, "Not all pods completed")
+	}
+
+	return nil
+}

--- a/pkg/migration/suppository.go
+++ b/pkg/migration/suppository.go
@@ -101,7 +101,7 @@ func ApplySuppository(script string, client kubernetes.Interface) error {
 				Spec: core.PodSpec{
 					TerminationGracePeriodSeconds: &null,
 					InitContainers: []core.Container{
-						core.Container{
+						{
 							Name:  "init",
 							Image: image,
 							SecurityContext: &core.SecurityContext{
@@ -109,11 +109,11 @@ func ApplySuppository(script string, client kubernetes.Interface) error {
 							},
 							Command: []string{"/bin/sh", "-c", chrootScript},
 							VolumeMounts: []core.VolumeMount{
-								core.VolumeMount{
+								{
 									Name:      "host",
 									MountPath: "/host",
 								},
-								core.VolumeMount{
+								{
 									Name:      "scripts",
 									MountPath: "/usr/local/scripts",
 								},
@@ -121,13 +121,13 @@ func ApplySuppository(script string, client kubernetes.Interface) error {
 						},
 					},
 					Containers: []core.Container{
-						core.Container{
+						{
 							Name:  "pause",
 							Image: pause,
 						},
 					},
 					Volumes: []core.Volume{
-						core.Volume{
+						{
 							Name: "host",
 							VolumeSource: core.VolumeSource{
 								HostPath: &core.HostPathVolumeSource{
@@ -135,7 +135,7 @@ func ApplySuppository(script string, client kubernetes.Interface) error {
 								},
 							},
 						},
-						core.Volume{
+						{
 							Name: "scripts",
 							VolumeSource: core.VolumeSource{
 								ConfigMap: &core.ConfigMapVolumeSource{

--- a/pkg/migration/suppository.go
+++ b/pkg/migration/suppository.go
@@ -157,7 +157,7 @@ func ApplySuppository(script string, client kubernetes.Interface) error {
 
 	pods := informers.NewFilteredSharedInformerFactory(client, 1*time.Minute, namespace.Name, nil).Core().V1().Pods().Lister()
 
-	ok := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (done bool, err error) {
+	wait.PollImmediate(1*time.Second, 2*time.Minute, func() (done bool, err error) {
 		pods, err := pods.List(labels.Everything())
 		if err != nil {
 			return false, err
@@ -175,10 +175,6 @@ func ApplySuppository(script string, client kubernetes.Interface) error {
 
 		return running == len(pods), nil
 	})
-
-	if ok != nil {
-		return errors.Wrap(ok, "Not all pods completed")
-	}
 
 	return nil
 }


### PR DESCRIPTION
This PR adds a utility function that helps to apply a script to all nodes in a cluster.

It creates a DaemonSet in a randomly suffixed namespace. It includes an init container that applies the provided script with a bit of `chroot` magic. It runs in `priviledged` mode and has access to binaries on the host. The host's filesystem is mapped into the init container to `/host` and used as the root for the `chroot` command. `chroot` executes the provided script, that is inserted into the pod as ConfigMap. If the init container successfully completes the `pause` container will wait endlessly for self-destruction.

Afterwards the function checks whether created Pods are `Running` indicating that the migration applied to all nodes. If so, everything is deleted. 

This can be used in a migration to apply something to all nodes. See the provided migration that fixes a broken certificate.