### PR TITLE
Fix running node state

### DIFF
--- a/pkg/client/openstack/kluster/node.go
+++ b/pkg/client/openstack/kluster/node.go
@@ -29,7 +29,7 @@ func (n *Node) Starting() bool {
 }
 
 func (n *Node) Stopping() bool {
-	if n.TaskState == "spawning" || n.TaskState == "scheduling" || n.TaskState == "networking" || n.TaskState == "block_device_mapping" {
+	if n.TaskState == "spawning" || n.TaskState == "scheduling" || n.TaskState == "networking" || n.TaskState == "block_device_mapping" || n.TaskState == "image_uploading" {
 		return false
 	}
 


### PR DESCRIPTION
This PR fixes detection of running nodes. Currently a new node gets created when a node is in task state `image_uploading` and status `active`.