### PR TITLE
Enable Dex for older Kubernetes versions

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -83,30 +83,51 @@ imagesForVersion:
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.10.11'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.10.8':
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.10.8'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.10.7':
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.10.7'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.10.1':
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.10.1'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.9.11':
     hyperkube:
       repository: 'quay.io/coreos/hyperkube'
       tag: 'v1.9.11_coreos.1'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.9.0':
     hyperkube:
       repository: 'quay.io/coreos/hyperkube'
       tag: 'v1.9.0_coreos.0'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.8.14':
     hyperkube: 
       repository: 'quay.io/coreos/hyperkube'
       tag: 'v1.8.14_coreos.1'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '7abab130c718576e93f7a7cc233dfd90cb8783bb'
   '1.7.16':
     hyperkube:
       repository: 'quay.io/coreos/hyperkube'

--- a/charts/kube-master/templates/dashboard.yaml
+++ b/charts/kube-master/templates/dashboard.yaml
@@ -1,3 +1,4 @@
+{{ if (semverCompare ">= 1.11.9" .Values.version.kubernetes) }}
 {{/* vim: set filetype=gotexttmpl: */ -}}
 {{ if and .Values.dex.enabled .Values.dashboard.enabled }}
 kind: Deployment
@@ -166,4 +167,5 @@ spec:
   - hosts:
     -  {{ include "dashboard.url" . }} 
     secretName: {{ required "dashboard.ingressSecret undefined" .Values.dashboard.ingressSecret }}
+{{ end }}
 {{ end }}

--- a/charts/kube-master/templates/dashboard.yaml
+++ b/charts/kube-master/templates/dashboard.yaml
@@ -1,4 +1,3 @@
-{{ if (semverCompare ">= 1.11.9" .Values.version.kubernetes) }}
 {{/* vim: set filetype=gotexttmpl: */ -}}
 {{ if and .Values.dex.enabled .Values.dashboard.enabled }}
 kind: Deployment
@@ -167,5 +166,4 @@ spec:
   - hosts:
     -  {{ include "dashboard.url" . }} 
     secretName: {{ required "dashboard.ingressSecret undefined" .Values.dashboard.ingressSecret }}
-{{ end }}
 {{ end }}


### PR DESCRIPTION
This PR makes it possible to enable `dex:true` for the old clusters back until 1.8.14.

Dex installation (API server flags) and OIDC login (`kubernetes_admin` & `kubernetes_member` roles) to the clusters are tested with the following versions:

- 1.8.14 
- 1.9.0 
- 1.9.11 
- 1.10.1 
- 1.10.7 
- 1.10.8 
- 1.10.11

/cc @BugRoger 