### PR TITLE
Add secure etcd communication

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -43,11 +43,27 @@ data:
     exec etcd \
       --name=kubernikus \
       --data-dir=/var/lib/etcd/new.etcd \
+{{- if .Values.secure.enabled }}
+      --cert-file=/etc/kubernetes/certs/tls-etcd.pem \
+      --key-file=/etc/kubernetes/certs/tls-etcd-key.pem \
+      --client-cert-auth=true \
+      --trusted-ca-file=/etc/kubernetes/certs/etcd-clients-ca.pem \
+      --peer-cert-file=/etc/kubernetes/certs/tls-etcd.pem \
+      --peer-key-file=/etc/kubernetes/certs/tls-etcd-key.pem \
+      --peer-client-cert-auth=true \
+      --peer-trusted-ca-file=/etc/kubernetes/certs/etcd-peers-ca.pem \
+      --advertise-client-urls=https://${ETCD_IP}:2379 \
+      --initial-advertise-peer-urls=https://${ETCD_IP}:2380 \
+      --initial-cluster=kubernikus=https://${ETCD_IP}:2380 \
+      --listen-client-urls=https://0.0.0.0:2379 \
+      --listen-peer-urls=https://${ETCD_IP}:2380
+{{- else }}
       --advertise-client-urls=http://${ETCD_IP}:2379 \
       --initial-advertise-peer-urls=http://${ETCD_IP}:2380 \
       --initial-cluster=kubernikus=http://${ETCD_IP}:2380 \
       --listen-client-urls=http://0.0.0.0:2379 \
       --listen-peer-urls=http://${ETCD_IP}:2380
+{{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -82,6 +98,38 @@ spec:
           configMap:
             name: {{ include "fullname" . }}
             defaultMode: 0700
+{{- if .Values.secure.enabled }}
+        - name: certs-etcd
+          secret:
+            secretName: {{ include "master.fullname" . }}-secret
+            items:
+              - key: etcd-clients-ca.pem
+                path: etcd-clients-ca.pem
+              - key: etcd-peers-ca.pem
+                path: etcd-peers-ca.pem
+              - key: tls-etcd-ca.pem
+                path: tls-etcd-ca.pem
+              - key: tls-etcd.pem
+                path: tls-etcd.pem
+              - key: tls-etcd-key.pem
+                path: tls-etcd-key.pem
+              - key: etcd-clients-backup.pem
+                path: etcd-clients-backup.pem
+              - key: etcd-clients-backup-key.pem
+                path: etcd-clients-backup-key.pem
+        - name: certs-backup
+          secret:
+            secretName: {{ include "master.fullname" . }}-secret
+            items:
+              - key: tls-etcd-ca.pem
+                path: tls-etcd-ca.pem
+              - key: etcd-clients-ca.pem
+                path: etcd-clients-ca.pem
+              - key: etcd-clients-backup.pem
+                path: etcd-clients-backup.pem
+              - key: etcd-clients-backup-key.pem
+                path: etcd-clients-backup-key.pem
+{{- end }}
       containers:
         - name: etcd
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -97,12 +145,21 @@ spec:
               name: data
             - mountPath: /bootstrap
               name: bootstrap
+{{- if .Values.secure.enabled }}
+            - mountPath: /etc/kubernetes/certs
+              name: certs-etcd
+              readOnly: true
+{{- end }}
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -ec
+                {{- if .Values.secure.enabled }}
+                - ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem --cert=/etc/kubernetes/certs/etcd-clients-backup.pem --key=/etc/kubernetes/certs/etcd-clients-backup-key.pem --insecure-transport=false endpoint health
+                {{- else }}
                 - ETCDCTL_API=3 etcdctl get foo
+                {{- end }}
             initialDelaySeconds: 300
             periodSeconds: 30
           readinessProbe:
@@ -110,7 +167,11 @@ spec:
               command:
                 - /bin/sh
                 - -ec
+                {{- if .Values.secure.enabled }}
+                - ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem --cert=/etc/kubernetes/certs/etcd-clients-backup.pem --key=/etc/kubernetes/certs/etcd-clients-backup-key.pem --insecure-transport=false endpoint health
+                {{- else }}
                 - ETCDCTL_API=3 etcdctl get foo
+                {{- end }}
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
@@ -125,11 +186,18 @@ spec:
             - --max-backups={{ .Values.backup.maxBackups }}
             {{- end }}
             - --data-dir=/var/lib/etcd/new.etcd
-            - --insecure-transport=true
             - --storage-provider={{ .Values.backup.storageProvider | default "Swift" }}
             - --delta-snapshot-period-seconds={{ .Values.backup.deltaSnapshotPeriod }}
             - --garbage-collection-period-seconds={{ .Values.backup.garbageCollectionPeriod }}
             - --garbage-collection-policy={{ .Values.backup.garbageCollectionPolicy }}
+            {{- if .Values.secure.enabled }}
+            - --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem
+            - --cert=/etc/kubernetes/certs/etcd-clients-backup.pem
+            - --key=/etc/kubernetes/certs/etcd-clients-backup-key.pem
+            - --insecure-transport=false
+            - {{- else }}
+            - --insecure-transport=true
+            {{- end }}
           image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
           imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
           ports:
@@ -187,6 +255,11 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/etcd
               name: data
+{{- if .Values.secure.enabled }}
+            - mountPath: /etc/kubernetes/certs
+              name: certs-backup
+              readOnly: true
+{{- end }}
           resources:
 {{ toYaml .Values.backup.resources | indent 12 }}
 {{- end }}

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -48,21 +48,11 @@ data:
       --key-file=/etc/kubernetes/certs/tls-etcd-key.pem \
       --client-cert-auth=true \
       --trusted-ca-file=/etc/kubernetes/certs/etcd-clients-ca.pem \
-      --peer-cert-file=/etc/kubernetes/certs/tls-etcd.pem \
-      --peer-key-file=/etc/kubernetes/certs/tls-etcd-key.pem \
-      --peer-client-cert-auth=true \
-      --peer-trusted-ca-file=/etc/kubernetes/certs/etcd-peers-ca.pem \
       --advertise-client-urls=https://${ETCD_IP}:2379 \
-      --initial-advertise-peer-urls=https://${ETCD_IP}:2380 \
-      --initial-cluster=kubernikus=https://${ETCD_IP}:2380 \
-      --listen-client-urls=https://0.0.0.0:2379 \
-      --listen-peer-urls=https://${ETCD_IP}:2380
+      --listen-client-urls=https://0.0.0.0:2379
 {{- else }}
       --advertise-client-urls=http://${ETCD_IP}:2379 \
-      --initial-advertise-peer-urls=http://${ETCD_IP}:2380 \
-      --initial-cluster=kubernikus=http://${ETCD_IP}:2380 \
-      --listen-client-urls=http://0.0.0.0:2379 \
-      --listen-peer-urls=http://${ETCD_IP}:2380
+      --listen-client-urls=http://0.0.0.0:2379
 {{- end }}
 ---
 apiVersion: extensions/v1beta1
@@ -105,8 +95,6 @@ spec:
             items:
               - key: etcd-clients-ca.pem
                 path: etcd-clients-ca.pem
-              - key: etcd-peers-ca.pem
-                path: etcd-peers-ca.pem
               - key: tls-etcd-ca.pem
                 path: tls-etcd-ca.pem
               - key: tls-etcd.pem

--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -44,4 +44,4 @@ backup:
       cpu: 500m
       memory: 1.5Gi
 secure:
-  enabled: false
+  enabled: true

--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -43,3 +43,5 @@ backup:
     limits:
       cpu: 500m
       memory: 1.5Gi
+secure:
+  enabled: false

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -33,6 +33,8 @@ spec:
                 path: apiserver-clients-and-nodes-ca.pem
               - key: apiserver-clients-ca-key.pem
                 path: apiserver-clients-ca-key.pem
+              - key: tls-etcd-ca.pem
+                path: tls-etcd-ca.pem
               - key: etcd-clients-ca.pem
                 path: etcd-clients-ca.pem
               - key: etcd-clients-apiserver.pem
@@ -114,7 +116,18 @@ spec:
             - sh
             - -c
           args:
+{{- if .Values.api.secureEtcd }}
+            - until etcdctl --endpoints https://{{ include "etcd.fullname" . }}:2379 --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem --cert=/etc/kubernetes/certs/etcd-clients-apiserver.pem --key=/etc/kubernetes/certs/etcd-clients-apiserver-key.pem --insecure-transport=false endpoint health; do sleep 5; done;
+          env:
+            - name: ETCDCTL_API
+              value: "3"
+          volumeMounts:
+            - mountPath: /etc/kubernetes/certs
+              name: certs
+              readOnly: true
+{{- else }}
             - until etcdctl --total-timeout=4s --endpoints http://{{ include "etcd.fullname" . }}:2379 cluster-health; do sleep 5; done;
+{{- end }}
       containers:
         - name: apiserver
           image: {{ include "hyperkube.image" . | quote }}
@@ -125,7 +138,11 @@ spec:
 {{- else }}
             - apiserver
 {{- end }}
+            {{- if .Values.api.secureEtcd }}
+            - --etcd-servers=https://{{ include "etcd.fullname" . }}:2379
+            {{- else }}
             - --etcd-servers=http://{{ include "etcd.fullname" . }}:2379
+            {{- end }}
             - --secure-port={{ required "missing advertisePort" .Values.advertisePort }}
             - --advertise-address={{ .Values.advertiseAddress }}
             - --allow-privileged=true
@@ -167,7 +184,7 @@ spec:
 {{- end }}
             #Cert Spratz
             - --client-ca-file=/etc/kubernetes/certs/apiserver-clients-and-nodes-ca.pem
-            - --etcd-cafile=/etc/kubernetes/certs/etcd-clients-ca.pem
+            - --etcd-cafile=/etc/kubernetes/certs/tls-etcd-ca.pem
             - --etcd-certfile=/etc/kubernetes/certs/etcd-clients-apiserver.pem
             - --etcd-keyfile=/etc/kubernetes/certs/etcd-clients-apiserver-key.pem
             - --kubelet-client-certificate=/etc/kubernetes/certs/kubelet-clients-apiserver.pem

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -116,7 +116,7 @@ spec:
             - sh
             - -c
           args:
-{{- if .Values.api.secureEtcd }}
+{{- if .Values.etcd.secure.enabled }}
             - until etcdctl --endpoints https://{{ include "etcd.fullname" . }}:2379 --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem --cert=/etc/kubernetes/certs/etcd-clients-apiserver.pem --key=/etc/kubernetes/certs/etcd-clients-apiserver-key.pem --insecure-transport=false endpoint health; do sleep 5; done;
           env:
             - name: ETCDCTL_API
@@ -138,7 +138,7 @@ spec:
 {{- else }}
             - apiserver
 {{- end }}
-            {{- if .Values.api.secureEtcd }}
+            {{- if .Values.etcd.secure.enabled }}
             - --etcd-servers=https://{{ include "etcd.fullname" . }}:2379
             {{- else }}
             - --etcd-servers=http://{{ include "etcd.fullname" . }}:2379

--- a/charts/kube-master/templates/dex-configmap.yaml
+++ b/charts/kube-master/templates/dex-configmap.yaml
@@ -16,7 +16,16 @@ data:
       type: etcd
       config:
         endpoints:
+{{- if .Values.etcd.secure.enabled }}
+          - https://{{ include "etcd.fullname" . }}:2379
+        ssl:
+          serverName: {{ include "etcd.fullname" . }}
+          caFile: /etc/kubernetes/certs/tls-etcd-ca.pem
+          keyFile: /etc/kubernetes/certs/etcd-clients-dex-key.pem
+          certFile: /etc/kubernetes/certs/etcd-clients-dex.pem
+{{- else }}
           - http://{{ include "etcd.fullname" . }}:2379
+{{- end }}
         namespace: dex/
     
     web:

--- a/charts/kube-master/templates/dex.yaml
+++ b/charts/kube-master/templates/dex.yaml
@@ -28,7 +28,18 @@ spec:
           - sh
           - -c
         args:
+{{- if .Values.etcd.secure.enabled }}
+          - until etcdctl --dial-timeout=4s --endpoints https://{{ include "etcd.fullname" . }}:2379 --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem --cert=/etc/kubernetes/certs/etcd-clients-dex.pem --key=/etc/kubernetes/certs/etcd-clients-dex-key.pem --insecure-transport=false endpoint health; do sleep 5; done;
+        env:
+        - name: ETCDCTL_API
+          value: "3"
+        volumeMounts:
+        - name: certs
+          mountPath: /etc/kubernetes/certs
+          readOnly: true
+{{- else }}
           - until etcdctl --total-timeout=4s --endpoints http://{{ include "etcd.fullname" . }}:2379 cluster-health; do sleep 5; done;
+{{- end }}
       containers:
       - image: {{ include "dex.image" . | quote }}
         name: dex
@@ -115,7 +126,12 @@ spec:
           timeoutSeconds: 2
         volumeMounts:
         - name: config
-          mountPath: /etc/dex/cfg 
+          mountPath: /etc/dex/cfg
+{{- if .Values.etcd.secure.enabled }}
+        - name: certs
+          mountPath: /etc/kubernetes/certs
+          readOnly: true
+{{- end }}
       volumes:
       - name: config
         defaultMode: 420
@@ -124,6 +140,18 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+{{- if .Values.etcd.secure.enabled }}
+      - name: certs
+        secret:
+          secretName: {{ required "secretName undefined" .Values.secretName }}
+          items:
+            - key: tls-etcd-ca.pem
+              path: tls-etcd-ca.pem
+            - key: etcd-clients-dex.pem
+              path: etcd-clients-dex.pem
+            - key: etcd-clients-dex-key.pem
+              path: etcd-clients-dex-key.pem
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kube-master/test-values.yaml
+++ b/charts/kube-master/test-values.yaml
@@ -14,7 +14,6 @@ openstack:
   region: xy-xy-1
   projectDomainName: xyz
 api:
-  secureEtcd: true
   apiserverHost: xyz.com
   wormholeHost: xyz.com
 version:

--- a/charts/kube-master/test-values.yaml
+++ b/charts/kube-master/test-values.yaml
@@ -14,6 +14,7 @@ openstack:
   region: xy-xy-1
   projectDomainName: xyz
 api:
+  secureEtcd: true
   apiserverHost: xyz.com
   wormholeHost: xyz.com
 version:
@@ -22,6 +23,8 @@ version:
 etcd:
   backup:
     storageProvider: Swift
+  secure:
+    enabled: true
   openstack:
     authURL: http://xyz.com
     username: xyz

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -43,7 +43,6 @@ api:
   replicaCount: 1
   # apiserverHost:
   # wormholeHost:
-  secureEtcd: false
   resources:
     requests:
       cpu: 200m

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -43,6 +43,7 @@ api:
   replicaCount: 1
   # apiserverHost:
   # wormholeHost:
+  secureEtcd: false
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
This PR adds etcd certificates and configuration for secure communication with apiserver and backup sidecar. It is disabled by default for now.