### PR TITLE
Restart apiserver if etcd is gone

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         - name: bootstrap
           configMap:
             name: {{ include "fullname" . }}
-            defaultMode: 0356
+            defaultMode: 0700
       containers:
         - name: etcd
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/kube-master/charts/etcd/templates/service.yaml
+++ b/charts/kube-master/charts/etcd/templates/service.yaml
@@ -10,5 +10,8 @@ spec:
   type: ClusterIP
   ports:
   - port: 2379
+    name: etcd
+  - port: 8080
+    name: backup
   selector:
     app: {{ include "fullname" . }}

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -100,6 +100,8 @@ spec:
             items:
               - key: local-kubeconfig
                 path: kubeconfig
+              - key: liveness-probe.sh
+                path: liveness-probe.sh
       initContainers:
         - name: etcd-wait
           image: "{{ required "etcd.image.repository undefined" .Values.etcd.image.repository }}:{{ required "etcd.image.tag undefined" .Values.etcd.image.tag }}"
@@ -181,15 +183,14 @@ spec:
             - mountPath: /etc/kubernetes/bootstrap
               name: bootstrap
               readOnly: true
+            - mountPath: /
+              name: liveness-probe.sh
+              readOnly: true
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 6443
-              scheme: HTTPS
+            command:
+              - /liveness-probe.sh
             initialDelaySeconds: 60
-            periodSeconds: 5
-            timeoutSeconds: 1
-            failureThreshold: 1
+            periodSeconds: 60
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -99,8 +99,8 @@ spec:
             name: {{ include "master.fullname" . }}
             defaultMode: 0356
             items:
-              - key: api-liveness-probe.sh
-                path: api-liveness-probe.sh
+              - key: api-liveness-probe.py
+                path: api-liveness-probe.py
         - name: wormhole-config
           configMap:
             name: {{ include "master.fullname" . }}
@@ -193,7 +193,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - /liveness-probe/api-liveness-probe.sh
+                - /liveness-probe/api-liveness-probe.py
             initialDelaySeconds: 60
             periodSeconds: 60
           readinessProbe:

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -94,14 +94,19 @@ spec:
         - name: config
           configMap:
             name: {{ include "master.fullname" . }}
+        - name: liveness-probe
+          configMap:
+            name: {{ include "master.fullname" . }}
+            defaultMode: 0356
+            items:
+              - key: api-liveness-probe.sh
+                path: api-liveness-probe.sh
         - name: wormhole-config
           configMap:
             name: {{ include "master.fullname" . }}
             items:
               - key: local-kubeconfig
                 path: kubeconfig
-              - key: liveness-probe.sh
-                path: liveness-probe.sh
       initContainers:
         - name: etcd-wait
           image: "{{ required "etcd.image.repository undefined" .Values.etcd.image.repository }}:{{ required "etcd.image.tag undefined" .Values.etcd.image.tag }}"
@@ -183,12 +188,12 @@ spec:
             - mountPath: /etc/kubernetes/bootstrap
               name: bootstrap
               readOnly: true
-            - mountPath: /
-              name: liveness-probe.sh
-              readOnly: true
+            - mountPath: /liveness-probe
+              name: liveness-probe
           livenessProbe:
-            command:
-              - /liveness-probe.sh
+            exec:
+              command:
+                - /liveness-probe/api-liveness-probe.sh
             initialDelaySeconds: 60
             periodSeconds: 60
           readinessProbe:
@@ -198,6 +203,11 @@ spec:
               scheme: HTTPS
             initialDelaySeconds: 15
             timeoutSeconds: 3
+          env:
+            - name: ETCD_HOST
+              value: {{ include "etcd.fullname" . }}
+            - name: ETCD_BACKUP_PORT
+              value: "8080" 
           resources:
 {{ toYaml .Values.api.resources | indent 12 }}
         - name: wormhole

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -97,7 +97,7 @@ spec:
         - name: liveness-probe
           configMap:
             name: {{ include "master.fullname" . }}
-            defaultMode: 0356
+            defaultMode: 0700
             items:
               - key: api-liveness-probe.py
                 path: api-liveness-probe.py

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -182,11 +182,10 @@ spec:
               name: bootstrap
               readOnly: true
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - cat < /dev/null > /dev/tcp/{{ include "etcd.fullname" . }}/2379
+            httpGet:
+              path: /healthz
+              port: 6443
+              scheme: HTTPS
             initialDelaySeconds: 60
             periodSeconds: 5
             timeoutSeconds: 1

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -181,6 +181,16 @@ spec:
             - mountPath: /etc/kubernetes/bootstrap
               name: bootstrap
               readOnly: true
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - cat < /dev/null > /dev/tcp/{{ include "etcd.fullname" . }}/2379
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            timeoutSeconds: 1
+            failureThreshold: 1
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/kube-master/templates/configmap.yaml
+++ b/charts/kube-master/templates/configmap.yaml
@@ -44,37 +44,20 @@ data:
         user:
           client-certificate: /etc/kubernetes/certs/kube-client.pem
           client-key: /etc/kubernetes/certs/kube-client.key
-  api-liveness-probe.sh: |-
-    #!/bin/bash
-
-    STAT_FILE=/etcdbr_restoration_duration_seconds_count.txt
-    CURL_BIN=/usr/bin/curl
-    if [ ! -f "$CURL_BIN" ]; then
-      clean-install curl
-      if [ $? -ne 0 ]; then
-        exit 1
-      fi
-    fi
-
-    BACKUP=$(curl -s http://${ETCD_HOST}:${ETCD_BACKUP_PORT}/metrics | grep etcdbr_restoration_duration_seconds_count)
-    if [ $? -ne 0 ]; then
-      exit 2
-    fi
-    IFS=" "
-    set -- $BACKUP
-    REST_COUNT=$2
-
-    if [ -z "$REST_COUNT" ]; then
-      REST_COUNT=0
-    fi
-
-    if [ ! -f "$STAT_FILE" ]; then
-      echo $REST_COUNT > $STAT_FILE
-    fi
-
-    STAT=$(cat $STAT_FILE)
-    if [ "$REST_COUNT" -gt "$STAT" ]; then
-      exit 3
-    fi
-
-    exit 0
+  api-liveness-probe.py: |-
+    #!/usr/bin/python
+    import requests, os, os.path, sys
+    try:
+      for line in requests.get('http://' + os.environ['ETCD_HOST'] + ':' + os.environ['ETCD_BACKUP_PORT'] + '/metrics', timeout=1).text.splitlines():
+        if line.startswith('etcdbr_restoration_duration_seconds_count{succeeded="true"}'):
+            restore_count=line.split(" ")[-1]
+            if os.path.isfile("/tmp/last"):
+              with open("/tmp/last", "r") as f:
+                last = int(f.read())
+                if last < int(restore_count):
+                  sys.exit("restore detected")
+            with open("/tmp/last", "w") as f:
+              f.write(restore_count)
+    except requests.exceptions.RequestException as e:
+      print e
+      sys.exit(0)

--- a/charts/kube-master/templates/configmap.yaml
+++ b/charts/kube-master/templates/configmap.yaml
@@ -44,19 +44,29 @@ data:
         user:
           client-certificate: /etc/kubernetes/certs/kube-client.pem
           client-key: /etc/kubernetes/certs/kube-client.key
-  liveness-probe.sh: |-
+  api-liveness-probe.sh: |-
     #!/bin/bash
 
     STAT_FILE=/etcdbr_restoration_duration_seconds_count.txt
     CURL_BIN=/usr/bin/curl
     if [ ! -f "$CURL_BIN" ]; then
       clean-install curl
+      if [ $? -ne 0 ]; then
+        exit 1
+      fi
     fi
 
     BACKUP=$(curl -s http://${ETCD_HOST}:${ETCD_BACKUP_PORT}/metrics | grep etcdbr_restoration_duration_seconds_count)
+    if [ $? -ne 0 ]; then
+      exit 2
+    fi
     IFS=" "
     set -- $BACKUP
     REST_COUNT=$2
+
+    if [ -z "$REST_COUNT" ]; then
+      REST_COUNT=0
+    fi
 
     if [ ! -f "$STAT_FILE" ]; then
       echo $REST_COUNT > $STAT_FILE
@@ -64,7 +74,7 @@ data:
 
     STAT=$(cat $STAT_FILE)
     if [ "$REST_COUNT" -gt "$STAT" ]; then
-      exit 1
+      exit 3
     fi
 
     exit 0

--- a/charts/kube-master/templates/configmap.yaml
+++ b/charts/kube-master/templates/configmap.yaml
@@ -44,3 +44,27 @@ data:
         user:
           client-certificate: /etc/kubernetes/certs/kube-client.pem
           client-key: /etc/kubernetes/certs/kube-client.key
+  liveness-probe.sh: |-
+    #!/bin/bash
+
+    STAT_FILE=/etcdbr_restoration_duration_seconds_count.txt
+    CURL_BIN=/usr/bin/curl
+    if [ ! -f "$CURL_BIN" ]; then
+      clean-install curl
+    fi
+
+    BACKUP=$(curl -s http://${ETCD_HOST}:${ETCD_BACKUP_PORT}/metrics | grep etcdbr_restoration_duration_seconds_count)
+    IFS=" "
+    set -- $BACKUP
+    REST_COUNT=$2
+
+    if [ ! -f "$STAT_FILE" ]; then
+      echo $REST_COUNT > $STAT_FILE
+    fi
+
+    STAT=$(cat $STAT_FILE)
+    if [ "$REST_COUNT" -gt "$STAT" ]; then
+      exit 1
+    fi
+
+    exit 0


### PR DESCRIPTION
This PR adds a liveness probe to the apiserver to solve caching problems. It is now restarted if etcd is gone for some reason.