### PR TITLE
fix typo

### DIFF
--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -27,7 +27,7 @@ func UpdateKlusterWithRetries(klusterClient client.KlusterInterface, klusterList
 		kluster = kluster.DeepCopy()
 		// Apply the update, then attempt to push it to the apiserver.
 		if applyErr := applyUpdate(kluster); applyErr != nil {
-			if err == KlusterNotUpdated {
+			if applyErr == KlusterNotUpdated {
 				return nil
 			}
 			return applyErr


### PR DESCRIPTION
Noticed this while reading some of your code for reference. Am I right in assuming that this should be `applyErr` instead of `err`?