### PR TITLE
tweak resource limits of controlplanes

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.0.1
+version: 2.0.2

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -43,17 +43,17 @@ api:
   # wormholeHost:
   resources:
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 512Mi
     limits:
-      cpu: 500m
-      memory: 1024Mi
+      cpu: 1
+      memory: 2Gi
 
 controllerManager:
   replicaCount: 1
   resources:
     requests:
-      cpu: 50m
+      cpu: 100m
       memory: 256Mi
     limits:
       cpu: 500m
@@ -64,7 +64,7 @@ scheduler:
   resources:
     requests:
       cpu: 50m
-      memory: 256Mi
+      memory: 128Mi
     limits:
       cpu: 500m
       memory: 512Mi


### PR DESCRIPTION
We have a problem with apiservers that get killed during a help deployment. I adjusted a few other values based on our busiest region.