### PR TITLE
Kubernikus charts improvments

### DIFF
--- a/charts/kubernikus/templates/api.yaml
+++ b/charts/kubernikus/templates/api.yaml
@@ -21,6 +21,9 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
+      {{- if .Values.useServiceAccount }}
+      serviceAccountName: kubernikus-api
+      {{- end }}
       containers:
         - name: api
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/kubernikus/templates/operator.yaml
+++ b/charts/kubernikus/templates/operator.yaml
@@ -37,6 +37,9 @@ spec:
             - --kubernikus-domain={{ .Values.domain }}
             - --namespace={{ default "kubernikus" .Values.namespace }}
             - --metric-port={{ default 9091 .Values.operator.metrics_port }}
+            {{- if .Values.operator.controllers }}
+            - --controllers={{ join "," .Values.operator.controllers }}
+            {{- end }}
             - --v={{ default 1 .Values.groundctl.log_level }}
           env:
             {{- if .Values.operator.nodeAffinity }}

--- a/charts/kubernikus/templates/operator.yaml
+++ b/charts/kubernikus/templates/operator.yaml
@@ -39,8 +39,10 @@ spec:
             - --metric-port={{ default 9091 .Values.operator.metrics_port }}
             - --v={{ default 1 .Values.groundctl.log_level }}
           env:
+            {{- if .Values.operator.nodeAffinity }}
             - name: NODEPOOL_AFFINITY
               value: "true"
+            {{- end }}
             - name: OS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/kubernikus/templates/operator.yaml
+++ b/charts/kubernikus/templates/operator.yaml
@@ -18,6 +18,9 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: {{ .Values.operator.metrics_port | quote }}
     spec:
+      {{- if .Values.useServiceAccount }}
+      serviceAccountName: kubernikus-operator
+      {{- end }}
       containers:
         - name: operator
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/kubernikus/templates/rbac.yaml
+++ b/charts/kubernikus/templates/rbac.yaml
@@ -1,0 +1,155 @@
+{{ if .Values.useServiceAccount -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "kubernikus-operator"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "kubernikus-api"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "kubernikus:{{.Release.Name}}"
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  resourceNames:
+  - klusters.kubernikus.sap.cc
+  verbs:
+  - update
+  - get
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "kubernikus:{{ .Release.Name }}"
+subjects:
+- kind: ServiceAccount
+  name: "kubernikus-operator"
+  namespace: "{{.Release.Namespace}}"
+- kind: ServiceAccount
+  name: "kubernikus-api"
+  namespace: "{{.Release.Namespace}}"
+roleRef:
+  kind: ClusterRole #this must be Role or ClusterRole
+  name: "kubernikus:{{.Release.Namespace}}"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "kubernikus:operator"
+rules:
+- apiGroups:
+  - kubernikus.sap.cc
+  resources:
+  - klusters
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - update
+  - delete
+  - list
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "kubernikus:operator"
+subjects:
+- kind: ServiceAccount
+  name: "kubernikus-operator"
+roleRef:
+  kind: Role #this must be Role or ClusterRole
+  name: "kubernikus:operator"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "kubernikus:api"
+subjects:
+- kind: ServiceAccount
+  name: "kubernikus-api"
+  namespace: "{{ .Release.Namespace }}"
+roleRef:
+  kind: Role #this must be Role or ClusterRole
+  name: "kubernikus:api"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "kubernikus:api"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - kubernikus.sap.cc
+  resources:
+  - klusters
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - list
+  - get
+  - watch
+{{- end }}

--- a/charts/kubernikus/values.yaml
+++ b/charts/kubernikus/values.yaml
@@ -27,5 +27,6 @@ k8sniff:
 standalone: true
 
 operator:
+  controllers: []
   nodeAffinity: true
   metrics_port: 9091

--- a/charts/kubernikus/values.yaml
+++ b/charts/kubernikus/values.yaml
@@ -27,4 +27,5 @@ k8sniff:
 standalone: true
 
 operator:
+  nodeAffinity: true
   metrics_port: 9091


### PR DESCRIPTION
* Optional use dedicated serviceAccounts with specific RBAC rules for kubernikus api and operator
* Add some knobs for upcoming `v-*` deployments