### PR TITLE
Add prometheus target to etcd

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -69,7 +69,11 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
+{{- if eq .Values.global.region "admin" }}
         prometheus.io/targets: "kubernetes"
+{{- else }}
+        prometheus.io/targets: "kubernikus"
+{{- end }}
     spec:
       volumes:
         - name: data

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
+        prometheus.io/targets: "kubernetes"
     spec:
       volumes:
         - name: data

--- a/charts/kube-master/test-values.yaml
+++ b/charts/kube-master/test-values.yaml
@@ -1,3 +1,5 @@
+global:
+  region: xy-xy-1
 domain: xyz.com
 bootstrapToken: xyz
 nodePassword: xyz


### PR DESCRIPTION
This PR enables scraping of etcd-backup-restore metrics. @auhlig Will scraping still work for our customer klusters in k-region with this annotation?