### PR TITLE
Exclude unavailable AVZs from default

### DIFF
--- a/pkg/client/openstack/project/client.go
+++ b/pkg/client/openstack/project/client.go
@@ -233,7 +233,9 @@ func (c *projectClient) getAvailabilityZones() ([]models.AvailabilityZone, error
 		return nil, err
 	}
 	for _, zone := range zones {
-		result = append(result, models.AvailabilityZone{Name: zone.ZoneName})
+		if zone.ZoneState.Available {
+			result = append(result, models.AvailabilityZone{Name: zone.ZoneName})
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
This PR excludes unavailable AVZs from default selection. Apparently there will be a new zone `na-us-1d` that is unavailable right now. Currently Kubernikus tries to deploy in that AVZ when there is none choosen.