### PR TITLE
Add service roles reconciler

### DIFF
--- a/pkg/client/openstack/admin/client.go
+++ b/pkg/client/openstack/admin/client.go
@@ -85,6 +85,9 @@ func (c *adminClient) CreateKlusterServiceUser(username, password, domainName, p
 			Description:      "Kubernikus kluster service user",
 		}).Extract()
 	}
+	if err != nil {
+		return err
+	}
 
 	err = c.AssignUserRoles(projectID, username, domainName, c.GetDefaultServiceUserRoles())
 	if err != nil {

--- a/pkg/client/openstack/admin/client.go
+++ b/pkg/client/openstack/admin/client.go
@@ -28,8 +28,8 @@ type AdminClient interface {
 	GetKubernikusCatalogEntry() (string, error)
 	GetRegion() (string, error)
 	CreateStorageContainer(projectID, containerName, serviceUserName, serviceUserDomainName string) error
-	AssignUserRoles(string, string, string, []string) error
-	GetUserRoles(string, string, string) ([]string, error)
+	AssignUserRoles(projectID, userName, domainName string, userRoles []string) error
+	GetUserRoles(projectID, userName, domainName string) ([]string, error)
 	GetDefaultServiceUserRoles() []string
 }
 

--- a/pkg/client/openstack/admin/logging.go
+++ b/pkg/client/openstack/admin/logging.go
@@ -81,3 +81,21 @@ func (c LoggingClient) CreateStorageContainer(projectID, containerName, serviceU
 	}(time.Now())
 	return c.Client.CreateStorageContainer(projectID, containerName, serviceUserName, serviceUserDomainName)
 }
+
+func (c LoggingClient) AssignUserRoles(projectID, userID string, userRoles []string) (err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "assign user roles",
+			"project_id", projectID,
+			"user_id", userID,
+			"user_roles", userRoles,
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+	}(time.Now())
+	return c.Client.AssignUserRoles(projectID, userID, userRoles)
+}
+
+func (c LoggingClient) AssignUserRoles(projectID, userID string, userRoles []string) (err error) {
+}

--- a/pkg/client/openstack/admin/logging.go
+++ b/pkg/client/openstack/admin/logging.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -82,20 +83,38 @@ func (c LoggingClient) CreateStorageContainer(projectID, containerName, serviceU
 	return c.Client.CreateStorageContainer(projectID, containerName, serviceUserName, serviceUserDomainName)
 }
 
-func (c LoggingClient) AssignUserRoles(projectID, userID string, userRoles []string) (err error) {
+func (c LoggingClient) AssignUserRoles(projectID, userName, domainName string, userRoles []string) (err error) {
 	defer func(begin time.Time) {
 		c.Logger.Log(
 			"msg", "assign user roles",
 			"project_id", projectID,
-			"user_id", userID,
-			"user_roles", userRoles,
+			"user_id", userName,
+			"domain_name", domainName,
+			"user_roles", fmt.Sprintf("%v", userRoles),
 			"took", time.Since(begin),
 			"v", 2,
 			"err", err,
 		)
 	}(time.Now())
-	return c.Client.AssignUserRoles(projectID, userID, userRoles)
+	return c.Client.AssignUserRoles(projectID, userName, domainName, userRoles)
 }
 
-func (c LoggingClient) AssignUserRoles(projectID, userID string, userRoles []string) (err error) {
+func (c LoggingClient) GetUserRoles(projectID, userName, domainName string) (userRoles []string, err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "get user roles",
+			"project_id", projectID,
+			"user_id", userName,
+			"domain_name", domainName,
+			"roles", fmt.Sprintf("%v", userRoles),
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+	}(time.Now())
+	return c.Client.GetUserRoles(projectID, userName, domainName)
+}
+
+func (c LoggingClient) GetDefaultServiceUserRoles() (roles []string) {
+	return c.Client.GetDefaultServiceUserRoles()
 }

--- a/pkg/controller/flight/controller.go
+++ b/pkg/controller/flight/controller.go
@@ -67,7 +67,7 @@ type FlightController struct {
 func NewController(threadiness int, factories config.Factories, clients config.Clients, recorder record.EventRecorder, logger log.Logger) base.Controller {
 
 	logger = log.With(logger, "controller", "flight")
-	factory := NewFlightReconcilerFactory(factories.Openstack, factories.NodesObservatory.NodeInformer(), recorder, logger)
+	factory := NewFlightReconcilerFactory(factories.Openstack, clients.Kubernetes, factories.NodesObservatory.NodeInformer(), recorder, logger)
 
 	var controller base.Reconciler
 	controller = &FlightController{factory, logger}

--- a/pkg/controller/flight/controller.go
+++ b/pkg/controller/flight/controller.go
@@ -94,6 +94,7 @@ func (d *FlightController) Reconcile(kluster *v1.Kluster) (bool, error) {
 	reconciler.EnsureInstanceSecurityGroupAssignment()
 	reconciler.DeleteIncompletelySpawnedInstances()
 	reconciler.DeleteErroredInstances()
+	reconciler.EnsureServiceUserRoles()
 
 	return false, nil
 }

--- a/pkg/controller/flight/controller_test.go
+++ b/pkg/controller/flight/controller_test.go
@@ -43,6 +43,11 @@ func (m *MockFlightReconciler) DeleteErroredInstances() []string {
 	return args.Get(0).([]string)
 }
 
+func (m *MockFlightReconciler) EnsureServiceUserRoles() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}
+
 func TestReconcile(t *testing.T) {
 	kluster := &v1.Kluster{}
 	kluster.Status.Phase = models.KlusterPhaseRunning
@@ -52,6 +57,7 @@ func TestReconcile(t *testing.T) {
 	reconciler.On("EnsureInstanceSecurityGroupAssignment").Return([]string{})
 	reconciler.On("DeleteIncompletelySpawnedInstances").Return([]string{})
 	reconciler.On("DeleteErroredInstances").Return([]string{})
+	reconciler.On("EnsureServiceUserRoles").Return([]string{})
 
 	factory := &MockFlightReconcilerFactory{}
 	factory.On("FlightReconciler", kluster).Return(reconciler, nil)
@@ -65,4 +71,5 @@ func TestReconcile(t *testing.T) {
 	reconciler.AssertCalled(t, "EnsureInstanceSecurityGroupAssignment")
 	reconciler.AssertCalled(t, "DeleteIncompletelySpawnedInstances")
 	reconciler.AssertCalled(t, "DeleteErroredInstances")
+	reconciler.AssertCalled(t, "EnsureServiceUserRoles")
 }

--- a/pkg/controller/flight/logging.go
+++ b/pkg/controller/flight/logging.go
@@ -1,6 +1,7 @@
 package flight
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-kit/kit/log"
@@ -56,4 +57,16 @@ func (f *LoggingFlightReconciler) EnsureKubernikusRuleInSecurityGroup() bool {
 		)
 	}
 	return ensured
+}
+
+func (f *LoggingFlightReconciler) EnsureServiceUserRoles() []string {
+	createdRoles := f.Reconciler.EnsureServiceUserRoles()
+	if len(createdRoles) > 0 {
+		f.Logger.Log(
+			"msg", "created missing service user roles",
+			"roles", fmt.Sprintf("%v", createdRoles),
+			"v", 2,
+		)
+	}
+	return createdRoles
 }

--- a/pkg/controller/flight/reconciler.go
+++ b/pkg/controller/flight/reconciler.go
@@ -1,11 +1,11 @@
 package flight
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/client/openstack/admin"
@@ -22,16 +22,17 @@ type FlightReconciler interface {
 	DeleteIncompletelySpawnedInstances() []string
 	DeleteErroredInstances() []string
 	EnsureKubernikusRuleInSecurityGroup() bool
-	EnsureServiceUserRoles() error
+	EnsureServiceUserRoles() []string
 }
 
 type flightReconciler struct {
-	Kluster     *v1.Kluster
-	Instances   []Instance
-	Nodes       []*core_v1.Node
-	Client      openstack_kluster.KlusterClient
-	AdminClient admin.AdminClient
-	Logger      log.Logger
+	Kluster          *v1.Kluster
+	Instances        []Instance
+	Nodes            []*core_v1.Node
+	Client           openstack_kluster.KlusterClient
+	KubernetesClient kubernetes.Interface
+	AdminClient      admin.AdminClient
+	Logger           log.Logger
 }
 
 func (f *flightReconciler) EnsureInstanceSecurityGroupAssignment() []string {
@@ -119,23 +120,46 @@ func (f *flightReconciler) DeleteErroredInstances() []string {
 	return deletedInstanceIDs
 }
 
-func (f *flightReconciler) EnsureServiceUserRoles() {
-	secret, err := util.KlusterSecret(f.Kluster)
+func (f *flightReconciler) EnsureServiceUserRoles() []string {
+	secret, err := util.KlusterSecret(f.KubernetesClient, f.Kluster)
 	if err != nil {
-		return fmt.Errorf("Could not get kluster secret: %v", err)
+		f.Logger.Log(
+			"msg", "could not get kluster secret",
+			"err", err)
+		return []string{}
 	}
 
-	wantedUserRoles := f.AdminClient.ServiceUserRoles
+	wantedUserRoles := f.AdminClient.GetDefaultServiceUserRoles()
+	existingUserRoles, err := f.AdminClient.GetUserRoles(secret.Openstack.ProjectID, secret.Openstack.Username, secret.Openstack.DomainName)
+	if err != nil {
+		f.Logger.Log(
+			"msg", "could not get service user roles",
+			"err", err)
+		return []string{}
+	}
 
-	/*
-		userRoles := f.AdminClient.GetUserRoles(secret.Openstack.ProjectID, secret.Openstack.Username)
-		userRoles, err := roles.ExtractRoles(userRolePages)
-		if len(userRoles) != len(wantedUserRoles) {
+	rolesToCreate := []string{}
+	if len(existingUserRoles) != len(wantedUserRoles) {
+		for _, wantedUserRole := range wantedUserRoles {
+			exists := false
+			for _, existingUserRole := range existingUserRoles {
+				if existingUserRole == wantedUserRole {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				rolesToCreate = append(rolesToCreate, wantedUserRole)
+			}
 		}
-	*/
 
-	f.Logger.Log("msg", "Reconciling service user roles", "wanted user roles", wantedUserRoles)
-	return f.AdminClient.AssignUserRoles(secret.Openstack.ProjectID, secret.Openstack.Username, wantedUserRoles)
+		err = f.AdminClient.AssignUserRoles(secret.Openstack.ProjectID, secret.Openstack.Username, secret.Openstack.DomainName, wantedUserRoles)
+		if err != nil {
+			f.Logger.Log("msg", "couldn't reconcile service user roles", "err", err)
+		}
+	}
+
+	return rolesToCreate
 }
 
 func (f *flightReconciler) getErroredInstances() []Instance {

--- a/pkg/controller/flight/reconciler_test.go
+++ b/pkg/controller/flight/reconciler_test.go
@@ -117,6 +117,8 @@ func TestEnsureInstanceSecurityGroupAssignment(t *testing.T) {
 		instances,
 		nodes,
 		client,
+		nil,
+		nil,
 		log.NewNopLogger(),
 	}
 
@@ -167,6 +169,8 @@ func TestDeleteIncompletelySpawnedInstances(t *testing.T) {
 		instances,
 		nodes,
 		client,
+		nil,
+		nil,
 		log.NewNopLogger(),
 	}
 
@@ -202,6 +206,8 @@ func TestDeleteErroredInstances(t *testing.T) {
 		instances,
 		nodes,
 		client,
+		nil,
+		nil,
 		log.NewNopLogger(),
 	}
 
@@ -226,6 +232,8 @@ func TestEnsureKubernikusRuleInSecurityGroup(t *testing.T) {
 		instances,
 		nodes,
 		client,
+		nil,
+		nil,
 		log.NewNopLogger(),
 	}
 

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -186,7 +186,7 @@ func NewKubernikusOperator(options *KubernikusOperatorOptions, logger log.Logger
 		case "deorbiter":
 			o.Config.Kubernikus.Controllers["deorbiter"] = deorbit.NewController(10, o.Factories, o.Clients, recorder, logger)
 		case "flight":
-			o.Config.Kubernikus.Controllers["flight"] = flight.NewController(5, o.Factories, o.Clients, recorder, logger)
+			o.Config.Kubernikus.Controllers["flight"] = flight.NewController(10, o.Factories, o.Clients, recorder, logger)
 		case "migration":
 			o.Config.Kubernikus.Controllers["migration"] = migration.NewController(10, o.Factories, o.Clients, recorder, logger)
 		case "hammertime":

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -186,7 +186,7 @@ func NewKubernikusOperator(options *KubernikusOperatorOptions, logger log.Logger
 		case "deorbiter":
 			o.Config.Kubernikus.Controllers["deorbiter"] = deorbit.NewController(10, o.Factories, o.Clients, recorder, logger)
 		case "flight":
-			o.Config.Kubernikus.Controllers["flight"] = flight.NewController(10, o.Factories, o.Clients, recorder, logger)
+			o.Config.Kubernikus.Controllers["flight"] = flight.NewController(5, o.Factories, o.Clients, recorder, logger)
 		case "migration":
 			o.Config.Kubernikus.Controllers["migration"] = migration.NewController(10, o.Factories, o.Clients, recorder, logger)
 		case "hammertime":

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/doc.go
@@ -1,0 +1,135 @@
+/*
+Package roles provides information and interaction with the roles API
+resource for the OpenStack Identity service.
+
+Example to List Roles
+
+	listOpts := roles.ListOpts{
+		DomainID: "default",
+	}
+
+	allPages, err := roles.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
+Example to Create a Role
+
+	createOpts := roles.CreateOpts{
+		Name:             "read-only-admin",
+		DomainID:         "default",
+		Extra: map[string]interface{}{
+			"description": "this role grants read-only privilege cross tenant",
+		}
+	}
+
+	role, err := roles.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Role
+
+	roleID := "0fe36e73809d46aeae6705c39077b1b3"
+
+	updateOpts := roles.UpdateOpts{
+		Name: "read only admin",
+	}
+
+	role, err := roles.Update(identityClient, roleID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Role
+
+	roleID := "0fe36e73809d46aeae6705c39077b1b3"
+	err := roles.Delete(identityClient, roleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Role Assignments
+
+	listOpts := roles.ListAssignmentsOpts{
+		UserID:         "97061de2ed0647b28a393c36ab584f39",
+		ScopeProjectID: "9df1a02f5eb2416a9781e8b0c022d3ae",
+	}
+
+	allPages, err := roles.ListAssignments(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoleAssignments(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
+Example to List Role Assignments for a User on a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	listAssignmentsOnResourceOpts := roles.ListAssignmentsOnResourceOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}
+
+	allPages, err := roles.ListAssignmentsOnResource(identityClient, listAssignmentsOnResourceOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRoles, err := roles.ExtractRoles(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, role := range allRoles {
+		fmt.Printf("%+v\n", role)
+	}
+
+Example to Assign a Role to a User in a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.Assign(identityClient, roleID, roles.AssignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+
+Example to Unassign a Role From a User in a Project
+
+	projectID := "a99e9b4e620e4db09a2dfb6e42a01e66"
+	userID := "9df1a02f5eb2416a9781e8b0c022d3ae"
+	roleID := "9fe2ff9ee4384b1894a90878d3e92bab"
+
+	err := roles.Unassign(identityClient, roleID, roles.UnassignOpts{
+		UserID:    userID,
+		ProjectID: projectID,
+	}).ExtractErr()
+
+	if err != nil {
+		panic(err)
+	}
+*/
+package roles

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/errors.go
@@ -1,0 +1,17 @@
+package roles
+
+import "fmt"
+
+// InvalidListFilter is returned by the ToUserListQuery method when validation of
+// a filter does not pass
+type InvalidListFilter struct {
+	FilterName string
+}
+
+func (e InvalidListFilter) Error() string {
+	s := fmt.Sprintf(
+		"Invalid filter name [%s]: it must be in format of NAME__COMPARATOR",
+		e.FilterName,
+	)
+	return s
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/requests.go
@@ -1,0 +1,392 @@
+package roles
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToRoleListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	// DomainID filters the response by a domain ID.
+	DomainID string `q:"domain_id"`
+
+	// Name filters the response by role name.
+	Name string `q:"name"`
+
+	// Filters filters the response by custom filters such as
+	// 'name__contains=foo'
+	Filters map[string]string `q:"-"`
+}
+
+// ToRoleListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRoleListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+	for k, v := range opts.Filters {
+		i := strings.Index(k, "__")
+		if i > 0 && i < len(k)-2 {
+			params.Add(k, v)
+		} else {
+			return "", InvalidListFilter{FilterName: k}
+		}
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}
+
+// List enumerates the roles to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToRoleListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details on a single role, by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToRoleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a role.
+type CreateOpts struct {
+	// Name is the name of the new role.
+	Name string `json:"name" required:"true"`
+
+	// DomainID is the ID of the domain the role belongs to.
+	DomainID string `json:"domain_id,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the role.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToRoleCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToRoleCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "role")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["role"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Create creates a new Role.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRoleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToRoleUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts provides options for updating a role.
+type UpdateOpts struct {
+	// Name is the name of the new role.
+	Name string `json:"name,omitempty"`
+
+	// Extra is free-form extra key/value pairs to describe the role.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// ToRoleUpdateMap formats a UpdateOpts into an update request.
+func (opts UpdateOpts) ToRoleUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "role")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["role"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Update updates an existing Role.
+func Update(client *gophercloud.ServiceClient, roleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRoleUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(updateURL(client, roleID), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete deletes a role.
+func Delete(client *gophercloud.ServiceClient, roleID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, roleID), nil)
+	return
+}
+
+// ListAssignmentsOptsBuilder allows extensions to add additional parameters to
+// the ListAssignments request.
+type ListAssignmentsOptsBuilder interface {
+	ToRolesListAssignmentsQuery() (string, error)
+}
+
+// ListAssignmentsOpts allows you to query the ListAssignments method.
+// Specify one of or a combination of GroupId, RoleId, ScopeDomainId,
+// ScopeProjectId, and/or UserId to search for roles assigned to corresponding
+// entities.
+type ListAssignmentsOpts struct {
+	// GroupID is the group ID to query.
+	GroupID string `q:"group.id"`
+
+	// RoleID is the specific role to query assignments to.
+	RoleID string `q:"role.id"`
+
+	// ScopeDomainID filters the results by the given domain ID.
+	ScopeDomainID string `q:"scope.domain.id"`
+
+	// ScopeProjectID filters the results by the given Project ID.
+	ScopeProjectID string `q:"scope.project.id"`
+
+	// UserID filterst he results by the given User ID.
+	UserID string `q:"user.id"`
+
+	// Effective lists effective assignments at the user, project, and domain
+	// level, allowing for the effects of group membership.
+	Effective *bool `q:"effective"`
+}
+
+// ToRolesListAssignmentsQuery formats a ListAssignmentsOpts into a query string.
+func (opts ListAssignmentsOpts) ToRolesListAssignmentsQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListAssignments enumerates the roles assigned to a specified resource.
+func ListAssignments(client *gophercloud.ServiceClient, opts ListAssignmentsOptsBuilder) pagination.Pager {
+	url := listAssignmentsURL(client)
+	if opts != nil {
+		query, err := opts.ToRolesListAssignmentsQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RoleAssignmentPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// ListAssignmentsOnResourceOpts provides options to list role assignments
+// for a user/group on a project/domain
+type ListAssignmentsOnResourceOpts struct {
+	// UserID is the ID of a user to assign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to assign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to assign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to assign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// AssignOpts provides options to assign a role
+type AssignOpts struct {
+	// UserID is the ID of a user to assign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to assign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to assign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to assign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// UnassignOpts provides options to unassign a role
+type UnassignOpts struct {
+	// UserID is the ID of a user to unassign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	UserID string `xor:"GroupID"`
+
+	// GroupID is the ID of a group to unassign a role
+	// Note: exactly one of UserID or GroupID must be provided
+	GroupID string `xor:"UserID"`
+
+	// ProjectID is the ID of a project to unassign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	ProjectID string `xor:"DomainID"`
+
+	// DomainID is the ID of a domain to unassign a role on
+	// Note: exactly one of ProjectID or DomainID must be provided
+	DomainID string `xor:"ProjectID"`
+}
+
+// ListAssignmentsOnResource is the operation responsible for listing role
+// assignments for a user/group on a project/domain.
+func ListAssignmentsOnResource(client *gophercloud.ServiceClient, opts ListAssignmentsOnResourceOpts) pagination.Pager {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	url := listAssignmentsOnResourceURL(client, targetType, targetID, actorType, actorID)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Assign is the operation responsible for assigning a role
+// to a user/group on a project/domain.
+func Assign(client *gophercloud.ServiceClient, roleID string, opts AssignOpts) (r AssignmentResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	_, r.Err = client.Put(assignURL(client, targetType, targetID, actorType, actorID, roleID), nil, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Unassign is the operation responsible for unassigning a role
+// from a user/group on a project/domain.
+func Unassign(client *gophercloud.ServiceClient, roleID string, opts UnassignOpts) (r UnassignmentResult) {
+	// Check xor conditions
+	_, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	// Get corresponding URL
+	var targetID string
+	var targetType string
+	if opts.ProjectID != "" {
+		targetID = opts.ProjectID
+		targetType = "projects"
+	} else {
+		targetID = opts.DomainID
+		targetType = "domains"
+	}
+
+	var actorID string
+	var actorType string
+	if opts.UserID != "" {
+		actorID = opts.UserID
+		actorType = "users"
+	} else {
+		actorID = opts.GroupID
+		actorType = "groups"
+	}
+
+	_, r.Err = client.Delete(assignURL(client, targetType, targetID, actorType, actorID, roleID), &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/results.go
@@ -1,0 +1,214 @@
+package roles
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Role grants permissions to a user.
+type Role struct {
+	// DomainID is the domain ID the role belongs to.
+	DomainID string `json:"domain_id"`
+
+	// ID is the unique ID of the role.
+	ID string `json:"id"`
+
+	// Links contains referencing links to the role.
+	Links map[string]interface{} `json:"links"`
+
+	// Name is the role name
+	Name string `json:"name"`
+
+	// Extra is a collection of miscellaneous key/values.
+	Extra map[string]interface{} `json:"-"`
+}
+
+func (r *Role) UnmarshalJSON(b []byte) error {
+	type tmp Role
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Role(s.tmp)
+
+	// Collect other fields and bundle them into Extra
+	// but only if a field titled "extra" wasn't sent.
+	if s.Extra != nil {
+		r.Extra = s.Extra
+	} else {
+		var result interface{}
+		err := json.Unmarshal(b, &result)
+		if err != nil {
+			return err
+		}
+		if resultMap, ok := result.(map[string]interface{}); ok {
+			r.Extra = internal.RemainingKeys(Role{}, resultMap)
+		}
+	}
+
+	return err
+}
+
+type roleResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Role.
+type GetResult struct {
+	roleResult
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Role
+type CreateResult struct {
+	roleResult
+}
+
+// UpdateResult is the response from an Update operation. Call its Extract
+// method to interpret it as a Role.
+type UpdateResult struct {
+	roleResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// RolePage is a single page of Role results.
+type RolePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Roles contains any results.
+func (r RolePage) IsEmpty() (bool, error) {
+	roles, err := ExtractRoles(r)
+	return len(roles) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the links section of the result.
+func (r RolePage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+// ExtractProjects returns a slice of Roles contained in a single page of
+// results.
+func ExtractRoles(r pagination.Page) ([]Role, error) {
+	var s struct {
+		Roles []Role `json:"roles"`
+	}
+	err := (r.(RolePage)).ExtractInto(&s)
+	return s.Roles, err
+}
+
+// Extract interprets any roleResults as a Role.
+func (r roleResult) Extract() (*Role, error) {
+	var s struct {
+		Role *Role `json:"role"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Role, err
+}
+
+// RoleAssignment is the result of a role assignments query.
+type RoleAssignment struct {
+	Role  AssignedRole `json:"role,omitempty"`
+	Scope Scope        `json:"scope,omitempty"`
+	User  User         `json:"user,omitempty"`
+	Group Group        `json:"group,omitempty"`
+}
+
+// AssignedRole represents a Role in an assignment.
+type AssignedRole struct {
+	ID string `json:"id,omitempty"`
+}
+
+// Scope represents a scope in a Role assignment.
+type Scope struct {
+	Domain  Domain  `json:"domain,omitempty"`
+	Project Project `json:"project,omitempty"`
+}
+
+// Domain represents a domain in a role assignment scope.
+type Domain struct {
+	ID string `json:"id,omitempty"`
+}
+
+// Project represents a project in a role assignment scope.
+type Project struct {
+	ID string `json:"id,omitempty"`
+}
+
+// User represents a user in a role assignment scope.
+type User struct {
+	ID string `json:"id,omitempty"`
+}
+
+// Group represents a group in a role assignment scope.
+type Group struct {
+	ID string `json:"id,omitempty"`
+}
+
+// RoleAssignmentPage is a single page of RoleAssignments results.
+type RoleAssignmentPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the RoleAssignmentPage contains no results.
+func (r RoleAssignmentPage) IsEmpty() (bool, error) {
+	roleAssignments, err := ExtractRoleAssignments(r)
+	return len(roleAssignments) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to
+// the next page of results.
+func (r RoleAssignmentPage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Links.Next, err
+}
+
+// ExtractRoleAssignments extracts a slice of RoleAssignments from a Collection
+// acquired from List.
+func ExtractRoleAssignments(r pagination.Page) ([]RoleAssignment, error) {
+	var s struct {
+		RoleAssignments []RoleAssignment `json:"role_assignments"`
+	}
+	err := (r.(RoleAssignmentPage)).ExtractInto(&s)
+	return s.RoleAssignments, err
+}
+
+// AssignmentResult represents the result of an assign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type AssignmentResult struct {
+	gophercloud.ErrResult
+}
+
+// UnassignmentResult represents the result of an unassign operation.
+// Call ExtractErr method to determine if the request succeeded or failed.
+type UnassignmentResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/roles/urls.go
@@ -1,0 +1,39 @@
+package roles
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rolePath = "roles"
+)
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(rolePath)
+}
+
+func getURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(rolePath)
+}
+
+func updateURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, roleID string) string {
+	return client.ServiceURL(rolePath, roleID)
+}
+
+func listAssignmentsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("role_assignments")
+}
+
+func listAssignmentsOnResourceURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID string) string {
+	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath)
+}
+
+func assignURL(client *gophercloud.ServiceClient, targetType, targetID, actorType, actorID, roleID string) string {
+	return client.ServiceURL(targetType, targetID, actorType, actorID, rolePath, roleID)
+}


### PR DESCRIPTION
This PR adds a reconciler for service user roles. It creates Kubernikus service user roles in Openstack if they are missing for whatever reason.