### PR TITLE
Remove checking for the first attribute hyphen

### DIFF
--- a/contrib/kubernikus-kubectl/kubectl
+++ b/contrib/kubernikus-kubectl/kubectl
@@ -2,10 +2,6 @@
 set -o errexit
 set -o pipefail
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- kubectl "$@"
-fi
-
 if [ "$0" = '/usr/local/bin/kubectl' ]; then
   if [ ! -f $HOME/.kube/config ]; then
     kubernikusctl auth init


### PR DESCRIPTION
Resolves an error, when "kubectl -n kube-system get pods" doesn't work