### PR TITLE
Update k8sniff deployment

### DIFF
--- a/charts/k8sniff/templates/configmap.yaml
+++ b/charts/k8sniff/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
         },
         "metrics": {
             "host": "0.0.0.0",
-            "port": {{ default 9091 .Values.metrics_port }},
+            "port": {{ .Values.metrics_port }},
             "path": "/metrics"
         },
         "kubernetes": {}

--- a/charts/k8sniff/templates/deployment.yaml
+++ b/charts/k8sniff/templates/deployment.yaml
@@ -4,12 +4,21 @@ metadata:
   name: k8sniff-ingress-lb
   labels:
     role: k8sniff-ingress-lb
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ default "9091" .Values.metrics_port | quote }}
 
 spec:
-  replicas: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: role
+              operator: In
+              values:
+              - k8sniff-ingress-lb
+          topologyKey: kubernetes.io/hostname
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       role: k8sniff-ingress-lb
@@ -17,19 +26,24 @@ spec:
     metadata:
       labels:
         role: k8sniff-ingress-lb
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.metrics_port | quote }}
     spec:
       containers:
-      - image: {{ default "kubermatic/k8sniff" .Values.image }}:{{ default "v1.0" .Values.tag }}
+      - image: "{{ .Values.image }}:{{ .Values.tag }}"
         name: k8sniff-ingress-lb
         imagePullPolicy: IfNotPresent
         command:
-          - /bin/sh
-          - -c
-          - -x
-          - "/pipeline/source/k8sniff -logtostderr --v={{ default 9 .Values.log_level }} --config /etc/config/k8sniff.json"
+          - /pipeline/source/k8sniff
+          - -logtostderr
+          - --config /etc/config/k8sniff.json"
+          - --v={{ default 9 .Values.log_level }}
         ports:
         - name: https
           containerPort: 8443
+        - name: metrics
+          containerPort: {{ .Values.metrics_port }}
         volumeMounts:
         - name: k8sniff-config
           mountPath: /etc/config

--- a/charts/k8sniff/templates/deployment.yaml
+++ b/charts/k8sniff/templates/deployment.yaml
@@ -37,8 +37,14 @@ spec:
         command:
           - /pipeline/source/k8sniff
           - -logtostderr
-          - --config /etc/config/k8sniff.json"
+          - --config=/etc/config/k8sniff.json
           - --v={{ default 9 .Values.log_level }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         ports:
         - name: https
           containerPort: 8443

--- a/charts/k8sniff/values.yaml
+++ b/charts/k8sniff/values.yaml
@@ -1,6 +1,7 @@
-image: "kubermatic/k8sniff"
-tag: "8d5bf771eb906c58acfdd68e553f9408432043fa"
+image: "sapcc/k8sniff"
+tag: "e7435d989925e8559b0e5ca26da69f84a1035c32"
 metrics_port: 9091
 log_level: 2
+replicas: 2
 
 # loadBalancerIP

--- a/contrib/k8sniff/Dockerfile
+++ b/contrib/k8sniff/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.12-alpine
+
+WORKDIR /go/src/github.com/kubermatic/k8sniff
+
+RUN apk add --no-cache curl git \
+    && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+ARG VERSION=master
+RUN git clone https://github.com/kubermatic/k8sniff.git . \
+    && git checkout $VERSION
+
+RUN dep ensure
+
+RUN go build -v -o k8sniff .
+
+FROM alpine:3.9
+
+RUN apk add --no-cache ca-certificates
+COPY --from=0 /go/src/github.com/kubermatic/k8sniff /pipeline/source/k8sniff

--- a/contrib/k8sniff/Makefile
+++ b/contrib/k8sniff/Makefile
@@ -1,0 +1,7 @@
+IMAGE:= sapcc/k8sniff
+VERSION := e7435d989925e8559b0e5ca26da69f84a1035c32
+
+build:
+	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(VERSION) .
+push:
+	docker push $(IMAGE):$(VERSION)


### PR DESCRIPTION
This updates to k8sniff to our own build. Rebuilding the sniffer with no code changes with go 1.12.
This has a performance benefit as it now uses the `splice` syscall to proxy tcp connections.
And it also fixes hanging backend connections because go 1.12 enables tcp keepalives by default.

I'm also updateing the deployment to have 2 replicas running with anti affinity to improve availability of cluster apis in case of a control plane node failure