### PR TITLE
Bypass sni ingress proxy in the shared kubernetes client factory

### DIFF
--- a/pkg/client/kubernetes/shared_client_factory.go
+++ b/pkg/client/kubernetes/shared_client_factory.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"sync"
 
 	kitlog "github.com/go-kit/kit/log"
@@ -69,7 +70,7 @@ func (f *sharedClientFactory) ClientFor(k *kubernikus_v1.Kluster) (clientset kub
 	}
 
 	c := rest.Config{
-		Host: k.Status.Apiserver,
+		Host: fmt.Sprintf("https://%s:6443", k.Name), // access kubernetes api directly by service name (bypass sni sniffer)
 		TLSClientConfig: rest.TLSClientConfig{
 			CertData: []byte(secret.ApiserverClientsClusterAdminCertificate),
 			KeyData:  []byte(secret.ApiserverClientsClusterAdminPrivateKey),


### PR DESCRIPTION
This should fix hanging node observeratory watches we had in the past one one if the control plane nodes goes away without warning.

We already use this for the controller-manger and scheduler were we didn't observe hanging client to my knowledge.