### PR TITLE
Scale dns deployment

### DIFF
--- a/pkg/controller/ground/bootstrap/dns/coredns.go
+++ b/pkg/controller/ground/bootstrap/dns/coredns.go
@@ -206,10 +206,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "CoreDNS"
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -224,6 +221,16 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - kube-dns
+            topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:

--- a/pkg/controller/ground/bootstrap/dns/kubedns.go
+++ b/pkg/controller/ground/bootstrap/dns/kubedns.go
@@ -182,10 +182,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 10%
@@ -201,6 +198,16 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - kube-dns
+            topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"


### PR DESCRIPTION
This PR increases the dns deployment scale to 2 and adds anti affinity to make sure the pods run on different nodes.