### PR TITLE
Fix patching node annotations

### DIFF
--- a/test/patch-node-annotations/main.go
+++ b/test/patch-node-annotations/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	kitlog "github.com/go-kit/kit/log"
+
+	"github.com/sapcc/kubernikus/pkg/client/kubernetes"
+	"github.com/sapcc/kubernikus/pkg/util"
+)
+
+func main() {
+
+	kubeconfig := flag.String("kubeconfig", "", "")
+	context := flag.String("context", "", "")
+	node := flag.String("node", "", "")
+	key := flag.String("key", "", "")
+	val := flag.String("val", "", "")
+	flag.Parse()
+
+	client, err := kubernetes.NewClient(*kubeconfig, *context, kitlog.NewNopLogger())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *val == "" {
+		fmt.Printf("Removing annotation %s from node %s\n", *key, *node)
+		err := util.RemoveNodeAnnotation(*node, *key, client)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		fmt.Printf("Adding/Updating annoation %s=%s on node %s\n", *key, *val, *node)
+		err := util.AddNodeAnnotation(*node, *key, *val, client)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
json merge patch seems to do what we want.

Add annotation:
`kubectl patch node some-node --type=merge -p '{"metadata":{"annotations":{"nase/hase2":"blub"}}}'`
Remove annotation:
`kubectl patch node some-node --type=merge -p '{"metadata":{"annotations":{"nase/hase2":null}}}'`

I tried writing a unit test but the fake client is not properly implementing the patch operation. I manually tested this in qa with the script in test/patch-node-annotation/.