### PR TITLE
Add ca-certificates into kubernikusctl image

### DIFF
--- a/contrib/kubernikusctl/Dockerfile
+++ b/contrib/kubernikusctl/Dockerfile
@@ -2,5 +2,6 @@ ARG VERSION=latest
 FROM sapcc/kubernikus-binaries:$VERSION as kubernikus-binaries
 
 FROM alpine:3.8
+RUN apk add --update --no-cache ca-certificates
 COPY --from=kubernikus-binaries /kubernikusctl /usr/local/bin/
 CMD ["kubernikusctl"]


### PR DESCRIPTION
This is for https://hub.docker.com/r/sapcc/kubernikusctl to be better usable, as without certs `kubernikusctl auth init` fails:
```
Authenticating domain/user at domain/project
An error occurred: Authentication failed: Post <os-auth-url-signed-by-well-known-ca>/auth/tokens: x509: certificate signed by unknown authority
```