### PR TITLE
Limit Hostname Length

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -390,7 +390,7 @@ definitions:
         description: name of the cluster
         type: string
         pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
-        maxLength: 20
+        maxLength: 13
       spec:
         $ref: '#/definitions/KlusterSpec'
       status:
@@ -471,7 +471,7 @@ definitions:
         x-nullable: false
         type: string
         pattern: '^[a-z0-9]([-\.a-z0-9]*)?$'
-        maxLength: 20
+        maxLength: 13
       size:
         x-nullable: false
         type: integer


### PR DESCRIPTION
Kubelet refuses to register nodes with hostnames longer than 63 characters.
```
metadata.labels: Invalid value: "devops-kubernetes-devops-kubernetes-p7jxm.openstack.eu-de-1.clou": must be no more than 63 characters
```

There is a race condition between DHCP and metadata service. DHCP offers the domain `.novalocal` while the metadata service offers something like `.openstack.eu-de-1.cloud.sap`.

If the kubelet starts before the metadata service is available, the node registers with a hostname `$klusterName-$poolName-$prefix.novalocal`. Once the metadata service becomes available it will set the hostname to `$klusterName-$poolName-$prefix.openstack.eu-de-1.cloud.sap`. Rebooting the node or restarting the kubelet will then fail the registration if `len(klusterName) + len(nodePoolName) + 2 > 26`.

This PR limits `kluster` and `nodepool` names to a length of 13.


