### PR TITLE
Add noCloud option to kluster Spec

### DIFF
--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -77,12 +77,14 @@ spec:
               - key: apiserver-clients-cluster-admin-key.pem
                 path: kube-client.key
 
+        {{- if .Values.openstack }}
         - name: cloudprovider
           secret:
             secretName: {{ include "master.fullname" . }}-generated
             items:
               - key: openstack.config
                 path: openstack.config
+        {{- end }}
         - name: bootstrap
           secret:
             secretName: {{ include "master.fullname" . }}-generated
@@ -121,8 +123,10 @@ spec:
             - --advertise-address={{ .Values.advertiseAddress }}
             - --allow-privileged=true
             - --authorization-mode=Node,RBAC
+            {{- if .Values.openstack }}
             - --cloud-config=/etc/kubernetes/cloudprovider/openstack.config
             - --cloud-provider=openstack
+            {{- end }}
 {{- if (semverCompare ">= 1.8" .Values.version.kubernetes) }}
             - --enable-bootstrap-token-auth=true
             - --external-hostname={{ required "missing .api.apiserverHost" .Values.api.apiserverHost }}
@@ -169,9 +173,11 @@ spec:
             - mountPath: /etc/kubernetes/certs
               name: certs
               readOnly: true
+            {{- if .Values.openstack }}
             - mountPath: /etc/kubernetes/cloudprovider
               name: cloudprovider
               readOnly: true
+            {{- end }}
             - mountPath: /etc/kubernetes/bootstrap
               name: bootstrap
               readOnly: true

--- a/charts/kube-master/templates/cloud-controller-manager.yaml
+++ b/charts/kube-master/templates/cloud-controller-manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.openstack }}
 {{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
 {{/* vim: set filetype=gotexttmpl: */ -}}
 apiVersion: "extensions/v1beta1"
@@ -89,4 +90,5 @@ spec:
               readOnly: true
           resources:
 {{ toYaml .Values.cloudControllerManager.resources | indent 12 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -50,6 +50,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "master.fullname" . }}
+        {{- if .Values.openstack }}
         - name: cloudprovider
           secret:
             secretName: {{ include "master.fullname" . }}-generated
@@ -59,6 +60,7 @@ spec:
         - name: openstack-hacks
           configMap:
             name: {{ include "master.fullname" . }}-os-hacks
+        {{- end }}
       initContainers:
         - name: apiserver-wait
           image: {{ include "hyperkube.image" . }}
@@ -85,18 +87,20 @@ spec:
             - controller-manager
 {{- end }}
             - --allocate-node-cidrs=true
+            {{- if .Values.openstack }}
             - --cloud-config=/etc/kubernetes/cloudprovider/openstack.config
 {{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
             - --cloud-provider=external
             - --external-cloud-volume-plugin=openstack
 {{- else }}
             - --cloud-provider=openstack
+            - --configure-cloud-routes=true
 {{- end }}
+            {{- end }}
             - --cluster-cidr={{ .Values.clusterCIDR }}
             - --cluster-name={{ .Values.name }}
             - --cluster-signing-cert-file=/etc/kubernetes/certs/apiserver-nodes-ca.pem
             - --cluster-signing-key-file=/etc/kubernetes/certs/apiserver-nodes-ca-key.pem
-            - --configure-cloud-routes=true
             - --controllers=*,bootstrapsigner,tokencleaner
             - --kubeconfig=/etc/kubernetes/config/kubeconfig
 {{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
@@ -130,14 +134,17 @@ spec:
             - mountPath: /etc/kubernetes/config
               name: config
               readOnly: true
+            {{- if .Values.openstack }}
             - mountPath: /etc/kubernetes/cloudprovider
               name: cloudprovider
               readOnly: true
             - mountPath: /var/lib/cloud/data/
               name: openstack-hacks
               readOnly: true
+            {{- end }}
           resources:
 {{ toYaml .Values.controllerManager.resources | indent 12 }}
+{{- if .Values.openstack }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -148,3 +155,4 @@ metadata:
     release: {{ .Release.Name }}
 data:
   instance-id: gurkenwurst
+{{- end }}

--- a/charts/kube-master/templates/secrets.yaml
+++ b/charts/kube-master/templates/secrets.yaml
@@ -8,5 +8,7 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
+  {{- if .Values.openstack }}
   openstack.config: {{ include (print $.Template.BasePath "/_openstack.config.tpl") . | b64enc}}
+  {{- end }}
   token.csv: {{ include (print $.Template.BasePath "/_token.csv.tpl") . | b64enc }}

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -111,11 +111,13 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 	}
 
 	//Ensure that the clust CIDR range does not overlap with other clusters in the same project
-	if overlap, err := d.overlapWithSiblingCluster(kluster.Spec.ClusterCIDR, kluster.Spec.Openstack.RouterID, principal); overlap || err != nil {
-		if overlap {
-			return NewErrorResponse(&operations.CreateClusterDefault{}, 409, err.Error())
+	if !kluster.Spec.NoCloud {
+		if overlap, err := d.overlapWithSiblingCluster(kluster.Spec.ClusterCIDR, kluster.Spec.Openstack.RouterID, principal); overlap || err != nil {
+			if overlap {
+				return NewErrorResponse(&operations.CreateClusterDefault{}, 409, err.Error())
+			}
+			return NewErrorResponse(&operations.CreateClusterDefault{}, 500, err.Error())
 		}
-		return NewErrorResponse(&operations.CreateClusterDefault{}, 500, err.Error())
 	}
 
 	kluster.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/api/models/kluster_spec.go
+++ b/pkg/api/models/kluster_spec.go
@@ -37,6 +37,9 @@ type KlusterSpec struct {
 	// Read Only: true
 	Name string `json:"name,omitempty"`
 
+	// no cloud
+	NoCloud bool `json:"noCloud,omitempty"`
+
 	// node pools
 	NodePools []NodePool `json:"nodePools"`
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -481,6 +481,9 @@ func init() {
           "type": "string",
           "readOnly": true
         },
+        "noCloud": {
+          "type": "boolean"
+        },
         "nodePools": {
           "type": "array",
           "items": {
@@ -1338,6 +1341,9 @@ func init() {
         "name": {
           "type": "string",
           "readOnly": true
+        },
+        "noCloud": {
+          "type": "boolean"
         },
         "nodePools": {
           "type": "array",

--- a/pkg/client/openstack/factory.go
+++ b/pkg/client/openstack/factory.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -122,6 +123,9 @@ func (f *factory) ProjectAdminClientFor(projectID string) (openstack_project.Pro
 }
 
 func (f *factory) projectClient(projectID string, authOptions *tokens.AuthOptions) (openstack_project.ProjectClient, error) {
+	if projectID == "" {
+		return nil, errors.New("Can't create project admin client for empty projectID")
+	}
 	if obj, found := f.projectClients.Load(projectID); found {
 		return obj.(openstack_project.ProjectClient), nil
 	}

--- a/pkg/controller/flight/controller.go
+++ b/pkg/controller/flight/controller.go
@@ -80,6 +80,10 @@ func (d *FlightController) Reconcile(kluster *v1.Kluster) (bool, error) {
 	if kluster.Status.Phase != models.KlusterPhaseRunning {
 		return false, nil
 	}
+	//Skip flight controller for klusters without cloudprovider
+	if kluster.Spec.NoCloud {
+		return false, nil
+	}
 
 	reconciler, err := d.Factory.FlightReconciler(kluster)
 	if err != nil {

--- a/pkg/controller/ground/bootstrap.go
+++ b/pkg/controller/ground/bootstrap.go
@@ -25,11 +25,6 @@ func SeedKluster(clients config.Clients, factories config.Factories, kluster *v1
 		return err
 	}
 
-	openstack, err := factories.Openstack.ProjectAdminClientFor(kluster.Spec.Openstack.ProjectID)
-	if err != nil {
-		return err
-	}
-
 	if err := SeedAllowBootstrapTokensToPostCSRs(kubernetes); err != nil {
 		return errors.Wrap(err, "seed allow bootstrap tokens to post CSRs")
 	}
@@ -45,8 +40,14 @@ func SeedKluster(clients config.Clients, factories config.Factories, kluster *v1
 	if err := SeedKubernikusMember(kubernetes); err != nil {
 		return errors.Wrap(err, "seed kubernikus member")
 	}
-	if err := SeedCinderStorageClasses(kubernetes, openstack); err != nil {
-		return errors.Wrap(err, "seed cinder storage classes")
+	if !kluster.Spec.NoCloud {
+		openstack, err := factories.Openstack.ProjectAdminClientFor(kluster.Spec.Openstack.ProjectID)
+		if err != nil {
+			return err
+		}
+		if err := SeedCinderStorageClasses(kubernetes, openstack); err != nil {
+			return errors.Wrap(err, "seed cinder storage classes")
+		}
 	}
 	if err := SeedAllowCertificateControllerToDeleteCSRs(kubernetes); err != nil {
 		return errors.Wrap(err, "seed allow certificate controller to delete CSRs")

--- a/pkg/controller/launch/controller.go
+++ b/pkg/controller/launch/controller.go
@@ -77,6 +77,10 @@ func (lr *LaunchReconciler) Reconcile(kluster *v1.Kluster) (requeue bool, err er
 	if kluster.Disabled() {
 		return false, nil
 	}
+	//disable launchctl for clusters with no cloudprovider
+	if kluster.Spec.NoCloud {
+		return false, nil
+	}
 	switch kluster.Status.Phase {
 	case models.KlusterPhaseCreating:
 		util.EnsureFinalizerCreated(lr.Kubernikus.Kubernikus(), lr.klusterInformer.Lister(), kluster, LaunchctlFinalizer)

--- a/pkg/controller/routegc/controller.go
+++ b/pkg/controller/routegc/controller.go
@@ -45,6 +45,11 @@ func (w *routeGarbageCollector) Reconcile(kluster *v1.Kluster) (err error) {
 		return nil
 	}
 
+	// disable routegc for clusters with no cloudprovider
+	if kluster.Spec.NoCloud {
+		return nil
+	}
+
 	routerID := kluster.Spec.Openstack.RouterID
 	defer func(begin time.Time) {
 		if err != nil {

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -110,17 +110,6 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 			Kubernetes: kubernetesVersion,
 			Kubernikus: kluster.Status.Version,
 		},
-		Openstack: openstackValues{
-			AuthURL:             secret.Openstack.AuthURL,
-			Username:            secret.Openstack.Username,
-			Password:            secret.Openstack.Password,
-			DomainName:          secret.Openstack.DomainName,
-			Region:              secret.Openstack.Region,
-			ProjectID:           kluster.Spec.Openstack.ProjectID,
-			LbSubnetID:          kluster.Spec.Openstack.LBSubnetID,
-			LbFloatingNetworkID: kluster.Spec.Openstack.LBFloatingNetworkID,
-			RouterID:            kluster.Spec.Openstack.RouterID,
-		},
 		Etcd: etcdValues{
 			Backup: etcdBackupValues{
 				Enabled:  !util.DisabledValue(kluster.Annotations[ETCDBackupAnnotation]), //enabled by default
@@ -142,6 +131,19 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 			ApiserverHost: apiserverURL.Hostname(),
 			WormholeHost:  wormholeURL.Hostname(),
 		},
+	}
+	if !kluster.Spec.NoCloud {
+		values.Openstack = openstackValues{
+			AuthURL:             secret.Openstack.AuthURL,
+			Username:            secret.Openstack.Username,
+			Password:            secret.Openstack.Password,
+			DomainName:          secret.Openstack.DomainName,
+			Region:              secret.Openstack.Region,
+			ProjectID:           kluster.Spec.Openstack.ProjectID,
+			LbSubnetID:          kluster.Spec.Openstack.LBSubnetID,
+			LbFloatingNetworkID: kluster.Spec.Openstack.LBFloatingNetworkID,
+			RouterID:            kluster.Spec.Openstack.RouterID,
+		}
 	}
 	if registry != nil {
 		values.ImageRegistry = *registry

--- a/swagger.yml
+++ b/swagger.yml
@@ -384,6 +384,8 @@ definitions:
     properties:
       openstack:
         $ref: '#/definitions/OpenstackSpec'
+      noCloud:
+        type: boolean
       serviceCIDR:
         description: CIDR Range for Services in the cluster. Can not be updated.
         default: 198.18.128.0/17


### PR DESCRIPTION
Forget about "No Code", the new hot shit is "No Cloud".

The kluster wil have all cloudprovider references removed from the helm deployment
launchctl, flightctl and routegc are skipped for "noCloud" klusters.

At the moment it still create a service user in the openstack project and sets up etcd to backup to swift. We disentail that at a later stage