### PR TITLE
Mitigate read-only root fs

### DIFF
--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -229,6 +229,19 @@ networkd:
 
 storage:
   files:
+    - path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+		  #
+		  # VMware SCSI devices Timeout adjustment
+		  #
+		  # Modify the timeout value for VMware SCSI devices so that
+		  # in the event of a failover, we don't time out.
+		  # See Bug 271286 for more information.
+
+		  ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -234,14 +234,14 @@ storage:
       mode: 0644
       contents:
         inline: |
-		  #
-		  # VMware SCSI devices Timeout adjustment
-		  #
-		  # Modify the timeout value for VMware SCSI devices so that
-		  # in the event of a failover, we don't time out.
-		  # See Bug 271286 for more information.
+          #
+          # VMware SCSI devices Timeout adjustment
+          #
+          # Modify the timeout value for VMware SCSI devices so that
+          # in the event of a failover, we don't time out.
+          # See Bug 271286 for more information.
 
-		  ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
+          ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.11.go
+++ b/pkg/templates/node_1.11.go
@@ -232,14 +232,14 @@ storage:
       mode: 0644
       contents:
         inline: |
-		  #
-		  # VMware SCSI devices Timeout adjustment
-		  #
-		  # Modify the timeout value for VMware SCSI devices so that
-		  # in the event of a failover, we don't time out.
-		  # See Bug 271286 for more information.
+          #
+          # VMware SCSI devices Timeout adjustment
+          #
+          # Modify the timeout value for VMware SCSI devices so that
+          # in the event of a failover, we don't time out.
+          # See Bug 271286 for more information.
 
-		  ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
+          ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.11.go
+++ b/pkg/templates/node_1.11.go
@@ -227,6 +227,19 @@ networkd:
 
 storage:
   files:
+	- path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+		  #
+		  # VMware SCSI devices Timeout adjustment
+		  #
+		  # Modify the timeout value for VMware SCSI devices so that
+		  # in the event of a failover, we don't time out.
+		  # See Bug 271286 for more information.
+
+		  ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.11.go
+++ b/pkg/templates/node_1.11.go
@@ -227,7 +227,7 @@ networkd:
 
 storage:
   files:
-	- path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+    - path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
       filesystem: root
       mode: 0644
       contents:

--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -174,6 +174,19 @@ networkd:
 
 storage:
   files:
+    - path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          #
+          # VMware SCSI devices Timeout adjustment
+          #
+          # Modify the timeout value for VMware SCSI devices so that
+          # in the event of a failover, we don't time out.
+          # See Bug 271286 for more information.
+
+          ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -176,6 +176,19 @@ networkd:
 
 storage:
   files:
+    - path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          #
+          # VMware SCSI devices Timeout adjustment
+          #
+          # Modify the timeout value for VMware SCSI devices so that
+          # in the event of a failover, we don't time out.
+          # See Bug 271286 for more information.
+
+          ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -176,6 +176,19 @@ networkd:
 
 storage:
   files:
+    - path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          #
+          # VMware SCSI devices Timeout adjustment
+          #
+          # Modify the timeout value for VMware SCSI devices so that
+          # in the event of a failover, we don't time out.
+          # See Bug 271286 for more information.
+
+          ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
     - path: /etc/ssl/certs/SAPGlobalRootCA.pem
       filesystem: root
       mode: 0644


### PR DESCRIPTION
Some kubernikus instances are currently hanging with read-only root fs due to failover in vmware.
The default timeout for the disk devices is 30 sec which is far too small for SAN which takes about 60 sec on average to failover.

This applies the udev rule vmware used to rollout with vmware-tools which has been superseeded by
open-vm-tools which does not ship with udev rules anymore.
