### PR TITLE
Update Prometheus server to v2.12.0

### DIFF
--- a/charts/kubernikus-monitoring/Chart.yaml
+++ b/charts/kubernikus-monitoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kubernikus-monitoring
-version: 0.1.0
+version: 0.1.1

--- a/charts/kubernikus-monitoring/alerts/kubernikus-operator.alerts
+++ b/charts/kubernikus-monitoring/alerts/kubernikus-operator.alerts
@@ -71,7 +71,7 @@ groups:
       context: operator
       meta: "{{ $labels.kluster }} is having Hammertime"
     annotations:
-      description: Hammertime for kluster {{ $labels.kluster }}. Controller manager scaled down because no node posted a status update recently. <https://dashboard.REGION_MISSING.cloud.sap/_/{{ $labels.kluster | reReplaceAll ".*-" "" }}/webconsole|:terminal:>
+      description: Hammertime for kluster {{ $labels.kluster }}. Controller manager scaled down because no node posted a status update recently. <https://dashboard.{{ $externalLabels.region }}.cloud.sap/_/{{ $labels.kluster | reReplaceAll ".*-" "" }}/webconsole|:terminal:>
       summary: Hammertime for kluster {{ $labels.kluster }}
 
   - alert: KubernikusMigrationErrors

--- a/charts/kubernikus-monitoring/requirements.lock
+++ b/charts/kubernikus-monitoring/requirements.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.0
 - name: prometheus-server
   repository: file://vendor/prometheus-server
-  version: 1.1.13
+  version: 1.2.1
 - name: oomkill-exporter
   repository: file://vendor/oomkill-exporter
   version: 0.1.0
@@ -23,5 +23,5 @@ dependencies:
 - name: ping-exporter
   repository: file://vendor/ping-exporter
   version: 0.1.0
-digest: sha256:e8bd061f51835174a919e7307830a9e357fba8c4b1ebc7d564e40001dba05cf3
-generated: 2019-06-26T12:51:53.557951482+02:00
+digest: sha256:4756dff267e4027124e342e3e957c6f1b1d74fb0ff2859e2158e99f4ab150659
+generated: 2019-08-30T17:07:01.693171847+02:00

--- a/charts/kubernikus-monitoring/requirements.yaml
+++ b/charts/kubernikus-monitoring/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   - name: prometheus-server
     alias: prometheus-kubernikus
     repository: file://vendor/prometheus-server
-    version: 1.1.13
+    version: 1.2.1
 
   - name: oomkill-exporter
     repository: file://vendor/oomkill-exporter

--- a/charts/kubernikus-monitoring/values.yaml
+++ b/charts/kubernikus-monitoring/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # The alert tier.
+  tier: kks
+
 # Name of the Prometheus to which the alert and aggregation rules should be assigned to.
 prometheusName: kubernikus
 

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/CHANGELOG.md
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/CHANGELOG.md
@@ -1,0 +1,163 @@
+## 1.2.1
+
+* Fix playbook links.
+
+## 1.2.0
+
+* Bump Prometheus server to `v2.12.0`.
+* Introduce [alerts for common Prometheus failures](./templates/alerts).
+
+## 1.1.23
+
+* Adds `region` and if set add `cluster_type`, `cluster` label to all metrics. 
+
+## 1.1.22
+
+* Configurable OpenstackSeed for Thanos integration. Extend [Thanos README](./templates/thanos/README.md).
+
+## 1.1.21
+
+* Configurable `affinity` and `nodeSelector` for Prometheus server instances.
+
+## 1.1.20
+
+* Extend clusterrole to for kubelet (`nodes/metrics`), cAdvisor (`nodes/metrics/cAdvisor`) metrics.
+* Do not create serviceaccount with name `default` but generate the name in the format `prometheus-<name>` instead.
+
+## 1.1.19
+
+* Prometheus server to `v2.11.1`.
+
+## 1.1.18
+
+* [CI] Helm chart tests.
+
+## 1.1.17
+
+* Prometheus server to `v2.10.0`.
+
+## 1.1.16
+
+* Fix Service and Pod SD regex.
+
+## 1.1.15
+
+* Fix empty additionalScrapeConfigs by defaulting to `{}`.
+
+## 1.1.14
+
+* Set `honor_labels: true` for endpoint SD.
+
+## 1.1.13
+
+* Fix alertmanager configuration secret name.
+
+## 1.1.12
+
+* Re-add `ServiceMonitor.Spec.Selector` as required by k8s 1.10+.
+
+## 1.1.11
+
+* Cleanup PodMonitors.
+
+## 1.1.10
+
+* Fix metric port.
+
+## 1.1.9
+
+* Allow extending `prometheus.io/targets` annotations via `.Values.serviceDiscoveries.targetsOverride`.
+
+## 1.1.8
+
+* Bump Thanos image.
+
+## 1.1.7
+
+* Bump Prometheus to v2.9.2
+
+## 1.1.6
+
+* Bump Thanos image.
+
+## v1.1.5
+
+* Fix for incorrect thanos config name introduced in v1.1.4.
+
+## v1.1.4
+
+* Prefix Thanos components with `prometheus-<name>` and adjust labels to allow multiple Prometheis with Thanos instances per namespace.
+
+## v1.1.3
+
+* Fix setting Thanos image in chart.
+
+## v1.1.2
+
+* Fix OpenStack seed for Thanos.
+* Use `sapcc/thanos:v0.4.0-e697626a` with support for cross domain scoping.
+
+## v1.1.1
+
+* Adds Thanos support.
+
+## v1.1.0
+
+* Changed defaults to `rbac.create=true`, `serviceAccount.create=true`.
+
+## v1.0.20
+
+* Support mounting additional secrets.
+
+## v1.0.19
+
+* Prefix all resources (confimaps,ingress, service, etc.) with `prometheus-<name>`. 
+
+## v1.0.18
+
+* Configurable client certificate authentication. Enabled by default.
+
+## v1.0.17
+
+* Fix service name.
+
+## v1.0.16
+
+* Configurable selector for persistent volume.
+
+## v1.0.15
+
+* Configurable global `.Values.scrapeInterval`.
+
+## v1.0.14
+
+* Allow setting complete hostname via `.Values.ingress.hostNameOverride`.
+
+## v1.0.13
+
+* Allow setting additional annotations on ingress.
+
+## v1.0.12
+
+* Fix missing base64 encoding of alertmanager configuration.
+
+## v1.0.11
+
+* Update to prom/prometheus:v2.9.1
+
+## v1.0.10
+
+* Add tolerations.
+
+## v1.0.8
+
+* Add out-of-the-box service discovery for endpoints, services.
+
+## v1.0.7
+
+* Add configurable security context.
+
+## v1.0.6
+
+* Add option to inject additional configmaps to a prometheus instance via `.Values.configMaps`.
+* Add option to specify list of alertmanagers via `.Values.alertmanagers`.

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/Chart.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/Chart.yaml
@@ -1,3 +1,7 @@
 description: Prometheus via operator.
 name: prometheus-server
-version: 1.1.13
+version: 1.2.1
+appVersion: v2.12.0
+icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
+maintainers:
+  - name: auhlig

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/README.md
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/README.md
@@ -1,0 +1,118 @@
+Prometheus Chart
+----------------
+
+This chart shall serve as a template to deploy your own Prometheus.  
+It will set up:
+- Prometheus server instance (with 2 sidecars: configmap, rules reload)
+- Persistent volume claim (if configured; default off)
+- Ingress to manage external access for the Prometheus instance. (default off)
+- RBAC resources for the Prometheus. Might be required if e.g. when service discoveries are used. (default off)
+
+## Prerequisite
+
+This chart relies on resources brought to you by the [Prometheus Operator](https://github.com/coreos/prometheus-operator).  
+It may be installed using the [official helm chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator).
+
+## Scrape configuration
+
+A default scrape configuration ifor service, endpoint and pod service discovery is part of this chart and deployed via [ServiceMonitors](./templates/servicemonitors),
+[PodMonitors](./templates/podmonitors) and via [configuration](./examples/prometheus.yaml).
+It can be disabled via values.  
+See the official specification on [ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor) 
+and [PodMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmonitor) for additional information.  
+
+### Providing additional scrape configurations
+
+Additional scrape configuration is provided via a secret referenced by the `additionalScrapeConfigs.name` and `additionalScrapeConfigs.key` parameters.  
+See the `prometheus.yaml` and `additional-scrape-config.yaml` in the [examples](./examples) folder.
+
+## Aggregation and Alerting rules
+
+Aggregation and alerting rules can be deployed independently of the Prometheus server instance using the `PrometheusRule` CRD.  
+An example can be found [here](./examples/kubernetes-health.alerts.yaml).  
+Rules are assigned to a Prometheus instance by setting labels on the PrometheusRule as shown below. Refers to the `name` of the Prometheus as describe above.
+```
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  labels:
+    prometheus: < name of the prometheus to which the rule should be assigned to >
+  ...
+```
+
+## Integrate custom Service Discovery (SD)
+
+To integrate a [custom SD](https://prometheus.io/blog/2018/07/05/implementing-custom-sd/#implementing-custom-service-discovery) one needs to provide the scrape configuration
+```
+scrape_configs:
+  - job_name: "custom-sd"
+    scrape_interval: "15s"
+    file_sd_configs:
+    - files:
+      - /etc/prometheus/config/custom_sd.json
+```
+
+and have the Kubernetes configmap containing the `custom_sd.json` mounted to the Prometheus server by setting
+```
+configMaps:
+  - <name of the configmap containing the custom_sd.json`
+```
+
+## Thanos (Long-term storage for metrics)
+
+This chart supports [Thanos](https://github.com/improbable-eng/thanos) out-of-the-box.
+See [Thanos docs](./templates/thanos/README.md) for additional details specific to the SAP Converged Cloud Enterprise Edition.
+
+## Configuration
+
+The following table provides an overview of configurable parameters of this chart and their defaults.  
+See the [values.yaml](./values.yaml) for more details.  
+**TLDR;** Set the `name`, `global.region`, `global.domain` parameters and get started where `name` has to be a unique identifier for your prometheus.
+
+|       Parameter                        |           Description                                                                                                   |                         Default                     |
+|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| `global.region`                        | The OpenStack region.                                                                                                   | `""`                                                |
+| `global.domain`                        | The URL domain.                                                                                                         | `""`                                                |
+| `global.clusterType`                   | Optional: The type of the cluster to which the Prometheus is deployed.                                                  | `""`                                                |
+| `global.cluster`                       | Optional: The name of the cluster to which the Prometheus is deployed.                                                  | `$global.region`                                    |
+| `image.repository`                     | Repository of the Prometheus image.                                                                                     | `prom/prometheus`                                   |
+| `image.tag`                            | Tag of the Prometheus image.                                                                                            | `v2.8.0`                                            |
+| `name`                                 | Unique name for this Prometheus instance. The name will be used to assign aggregation and alerting rules to Prometheus. | `""`                                                |
+| `retentionTime`                        | Defines how long data is stored. Format: `[0-9]+(ms|s|m|h|d|w|y)`.                                                      | `7d`                                                |
+| `additionalScrapeConfigs.name`         | Name of the Secret containing the additional scrape configuration.                                                      | `""`                                                |
+| `additionalScrapeConfigs.key`          | Key in the Secret containing the additional scrape configuration.                                                       | `""`                                                |
+| `additionalScrapeConfigs.optional`     | Whether the Secret or the key must be found.                                                                            | `false`                                             |
+| `scrapeInterval`                       | Global interval between consecutive scrapes.                                                                            | `"60s"`                                             |
+| `ingress.enabled`                      | If enabled deploy an Ingress for this Prometheus.                                                                       | `false`                                             |
+| `ingress.host`                         | Used to generate the external URL and ingress host in the form `<host>.<region>.<domain>`.                              | `""`                                                |
+| `ingress.hostNameOverride`             | Used to set the complete hostname and skip above generation.                                                            | `""`                                                |
+| `ingress.vice_president`               | Automate certificate management via vice-president (k8s operator).                                                      | `true`                                              |
+| `ingress.disco`                        | Automate management of DNS provider via disco (k8s operator).                                                           | `true`                                              |
+| `ingress.annotations`                  | Additional annotations for ingress.                                                                                     | `{}`                                                |
+| `ingress.authentication`               | Ingress client certificate authentication. See values for details.                                                      | `{}`                                                |
+| `persistence.enabled`                  | If enabled a persistent volume is used to store the data. Else data is stored in memory.                                | `false`                                             |
+| `persistence.name`                     | Name of the persistent volume claim.                                                                                    | `$name`                                             |
+| `persistence.accessMode`               | Access mode for the persistent volume.                                                                                  | `ReadWriteOnce`                                     |
+| `persistence.size`                     | The size of the persistent volume claim with unit.                                                                      | `100Gi`                                             |
+| `persistence.selector`                 | Label selector to be applied to the PVC.                                                                                | `{}`                                                |
+| `logLevel`                             | The log level of the Prometheus server.                                                                                 | `info`                                              |
+| `resources.requests.cpu`               | Kubernetes resource requests for CPU.                                                                                   | `4`                                                 |
+| `resources.requests.memory`            | Kubernetes resource requests for memory.                                                                                | `8Gi`                                               |
+| `rbac.create`                          | Create RBAC resources.                                                                                                  | `false`                                             |
+| `serviceAccount.create`                | Create a service account for the Prometheus server.<br> Will not create a service account with name `default`. See values.yaml . | `false`                                             |                                               |
+| `serviceAccount.name`                  | Name of the service account to use for the Prometheus server.                                                           | `""`                                                |
+| `externalLabels`                       | The labels to add to any time series or alerts when communicating with any external system.                             | `{}`                                                |
+| `configMaps`                           | List of configmaps in the same namespace as the Prometheus that should be mounted to `/etc/prometheus/configmaps`.      | `[]`                                                |
+| `alertmanagers`                        | List of Alertmanagers to send alerts to.                                                                                | `[]`                                                |
+| `serviceDiscoveries.endpoints.enabled` | En-/Disable service discovery of endpoints. See documentation for additional details.                                   | `true`                                              |
+| `serviceDiscoveries.pods.enabled`      | En-/Disable service discovery of pods. See documentation for additional details.                                        | `false`                                             |    
+| `tolerations`                          | The pods tolerations.                                                                                                   | `[]`                                                |
+| `affinity`                             | The pod affinity.                                                                                                       | `{}`                                                |
+| `nodeSelector`                         | The pod node selector.                                                                                                  | `{}`                                                |
+| `secrets`                              | List of secrets in the same namespace as the Prometheus that should be mounted to `/etc/prometheus/secrets`.            | `[]`                                                |
+| `thanos.enabled`                       | Enable Thanos support.                                                                                                  | `false`                                             |
+| `thanos.seed.enabled`                  | Enable Openstack seed triggering creation of an OpenStack user and Swift container.                                     | `true`                                              |   
+| `thanos.swiftStorageConfig`            | Thanos storage configuration for use with OpenStack Swift. See values for details.                                      | `{}`                                                |
+| `thanos.spec`                          | The [Thanos spec](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#thanosspec)            | `{}`                                                |
+| `alerts.tier`                          | The `tier` to which the Prometheus alerts are assigned to. <br>`$values.global.tier` takes precedence if set.           | `$values.global.tier` or `k8s`                      |

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/ci/test-values.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/ci/test-values.yaml
@@ -1,0 +1,46 @@
+global:
+  region: regionOne
+  domain: evil.corp
+  clusterType: controlplane
+  cluster: x-regionOne
+  tier: alertTierKubernetes
+
+externalLabels:
+  foo: bar
+
+name: regionOnePrometheus
+retentionTime: 7d
+
+ingress:
+  enabled: true
+  host: regionOnePrometheus
+
+persistence:
+  enabled: true
+  size: 300Gi
+
+serviceAccount:
+  create: true
+  name: default
+
+serviceDiscoveries:
+  endpoints:
+    enabled: true
+  pods:
+    enabled: true
+
+# Send alerts to these alertmanagers.
+alertmanagers:
+  - alertmanager.evil.corp
+
+thanos:
+  enabled: true
+  swiftStorageConfig:
+    authURL: https://keystone.evil.corp/v3
+    userName: prometheus
+    userDomainName: Default
+    password: topSecret!
+    domainName: Default
+    tenantName: master
+    regionName: regionOne
+    containerName: regionOnePrometheusThanos

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/examples/prometheus.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/examples/prometheus.yaml
@@ -27,7 +27,7 @@
     regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
     target_label: __address__
-    regex: ([^:]+)(?::\d+);(\d+)
+    regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
@@ -39,27 +39,6 @@
   - action: labelmap
     replacement: __param_$1
     regex: __meta_kubernetes_service_annotation_prometheus_io_scrape_param_(.+)
-  metric_relabel_configs:
-  - source_labels: [component]
-    regex: 'snmp-exporter-(\w*-\w*-\w*)-(\S*)'
-    replacement: '$1'
-    target_label: availability_zone
-  - source_labels: [component]
-    regex: 'snmp-exporter-(\w*-\w*-\w*)-(\S*)'
-    replacement: '$2'
-    target_label: device
-  - source_labels: [component]
-    regex: 'snmp-exporter-(.+)'
-    replacement: '$1'
-    target_label: devicename
-  - source_labels: [component, cluster]
-    separator: ;
-    regex: elasticsearch-exporter-(.+);(.+)
-    target_label: elastic_cluster
-    replacement: $2
-    action: replace
-  - regex: 'cluster'
-    action: labeldrop
 
 # Scrape config for endpoints with an additional port for metrics via `prometheus.io/port_1` annotation.
 #
@@ -87,7 +66,7 @@
     regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port_1]
     target_label: __address__
-    regex: ([^:]+)(?::\d+);(\d+)
+    regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
@@ -119,7 +98,7 @@
     regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
     target_label: __address__
-    regex: ([^:]+)(?::\d+);(\d+)
+    regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: ${1}:${2}
   - action: labelmap
     regex: __meta_kubernetes_pod_label_(.+)
@@ -151,7 +130,7 @@
     regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port_1]
     target_label: __address__
-    regex: ([^:]+)(?::\d+);(\d+)
+    regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: ${1}:${2}
   - action: labelmap
     regex: __meta_kubernetes_pod_label_(.+)

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/_helpers.tpl
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/_helpers.tpl
@@ -29,10 +29,15 @@ prometheus-{{- (include "prometheus.name" .) -}}
 
 {{/* The name of the serviceAccount. */}}
 {{- define "serviceAccount.name" -}}
+{{- $name := .Values.serviceAccount.name -}}
 {{- if .Values.serviceAccount.create -}}
-{{- default (include "prometheus.fullName" . ) .Values.serviceAccount.name -}}
+{{- if and $name (ne $name "default") -}}
+{{- $name -}}
 {{- else -}}
-{{- default "default" .Values.serviceAccount.name -}}
+{{- (include "prometheus.fullName" . ) -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" $name -}}
 {{- end -}}
 {{- end -}}
 
@@ -101,5 +106,13 @@ thanos-peers.{{ .Release.Namespace }}.svc:10900
 {{- $value -}}|.*{{- .Values.serviceDiscoveries.additionalTargets | join ".*|.*" -}}.*
 {{- else -}}
 {{- $value -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "alerts.tier" -}}
+{{- if and .Values.global .Values.global.tier }}
+  {{- .Values.global.tier -}}
+{{- else -}}
+  {{- required ".Values.alerts.tier missing" .Values.alerts.tier -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/alerts/README.md
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/alerts/README.md
@@ -1,0 +1,7 @@
+Prometheus Alerts
+-----------------
+
+This folder contains a set of basic alerts for the Prometheus server which are deployed via the PrometheusRule custom resource.  
+They will only be active if one alertmanager is configured via `.Values.alertmanagers`.  
+
+Alerts are structured by `tier`, which can be provided via `.Values.global.tier`, `Values.alerts.tier`.

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/alerts/_prometheus.alerts.tpl
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/alerts/_prometheus.alerts.tpl
@@ -1,0 +1,111 @@
+groups:
+- name: prometheus.alerts
+  rules:
+  - alert: PrometheusFailedConfigReload
+    expr: prometheus_config_last_reload_successful == 0
+    for: 5m
+    labels:
+      context: availability
+      service: prometheus
+      severity: critical
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/failed_config_reload.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to load it`s configuration.'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to load it`s configuration. Prometheus cannot start with a malformed configuration.'
+      summary: Prometheus configuration reload has failed
+
+  - alert: PrometheusRuleEvaluationFailed
+    expr: increase(prometheus_rule_evaluation_failures_total[5m]) > 0
+    labels:
+      context: availability
+      service: prometheus
+      severity: warning
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/rule_evaluation.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to evaluate rules.'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to evaluate rules. Aggregation or alerting rules may not be loaded or provide false results.'
+      summary: Prometheus rule evaluation failed
+
+  - alert: PrometheusRuleEvaluationSlow
+    expr: prometheus_rule_evaluation_duration_seconds{quantile="0.9"} > 60
+    for: 10m
+    labels:
+      context: availability
+      service: prometheus
+      severity: info
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/rule_evaluation.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} rule evaluation is slow.'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} rule evaluation is slow'
+      summary: Prometheus rule evaluation is slow
+
+  - alert: PrometheusWALCorruption
+    expr: increase(prometheus_tsdb_wal_corruptions_total[5m]) > 0
+    labels:
+      context: availability
+      service: prometheus
+      severity: info
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/wal.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} has {{`{{ $value }}`}} WAL corruptions.'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}}  has {{`{{ $value }}`}} WAL corruptions.'
+      summary: Prometheus has WAL corruptions
+
+  - alert: PrometheusTSDBReloadsFailing
+    expr: increase(prometheus_tsdb_reloads_failures_total[2h]) > 0
+    for: 12h
+    labels:
+      context: availability
+      service: prometheus
+      severity: info
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/failed_tsdb_reload.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to reload TSDB.'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} had {{`{{$value | humanize}}`}} reload failures over the last four hours.'
+      summary: Prometheus has issues reloading data blocks from disk
+
+  - alert: PrometheusNotIngestingSamples
+    expr: rate(prometheus_tsdb_head_samples_appended_total[5m]) <= 0
+    for: 10m
+    labels:
+      context: availability
+      service: prometheus
+      severity: info
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/failed_scrapes.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to evaluate rules.'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} failed to evaluate rules. Aggregation or alerting rules may not be loaded or provide false results.'
+      summary: Prometheus rule evaluation failed
+
+  - alert: PrometheusTargetScrapesDuplicate
+    expr: increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[5m]) > 0
+    for: 10m
+    labels:
+      context: availability
+      service: prometheus
+      severity: info
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/failed_scrapes.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} rejects many samples'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} has many samples rejected due to duplicate timestamps but different values. This indicates metric duplication.'
+      summary: Prometheus rejects many samples
+
+  - alert: PrometheusLargeScrapes
+    expr: increase(prometheus_target_scrapes_exceeded_sample_limit_total[30m]) > 60
+    labels:
+      context: availability
+      service: prometheus
+      severity: info
+      tier: {{ include "alerts.tier" . }}
+      playbook: 'docs/support/playbook/prometheus/failed_scrapes.html'
+      meta: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} fails to scrape targets'
+    annotations:
+      description: 'Prometheus {{`{{ $externalLabels.region }}`}}/{{`{{ $labels.prometheus }}`}} has many scrapes that exceed the sample limit'
+      summary: Prometheus fails to scrape targets.

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/alerts/prometheus-alerts.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/alerts/prometheus-alerts.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.alertmanagers }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "prometheus.fullName" . }}-prometheus.alerts
+  labels:
+    prometheus: {{ include "prometheus.name" . }}
+
+spec:
+{{ include (print .Template.BasePath "/alerts/_prometheus.alerts.tpl") . | indent 2 }}
+
+{{- end }}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/cluster-role.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/cluster-role.yaml
@@ -11,19 +11,23 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
+      - nodes/metrics
+      - nodes/metrics/cadvisor
       - services
       - endpoints
       - pods
     verbs: ["get", "list", "watch"]
+
   - apiGroups: [""]
     resources:
       - configmaps
     verbs: ["get"]
+
   - apiGroups: ["extensions"]
     resources:
       - ingresses
     verbs: ["get", "list", "watch"]
+
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
-
-{{- end }}
+{{ end -}}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/podmonitors/pod-sd.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/podmonitors/pod-sd.yaml
@@ -48,7 +48,7 @@ spec:
             - __address__
             - __meta_kubernetes_pod_annotation_prometheus_io_port
           targetLabel: __address__
-          regex: '([^:]+)(?::\d+);(\d+)'
+          regex: '([^:]+)(?::\d+)?;(\d+)'
           replacement: ${1}:${2}
         - action: labelmap
           regex: '__meta_kubernetes_pod_label_(.+)'
@@ -58,6 +58,19 @@ spec:
         - sourceLabels:
             - __meta_kubernetes_pod_name
           targetLabel: kubernetes_pod_name
+        - action: replace
+          targetLabel: region
+          replacement: {{ required ".Values.global.region undefined" .Values.global.region }}
+        {{ if .Values.global.clusterType }}
+        - action: replace
+          targetLabel: cluster_type
+          replacement: {{ .Values.global.clusterType }}
+        {{ end }}
+        {{ if .Values.global.cluster }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ .Values.global.cluster }}
+        {{ end }}
 
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 60s
@@ -89,7 +102,7 @@ spec:
             - __address__
             - __meta_kubernetes_pod_annotation_prometheus_io_port_1
           targetLabel: __address__
-          regex: '([^:]+)(?::\d+);(\d+)'
+          regex: '([^:]+)(?::\d+)?;(\d+)'
           replacement: ${1}:${2}
         - action: labelmap
           regex: '__meta_kubernetes_pod_label_(.+)'
@@ -99,4 +112,17 @@ spec:
         - sourceLabels:
             - __meta_kubernetes_pod_name
           targetLabel: kubernetes_pod_name
+        - action: replace
+          targetLabel: region
+          replacement: {{ required ".Values.global.region undefined" .Values.global.region }}
+        {{ if .Values.global.clusterType }}
+        - action: replace
+          targetLabel: cluster_type
+          replacement: {{ .Values.global.clusterType }}
+        {{ end }}
+        {{ if .Values.global.cluster }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ .Values.global.cluster }}
+        {{ end }}
 {{ end }}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/prometheus-server.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/prometheus-server.yaml
@@ -138,3 +138,15 @@ spec:
   tolerations:
 {{ toYaml .Values.tolerations | indent 4 }}
   {{ end }}
+
+  {{ if .Values.affinity }}
+  # Assign custom affinity rules to the prometheus instance.
+  affinity:
+{{ toYaml .Values.affinity | indent 4 }}
+  {{ end }}
+
+  {{ if .Values.nodeSelector }}
+  # Define which Nodes the Pods are scheduled on.
+  nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 4 }}
+  {{ end }}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
@@ -25,6 +25,7 @@ spec:
       interval: 60s
       scrapeTimeout: 55s
       scheme: http
+      honorLabels: true
       relabelings:
         - action: keep
           sourceLabels:
@@ -52,7 +53,7 @@ spec:
             - __address__
             - __meta_kubernetes_service_annotation_prometheus_io_port
           targetLabel: __address__
-          regex: '([^:]+)(?::\d+);(\d+)'
+          regex: '([^:]+)(?::\d+)?;(\d+)'
           replacement: $1:$2
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
@@ -65,11 +66,25 @@ spec:
         - action: labelmap
           replacement: __param_$1
           regex: '__meta_kubernetes_service_annotation_prometheus_io_scrape_param_(.+)'
+        - action: replace
+          targetLabel: region
+          replacement: {{ required ".Values.global.region undefined" .Values.global.region }}
+        {{ if .Values.global.clusterType }}
+        - action: replace
+          targetLabel: cluster_type
+          replacement: {{ .Values.global.clusterType }}
+        {{ end }}
+        {{ if .Values.global.cluster }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ .Values.global.cluster }}
+        {{ end }}
 
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 60s
       scrapeTimeout: 55s
       scheme: http
+      honorLabels: true
       relabelings:
         - action: keep
           sourceLabels:
@@ -101,7 +116,7 @@ spec:
             - __address__
             - __meta_kubernetes_service_annotation_prometheus_io_port_1
           targetLabel: __address__
-          regex: '([^:]+)(?::\d+);(\d+)'
+          regex: '([^:]+)(?::\d+)?;(\d+)'
           replacement: $1:$2
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
@@ -114,4 +129,17 @@ spec:
         - action: labelmap
           replacement: __param_$1
           regex: '__meta_kubernetes_service_annotation_prometheus_io_scrape_param_(.+)'
+        - action: replace
+          targetLabel: region
+          replacement: {{ required ".Values.global.region undefined" .Values.global.region }}
+        {{ if .Values.global.clusterType }}
+        - action: replace
+          targetLabel: cluster_type
+          replacement: {{ .Values.global.clusterType }}
+        {{ end }}
+        {{ if .Values.global.cluster }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ .Values.global.cluster }}
+        {{ end }}
 {{- end }}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/servicemonitors/prometheus.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/servicemonitors/prometheus.yaml
@@ -19,3 +19,20 @@ spec:
       scrapeTimeout: 55s
       port: http
       scheme: http
+      relabelings:
+        - action: replace
+          targetLabel: region
+          replacement: {{ required ".Values.global.region undefined" .Values.global.region }}
+        - action: replace
+          targetLabel: prometheus
+          replacement: {{ include "prometheus.name" . }}
+        {{ if .Values.global.clusterType }}
+        - action: replace
+          targetLabel: cluster_type
+          replacement: {{ .Values.global.clusterType }}
+        {{ end }}
+        {{ if .Values.global.cluster }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ .Values.global.cluster }}
+        {{ end }}

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/thanos/README.md
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/thanos/README.md
@@ -1,0 +1,66 @@
+Thanos
+------
+
+[Thanos](https://github.com/improbable-eng/thanos) ready for SAP Converged Cloud.
+
+Enabling Thanos will install the following components:
+- Thanos compactor
+- Thanos query
+- Thanos store
+- OpenstackSeed for Swift service user and container
+- Thanos sidecar for Prometheus server
+
+## Configuration
+
+Minimal configuration for Thanos@SAP Converged Cloud:
+
+```
+# How long metrics are retained. 
+# For Thanos you want something like 1y.
+retentionTime: <retention>
+
+# In memory. Persist to Swift.
+persistence:
+  enabled: false
+
+thanos:
+  enabled: true
+  
+  # Create an OpenStack user in the given scope with required permissions and initialize container in Swift.
+  swiftStorageConfig:
+    authURL:            https://<keystone>/v3
+    userName:           <userName>
+    userDomainName:     <userDomainName>
+    password:           <password>
+    domainName:         <domainName>
+    projectName:        <projectName>
+    projectDomainName:  <projectDomainName>
+    regionName:         <regionName>
+    containerName:      <swiftContainerName>
+```
+
+An existing OpenStack user and Swift container can be used by disabled the OpenStack seed:
+```
+thanos:
+  seed:
+    enabled: false
+  
+  swiftStorageConfig:
+    ...
+```
+
+**Note**: The user must have permissions to read from/write to the Swift container in the given scope.  
+
+## Troubleshooting
+
+### Creation of the OpenStack user
+
+Thanos, as configured in this chart, uses OpenStack Swift as the backend.
+Thus an OpenStack service user with sufficient access is required.
+Luckily it is created without manual intervention using a Kubernetes operator, the [Openstack Seeder](https://github.com/sapcc/kubernetes-operators/tree/master/openstack-seeder).
+Its configuration is deployed via [OpenStackSeed](thanos-seed.yaml) for the Thanos service user.  
+However, creation of the OpenStack service user for Thanos might take longer than the Thanos components need to be up & running.
+In which case they might end up in `Error` state.
+This needs manual intervention: 
+1. Ensure the OpenStack service user and container was successfully created.
+2. Delete the Pod of the Prometheus StatefulSet and of the related Thanos components.

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/templates/thanos/thanos-seed.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/templates/thanos/thanos-seed.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.thanos.enabled }}
+{{- if and .Values.thanos.enabled .Values.thanos.seed.enabled }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
 metadata:
@@ -7,10 +7,10 @@ metadata:
     prometheus: {{ include "prometheus.name" . }}
 
 spec:
+  {{ if .Values.thanos.seed.requires }}
   requires:
-    - swift/swift-seed
-    - monsoon3/domain-ccadmin-seed
-    - monsoon3/domain-default-seed
+{{ toYaml .Values.thanos.seed.requires | indent 4 }}
+  {{ end }}
 
   domains:
     - name: {{ required ".Values.thanos.swiftStorageConfig.userDomainName missing" .Values.thanos.swiftStorageConfig.userDomainName }}
@@ -18,15 +18,15 @@ spec:
         - name: {{ required ".Values.thanos.swiftStorageConfig.userName missing" .Values.thanos.swiftStorageConfig.userName }}
           description: Thanos Service User
           password: {{ required ".Values.thanos.swiftStorageConfig.password missing" .Values.thanos.swiftStorageConfig.password | quote }}
-          roles:
+          role_assignments:
             - project: service
               role:    service
 
     - name: {{ required ".Values.thanos.swiftStorageConfig.domainName missing" .Values.thanos.swiftStorageConfig.domainName }}
       projects:
         - name: {{ include "thanos.projectName" . }}
-          roles:
-            # Permission to write to ccadmin/master containers.
+          role_assignments:
+            # Read/write permission to $domain/$project containers.
             - user: {{ required ".Values.thanos.swiftStorageConfig.userName missing" .Values.thanos.swiftStorageConfig.userName }}@{{ required ".Values.thanos.swiftStorageConfig.userDomainName missing" .Values.thanos.swiftStorageConfig.userDomainName }}
               role: swiftoperator
           swift:

--- a/charts/kubernikus-monitoring/vendor/prometheus-server/values.yaml
+++ b/charts/kubernikus-monitoring/vendor/prometheus-server/values.yaml
@@ -13,10 +13,13 @@ global:
   # Defaults to region if not set.
   # cluster:
 
+  # Optional tier for Prometheus alerts.
+  # tier: k8s
+
 # The repository and tag of the Prometheus image.
 image:
   repository: prom/prometheus
-  tag: v2.9.2
+  tag: v2.12.0
 
 # Mandatory name for this Prometheus.
 # The name is used to find relevant aggregation and alerting rules.
@@ -78,6 +81,7 @@ ingress:
   # Client certificate authentication on ingress level.
   authentication:
     enabled: true
+
     # The key (<namespace>/<name>) of the secret containing the CA certificate (`ca.crt`) that is enabled to authenticate against this Ingress.
     authTLSSecret: kube-system/ingress-cacrt
 
@@ -112,15 +116,16 @@ rbac:
   create: true
 
 # ServiceAccount to use for the Prometheus server.
+# Note that a ServiceAccount with name `default` cannot be created.
+# Instead the generated name will be used.
 serviceAccount:
   create: true
 
   # Optional name of the service account.
   # If not provided one will be generated in the format: prometheus-<name>.
-  name:
+  name: ""
 
 # Thanos configuration.
-
 thanos:
   # Enable Thanos components and Prometheus sidecar.
   enabled: false
@@ -129,6 +134,19 @@ thanos:
   # If `thanos.spec.peers` is set this values is ignored
   # Defaults to `thanos-peers.{{ .Release.Namespace }}.svc:10900`
   peers: ""
+
+  # Deploy an OpenstackSeed custom resource triggering creation of an Openstack user and Swift container used to persist Prometheus metrics.
+  # See: https://github.com/sapcc/kubernetes-operators/tree/master/openstack-seeder
+  seed:
+    # If disabled the user and container need to exist.
+    enabled: true
+
+    # List of required OpenstackSeeds that need to be resolved before.
+    # Warning: This list is rather specific to SAP Converged Cloud.
+    requires:
+      - swift/swift-seed
+      - monsoon3/domain-ccadmin-seed
+      - monsoon3/domain-default-seed
 
   # Configuration for OpenStack Swift Thanos storage backend.
   swiftStorageConfig: {}
@@ -207,3 +225,16 @@ serviceDiscoveries:
 # The pod's tolerations.
 # See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration
 tolerations: []
+
+# Assign custom affinity rules to the prometheus instance.
+# See https://kubernetes.io/docs/concepts/configuration/assign-pod-node
+affinity: {}
+
+# Define which Nodes the Pods are scheduled on.
+# See https://kubernetes.io/docs/user-guide/node-selection
+nodeSelector: {}
+
+# The tier of the alerts.
+# If set .Values.global.tier takes precedence.
+alerts:
+  tier: k8s

--- a/contrib/kubernikus-tests/Dockerfile
+++ b/contrib/kubernikus-tests/Dockerfile
@@ -8,8 +8,8 @@ RUN curl -Lf https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-a
 		| tar --strip-components=1 -C /usr/local/bin -zxv \
 		&& helm version -c
 
-RUN curl -Lf https://github.com/prometheus/prometheus/releases/download/v2.4.2/prometheus-2.4.2.linux-amd64.tar.gz \
-		| tar --strip-components=1 -C /usr/local/bin -zxv prometheus-2.4.2.linux-amd64/promtool \
+RUN curl -Lf https://github.com/prometheus/prometheus/releases/download/v2.12.0/prometheus-2.12.0.linux-amd64.tar.gz \
+		| tar --strip-components=1 -C /usr/local/bin -zxv prometheus-2.12.0.linux-amd64/promtool \
 		&& promtool --version
 
 RUN curl -Lfo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 \


### PR DESCRIPTION
Update Prometheus server to v2.12.0 which allows using `$externalLabels` in alerts.

Also introduces [alerts for common Prometheus errors](https://github.com/sapcc/helm-charts/blob/master/system/prometheus-server/templates/alerts/_prometheus.alerts.tpl).
For instance when reloading of the configmap or alert-/aggregation rules failed.

Moreover, it updates the `promtool` used for testing alerts to the same version.