### PR TITLE
Add custom collector for kluster_info metric

### DIFF
--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -79,6 +79,9 @@ func NewGroundController(threadiness int, factories config.Factories, clients co
 		threadiness:     threadiness,
 	}
 
+	//Register kluster collector
+	metrics.RegisterKlusterCollector(operator.klusterInformer.Lister())
+
 	operator.klusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    operator.klusterAdd,
 		UpdateFunc: operator.klusterUpdate,
@@ -192,7 +195,6 @@ func (op *GroundControl) handler(key string) error {
 				"took", time.Since(start))
 		}(time.Now())
 
-		metrics.SetMetricKlusterInfo(kluster.GetNamespace(), kluster.GetName(), kluster.Status.Version, kluster.Spec.Openstack.ProjectID, kluster.GetAnnotations(), kluster.GetLabels())
 		metrics.SetMetricKlusterStatusPhase(kluster.GetName(), kluster.Status.Phase)
 
 		switch phase := kluster.Status.Phase; phase {

--- a/pkg/controller/metrics/kluster.go
+++ b/pkg/controller/metrics/kluster.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/labels"
+
+	kubernikus_lister "github.com/sapcc/kubernikus/pkg/generated/listers/kubernikus/v1"
+)
+
+type klusterCollector struct {
+	infoMetric *prometheus.Desc
+	lister     kubernikus_lister.KlusterLister
+}
+
+func RegisterKlusterCollector(lister kubernikus_lister.KlusterLister) {
+	prometheus.MustRegister(NewKlusterCollector(lister))
+}
+
+func NewKlusterCollector(lister kubernikus_lister.KlusterLister) *klusterCollector {
+	return &klusterCollector{
+		infoMetric: prometheus.NewDesc(
+			"kubernikus_kluster_info",
+			"Detailed information on a kluster",
+			[]string{"kluster_namespace", "kluster_name", "phase", "api_version", "chart_version", "chart_name", "creator", "project_id"},
+			nil,
+		),
+		lister: lister,
+	}
+}
+
+//Each and every collector must implement the Describe function.
+//It essentially writes all descriptors to the prometheus desc channel.
+func (collector *klusterCollector) Describe(ch chan<- *prometheus.Desc) {
+	//Update this section with the each metric you create for a given collector
+	ch <- collector.infoMetric
+}
+
+//Collect implements required collect function for all promehteus collectors
+func (collector *klusterCollector) Collect(ch chan<- prometheus.Metric) {
+	klusters, err := collector.lister.List(labels.Everything())
+	if err != nil {
+		return
+	}
+
+	var value float64 = 1
+
+	for _, kluster := range klusters {
+		ch <- prometheus.MustNewConstMetric(
+			collector.infoMetric,
+			prometheus.GaugeValue,
+			value,
+			kluster.GetNamespace(),
+			kluster.GetName(),
+			string(kluster.Status.Phase),
+			kluster.Status.ApiserverVersion,
+			kluster.Status.ChartVersion,
+			kluster.Status.ChartName,
+			getCreatorFromAnnotations(kluster.Annotations),
+			getAccountFromLabels(kluster.Labels),
+		)
+	}
+
+	//Note that you can pass CounterValue, GaugeValue, or UntypedValue types here.
+	//ch <- prometheus.MustNewConstMetric(collector.fooMetric, prometheus.CounterValue, metricValue)
+
+}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -35,15 +35,6 @@ var klusterBootDurationSummary = prometheus.NewSummaryVec(
 	[]string{},
 )
 
-var klusterInfo = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: metricNamespace,
-		Name:      "kluster_info",
-		Help:      "detailed information on a kluster",
-	},
-	[]string{"kluster_namespace", "kluster_name", "kluster_version", "creator", "account", "project_id"},
-)
-
 var klusterStatusPhase = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: metricNamespace,
@@ -70,18 +61,6 @@ var nodePoolStatus = prometheus.NewGaugeVec(
 	},
 	[]string{"kluster_id", "node_pool", "status"},
 )
-
-func SetMetricKlusterInfo(namespace, name, version, projectID string, annotations, labels map[string]string) {
-	promLabels := prometheus.Labels{
-		"kluster_namespace": namespace,
-		"kluster_name":      name,
-		"kluster_version":   version,
-		"creator":           getCreatorFromAnnotations(annotations),
-		"account":           getAccountFromLabels(labels),
-		"project_id":        projectID,
-	}
-	klusterInfo.With(promLabels).Set(1)
-}
 
 /*
 kubernikus_kluster_status_phase{"kluster_id"="<id>","phase"="<phase>"} 			< 1|0 >
@@ -170,7 +149,6 @@ func getAccountFromLabels(labels map[string]string) string {
 
 func init() {
 	prometheus.MustRegister(
-		klusterInfo,
 		klusterStatusPhase,
 		klusterBootDurationSummary,
 		nodePoolSize,

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -30,11 +30,6 @@ kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",stat
 kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="running"} 2
 kubernikus_node_pool_status{kluster_id="klusterID",node_pool="nodePoolName",status="healthy"} 1
 		`,
-		klusterInfo: `
-# HELP kubernikus_kluster_info detailed information on a kluster
-# TYPE kubernikus_kluster_info gauge
-kubernikus_kluster_info{account="account",creator="D012345",kluster_name="klusterName",kluster_namespace="namespace",kluster_version="version",project_id="projectID"} 1
-		`,
 		klusterStatusPhase: `
 # HELP kubernikus_kluster_status_phase the phase the kluster is currently in
 # TYPE kubernikus_kluster_status_phase gauge
@@ -49,7 +44,6 @@ kubernikus_kluster_status_phase{kluster_id="klusterID",phase="Terminating"} 0
 	// call functions that update the metrics here
 	setMetricNodePoolSize("klusterID", "nodePoolName", "imageName", "flavorName", 3)
 	SetMetricNodePoolStatus("klusterID", "nodePoolName", map[string]int64{"schedulable": 2, "healthy": 1, "running": 2})
-	SetMetricKlusterInfo("namespace", "klusterName", "version", "projectID", map[string]string{"creator": "D012345"}, map[string]string{"account": "account"})
 	SetMetricKlusterStatusPhase("klusterID", models.KlusterPhaseRunning)
 
 	registry := prometheus.NewPedanticRegistry()


### PR DESCRIPTION
This moves the `kuberbikus_cluster_info` metric into a custom collector that uses a Lister to dynamically create the metric. This allows us to add labels like `api_version` and `chart_version` to the metric and not worry about old metrics that stick around after an upgrade.

This also obsoletes the `kluster_status_phase` metric because its a no brainer to add the phase as a label.