### PR TITLE
Remove projectID from cluster spec

### DIFF
--- a/pkg/api/models/openstack_spec.go
+++ b/pkg/api/models/openstack_spec.go
@@ -24,9 +24,6 @@ type OpenstackSpec struct {
 	// network ID
 	NetworkID string `json:"networkID,omitempty"`
 
-	// project ID
-	ProjectID string `json:"projectID,omitempty"`
-
 	// router ID
 	RouterID string `json:"routerID,omitempty"`
 

--- a/pkg/api/rest/api_test.go
+++ b/pkg/api/rest/api_test.go
@@ -289,7 +289,6 @@ func TestClusterUpdate(t *testing.T) {
 			Openstack: models.OpenstackSpec{
 				LBSubnetID: "lbid",
 				NetworkID:  "networkid",
-				ProjectID:  ACCOUNT,
 				RouterID:   "routerid",
 			},
 			NodePools: []models.NodePool{
@@ -324,7 +323,6 @@ func TestClusterUpdate(t *testing.T) {
 			Openstack: models.OpenstackSpec{
 				LBSubnetID: "changed",
 				NetworkID:  "changed",
-				ProjectID:  "changed",
 				RouterID:   "changed",
 			},
 			NodePools: []models.NodePool{
@@ -377,7 +375,6 @@ func TestClusterUpdate(t *testing.T) {
 	assert.Equal(t, "2.2.2.2/24", apiResponse.Spec.ServiceCIDR)
 	assert.Equal(t, "lbid", apiResponse.Spec.Openstack.LBSubnetID)
 	assert.Equal(t, "networkid", apiResponse.Spec.Openstack.NetworkID)
-	assert.Equal(t, ACCOUNT, apiResponse.Spec.Openstack.ProjectID)
 	assert.Equal(t, "routerid", apiResponse.Spec.Openstack.RouterID)
 	assert.Equal(t, models.KlusterPhaseRunning, apiResponse.Status.Phase)
 	assert.Equal(t, "someversion", apiResponse.Status.Version)

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -877,9 +877,6 @@ func init() {
         "networkID": {
           "type": "string"
         },
-        "projectID": {
-          "type": "string"
-        },
         "routerID": {
           "type": "string"
         },
@@ -1752,9 +1749,6 @@ func init() {
           "x-go-name": "LBSubnetID"
         },
         "networkID": {
-          "type": "string"
-        },
-        "projectID": {
           "type": "string"
         },
         "routerID": {

--- a/pkg/cmd/kubernikus/helm.go
+++ b/pkg/cmd/kubernikus/helm.go
@@ -104,9 +104,6 @@ func (o *HelmOptions) Run(c *cobra.Command) error {
 
 	kluster, err := kubernikus.NewKlusterFactory().KlusterFor(models.KlusterSpec{
 		Name: nameA[0],
-		Openstack: models.OpenstackSpec{
-			ProjectID: o.ProjectID,
-		},
 	})
 	if err != nil {
 		return err

--- a/pkg/cmd/kubernikusctl/common/kubecontext_test.go
+++ b/pkg/cmd/kubernikusctl/common/kubecontext_test.go
@@ -8,6 +8,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/util"
@@ -15,7 +17,7 @@ import (
 
 func TestKubernikusContext(t *testing.T) {
 
-	kluster := &v1.Kluster{Spec: models.KlusterSpec{AdvertiseAddress: "1.1.1.1", ServiceCIDR: "192.168.0.0/24", Openstack: models.OpenstackSpec{ProjectID: "12345678"}}}
+	kluster := &v1.Kluster{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"account": "12345678"}}, Spec: models.KlusterSpec{AdvertiseAddress: "1.1.1.1", ServiceCIDR: "192.168.0.0/24"}}
 	certs := new(v1.Certificates)
 
 	factory := util.NewCertificateFactory(kluster, certs, "test.local")

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -538,7 +538,7 @@ func (op *GroundControl) createKluster(kluster *v1.Kluster) error {
 	klusterSecret.Openstack.Username = fmt.Sprintf("kubernikus-%s", kluster.Name)
 	klusterSecret.Openstack.DomainName = "kubernikus"
 	klusterSecret.Openstack.Region = region
-	klusterSecret.Openstack.ProjectID = kluster.Spec.Openstack.ProjectID
+	klusterSecret.Openstack.ProjectID = kluster.Account()
 	//TODO: remove once the backup credentials are disentageled from the service user (e.g. backup to s3)
 	if klusterSecret.Openstack.ProjectID == "" {
 		klusterSecret.Openstack.ProjectID = kluster.Account()
@@ -687,8 +687,7 @@ func (op *GroundControl) requiresOpenstackInfo(kluster *v1.Kluster) bool {
 	if kluster.Spec.NoCloud {
 		return false
 	}
-	return kluster.Spec.Openstack.ProjectID == "" ||
-		kluster.Spec.Openstack.RouterID == "" ||
+	return kluster.Spec.Openstack.RouterID == "" ||
 		kluster.Spec.Openstack.NetworkID == "" ||
 		kluster.Spec.Openstack.LBSubnetID == "" ||
 		kluster.Spec.Openstack.LBFloatingNetworkID == ""
@@ -749,16 +748,7 @@ func (op *GroundControl) discoverOpenstackInfo(kluster *v1.Kluster) error {
 		"project", kluster.Account(),
 		"v", 5)
 
-	if kluster.Spec.Openstack.ProjectID == "" {
-		kluster.Spec.Openstack.ProjectID = kluster.Account()
-		op.Logger.Log(
-			"msg", "discovered ProjectID",
-			"id", kluster.Spec.Openstack.ProjectID,
-			"kluster", kluster.GetName(),
-			"project", kluster.Account())
-	}
-
-	client, err := op.Factories.Openstack.ProjectAdminClientFor(kluster.Spec.Openstack.ProjectID)
+	client, err := op.Factories.Openstack.ProjectAdminClientFor(kluster.Account())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/ground/bootstrap.go
+++ b/pkg/controller/ground/bootstrap.go
@@ -41,7 +41,7 @@ func SeedKluster(clients config.Clients, factories config.Factories, kluster *v1
 		return errors.Wrap(err, "seed kubernikus member")
 	}
 	if !kluster.Spec.NoCloud {
-		openstack, err := factories.Openstack.ProjectAdminClientFor(kluster.Spec.Openstack.ProjectID)
+		openstack, err := factories.Openstack.ProjectAdminClientFor(kluster.Account())
 		if err != nil {
 			return err
 		}

--- a/pkg/migration/03_etcdbr_create_storage_container.go
+++ b/pkg/migration/03_etcdbr_create_storage_container.go
@@ -32,7 +32,7 @@ func CreateEtcdBackupStorageContainer(rawKluster []byte, current *v1.Kluster, cl
 	}
 
 	err = adminClient.CreateStorageContainer(
-		current.Spec.Openstack.ProjectID,
+		current.Account(),
 		etcd_util.DefaultStorageContainer(current),
 		string(username),
 		string(domain),

--- a/pkg/migration/06_seed_storage_classes.go
+++ b/pkg/migration/06_seed_storage_classes.go
@@ -12,7 +12,7 @@ func SeedCinderStorageClasses(rawKluster []byte, current *v1.Kluster, clients co
 		return err
 	}
 
-	openstack, err := factories.Openstack.ProjectAdminClientFor(current.Spec.Openstack.ProjectID)
+	openstack, err := factories.Openstack.ProjectAdminClientFor(current.Account())
 	if err != nil {
 		return err
 	}

--- a/pkg/migration/10_ensure_lb_floating_network_id.go
+++ b/pkg/migration/10_ensure_lb_floating_network_id.go
@@ -14,7 +14,7 @@ import (
 func EnsureLBFloatingNetworkID(rawKluster []byte, current *v1.Kluster, clients config.Clients, factories config.Factories) (err error) {
 
 	if current.Spec.Openstack.LBFloatingNetworkID == "" {
-		client, err := factories.Openstack.ProjectAdminClientFor(current.Spec.Openstack.ProjectID)
+		client, err := factories.Openstack.ProjectAdminClientFor(current.Account())
 		if err != nil {
 			return err
 		}

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -287,11 +287,7 @@ func (cf *CertificateFactory) UserCert(principal *models.Principal, apiURL strin
 	for _, role := range principal.Roles {
 		organizations = append(organizations, "os:"+role)
 	}
-	projectid := cf.kluster.Spec.Openstack.ProjectID
-	//nocloud clusters don't have the projectID in the spec
-	if projectid == "" {
-		projectid = cf.kluster.Account()
-	}
+	projectid := cf.kluster.Account()
 
 	return caBundle.Sign(Config{
 		Sign:         fmt.Sprintf("%s@%s", principal.Name, principal.Domain),

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -208,7 +208,7 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 			Password:            secret.Openstack.Password,
 			DomainName:          secret.Openstack.DomainName,
 			Region:              secret.Openstack.Region,
-			ProjectID:           kluster.Spec.Openstack.ProjectID,
+			ProjectID:           kluster.Account(),
 			ProjectDomainName:   secret.ProjectDomainName,
 			LbSubnetID:          kluster.Spec.Openstack.LBSubnetID,
 			LbFloatingNetworkID: kluster.Spec.Openstack.LBFloatingNetworkID,

--- a/swagger.yml
+++ b/swagger.yml
@@ -479,8 +479,6 @@ definitions:
     type: object
     x-nullable: false
     properties:
-      projectID:
-        type: string
       routerID:
         type: string
       networkID:


### PR DESCRIPTION
The projectID should be fixed to the project the cluster was created in, we track it in the account label of the `Kluster` object.