### PR TITLE
Force reload of fluent-bit

### DIFF
--- a/charts/kubernikus-system/values.yaml
+++ b/charts/kubernikus-system/values.yaml
@@ -103,7 +103,7 @@ fluent-bit:
 
   podAnnotations:
     # manual versioning, raise if configmap changes
-    versioning: "1"
+    versioning: "2"
 
   existingConfigMap: fluent-bit-config
 


### PR DESCRIPTION
This PR forces reload of fluent-bit. We bring our own configmap, so checksum in template is not working in this case.