### PR TITLE
Project domain name for Dex integration

### DIFF
--- a/charts/kube-master/templates/dex-configmap.yaml
+++ b/charts/kube-master/templates/dex-configmap.yaml
@@ -40,7 +40,7 @@ data:
       name: Converged Cloud
       config:
         host:  {{ required "openstack.authURL undefined" .Values.openstack.authURL }}
-        domain: {{ required "openstack.domainName undefined" .Values.openstack.domainName }}
+        domain: {{ required "openstack.projectDomainName undefined" .Values.openstack.projectDomainName }}
         adminUsername: $KEYSTONE_ADMIN_USERNAME
         adminPassword:  $KEYSTONE_ADMIN_PASSWORD
         adminUserDomain: $KEYSTONE_ADMIN_USER_DOMAIN

--- a/charts/kube-master/test-values.yaml
+++ b/charts/kube-master/test-values.yaml
@@ -12,6 +12,7 @@ openstack:
   routerID: xyz
   projectID: xy
   region: xy-xy-1
+  projectDomainName: xyz
 api:
   apiserverHost: xyz.com
   wormholeHost: xyz.com

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -17,6 +17,7 @@ openstack: {}
   #lbFloatingNetworkID
   #routerID:
   #region
+  #projectDomainName:
 
 # specify a different certsSecretName if you want to use
 # an exiting secret

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -124,7 +124,7 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 
 	kluster.ObjectMeta = metav1.ObjectMeta{
 		Name:        qualifiedName(name, principal.Account),
-		Labels:      map[string]string{"account": principal.Account},
+		Labels:      map[string]string{"account": principal.Account, "domain": principal.Domain},
 		Annotations: map[string]string{"creator": principal.Name},
 	}
 

--- a/pkg/apis/kubernikus/v1/kluster.go
+++ b/pkg/apis/kubernikus/v1/kluster.go
@@ -34,6 +34,10 @@ func (spec Kluster) Account() string {
 	return spec.ObjectMeta.Labels["account"]
 }
 
+func (spec Kluster) Domain() string {
+	return spec.ObjectMeta.Labels["domain"]
+}
+
 func (spec Kluster) ApiServiceIP() (net.IP, error) {
 	_, ipnet, err := net.ParseCIDR(spec.Spec.ServiceCIDR)
 	if err != nil {

--- a/pkg/apis/kubernikus/v1/secret.go
+++ b/pkg/apis/kubernikus/v1/secret.go
@@ -61,12 +61,13 @@ func (s *Secret) ToStringData() (map[string]string, error) {
 }
 
 type Openstack struct {
-	AuthURL    string `json:"openstack-auth-url"`
-	Region     string `json:"openstack-region"`
-	Username   string `json:"openstack-username,omitempty"`
-	DomainName string `json:"openstack-domain-name,omitempty"`
-	Password   string `json:"openstack-password"`
-	ProjectID  string `json:"openstack-project-id"`
+	AuthURL           string `json:"openstack-auth-url"`
+	Region            string `json:"openstack-region"`
+	Username          string `json:"openstack-username,omitempty"`
+	DomainName        string `json:"openstack-domain-name,omitempty"`
+	Password          string `json:"openstack-password"`
+	ProjectID         string `json:"openstack-project-id"`
+	ProjectDomainName string `json:"openstack-project-domain-name,omitempty"`
 }
 
 type Certificates struct {

--- a/pkg/client/openstack/admin/client.go
+++ b/pkg/client/openstack/admin/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	gc_roles "github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
@@ -31,6 +32,7 @@ type AdminClient interface {
 	AssignUserRoles(projectID, userName, domainName string, userRoles []string) error
 	GetUserRoles(projectID, userName, domainName string) ([]string, error)
 	GetDefaultServiceUserRoles() []string
+	GetDomainNameByProject(projectID string) (string, error)
 }
 
 type adminClient struct {
@@ -155,6 +157,21 @@ func (c *adminClient) GetUserRoles(projectID, userName, domainName string) ([]st
 	}
 
 	return retRoles, nil
+}
+
+func (c *adminClient) GetDomainNameByProject(projectID string) (string, error) {
+
+	project, err := projects.Get(c.IdentityClient, projectID).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	domain, err := domains.Get(c.IdentityClient, project.DomainID).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return domain.Name, nil
 }
 
 func (c *adminClient) GetDefaultServiceUserRoles() []string {

--- a/pkg/client/openstack/admin/logging.go
+++ b/pkg/client/openstack/admin/logging.go
@@ -115,6 +115,19 @@ func (c LoggingClient) GetUserRoles(projectID, userName, domainName string) (use
 	return c.Client.GetUserRoles(projectID, userName, domainName)
 }
 
+func (c LoggingClient) GetDomainNameByProject(projectID string) (domainName string, err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "get domain name by project",
+			"project_id", projectID,
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+	}(time.Now())
+	return c.Client.GetDomainNameByProject(projectID)
+}
+
 func (c LoggingClient) GetDefaultServiceUserRoles() (roles []string) {
 	return c.Client.GetDefaultServiceUserRoles()
 }

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -543,6 +543,7 @@ func (op *GroundControl) createKluster(kluster *v1.Kluster) error {
 	if klusterSecret.Openstack.ProjectID == "" {
 		klusterSecret.Openstack.ProjectID = kluster.Account()
 	}
+	klusterSecret.Openstack.ProjectDomainName = kluster.Domain()
 	if klusterSecret.Openstack.Password, err = goutils.Random(20, 32, 127, true, true); err != nil {
 		return fmt.Errorf("Failed to generated password for cluster service user: %s", err)
 	}

--- a/pkg/migration/17_dex.go
+++ b/pkg/migration/17_dex.go
@@ -35,6 +35,22 @@ func AddDexSecretAndRoleBindings(rawKluster []byte, current *v1.Kluster, clients
 		}
 	}
 
+	if apiSecret.Openstack.ProjectDomainName == "" {
+
+		domainFromLabel := current.Domain()
+
+		if domainFromLabel == "" {
+			domainFromOpenstack, err := clients.OpenstackAdmin.GetDomainNameByProject(apiSecret.ProjectID)
+			if err != nil {
+				return err
+			}
+			apiSecret.Openstack.ProjectDomainName = domainFromOpenstack
+		} else {
+			apiSecret.Openstack.ProjectDomainName = domainFromLabel
+		}
+
+	}
+
 	err = util.UpdateKlusterSecret(clients.Kubernetes, current, apiSecret)
 	if err != nil {
 		return err

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -36,6 +36,7 @@ type openstackValues struct {
 	Password            string `yaml:"password"`
 	DomainName          string `yaml:"domainName"`
 	ProjectID           string `yaml:"projectID"`
+	ProjectDomainName   string `yaml:"projectDomainName"`
 	Region              string `yaml:"region,omitempty"`
 	LbSubnetID          string `yaml:"lbSubnetID,omitempty"`
 	LbFloatingNetworkID string `yaml:"lbFloatingNetworkID,omitempty"`
@@ -155,11 +156,12 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 			},
 			StorageContainer: etcd_util.DefaultStorageContainer(kluster),
 			Openstack: openstackValues{
-				AuthURL:    secret.Openstack.AuthURL,
-				Username:   secret.Openstack.Username,
-				Password:   secret.Openstack.Password,
-				DomainName: secret.Openstack.DomainName,
-				ProjectID:  secret.Openstack.ProjectID,
+				AuthURL:           secret.Openstack.AuthURL,
+				Username:          secret.Openstack.Username,
+				Password:          secret.Openstack.Password,
+				DomainName:        secret.Openstack.DomainName,
+				ProjectID:         secret.Openstack.ProjectID,
+				ProjectDomainName: secret.Openstack.ProjectDomainName,
 			},
 		},
 		Api: apiValues{
@@ -185,6 +187,7 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 			DomainName:          secret.Openstack.DomainName,
 			Region:              secret.Openstack.Region,
 			ProjectID:           kluster.Spec.Openstack.ProjectID,
+			ProjectDomainName:   secret.ProjectDomainName,
 			LbSubnetID:          kluster.Spec.Openstack.LBSubnetID,
 			LbFloatingNetworkID: kluster.Spec.Openstack.LBFloatingNetworkID,
 			RouterID:            kluster.Spec.Openstack.RouterID,


### PR DESCRIPTION
Dex installation requires the project domain name for Keystone integration. 

`openstack.domainName` helm value does not pass the domain of the cluster project.

- Get domain when the kluster is created and save into Kubernetes resource label
- Store in kluster secret for further usage
- Send as a Helm value to `kube-master` chart
- Migration step for the previous clusters
