### PR TITLE
Create extra values field in kluster secret

### DIFF
--- a/pkg/apis/kubernikus/v1/secret.go
+++ b/pkg/apis/kubernikus/v1/secret.go
@@ -18,7 +18,7 @@ type Secret struct {
 
 	Certificates
 
-	ExtraValues map[interface{}]interface{} `json:"extra-values,omitempty"`
+	ExtraValues string `json:"extra-values,omitempty"`
 }
 
 func NewSecret(secret *corev1.Secret) (*Secret, error) {

--- a/pkg/apis/kubernikus/v1/secret.go
+++ b/pkg/apis/kubernikus/v1/secret.go
@@ -17,6 +17,8 @@ type Secret struct {
 	DexStaticPassword string `json:"dex-static-password,omitempty"`
 
 	Certificates
+
+	ExtraValues map[interface{}]interface{} `json:"extra-values,omitempty"`
 }
 
 func NewSecret(secret *corev1.Secret) (*Secret, error) {

--- a/pkg/apis/kubernikus/v1/secret_test.go
+++ b/pkg/apis/kubernikus/v1/secret_test.go
@@ -12,6 +12,9 @@ func TestSecretMarsheling(t *testing.T) {
 	secret := Secret{
 		NodePassword:   "bla",
 		BootstrapToken: "blu",
+		ExtraValues: "joker: joker\n" +
+			"- one: two\n" +
+			"- two: three",
 	}
 
 	data, err := secret.ToData()

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -224,5 +224,18 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 		return nil, err
 	}
 
+	//Temporary unmarshal to map[string]interface{}
+	m := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(result, &m)
+	if err != nil {
+		return nil, err
+	}
+	// Merge extra values via deep merge
+	r := MergeMaps(m, secret.ExtraValues)
+	// Remarshal to byte[]
+	result, err = yaml.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
 	return result, nil
 }

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -224,15 +224,21 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 		return nil, err
 	}
 
-	//Temporary unmarshal to map[string]interface{}
+	// Unmarshal string inside ExtraValues into map
+	extraValues := make(map[interface{}]interface{})
+	err = yaml.Unmarshal([]byte(secret.ExtraValues), &extraValues)
+	if err != nil {
+		return nil, err
+	}
+	// Temporary unmarshal values as well
 	m := make(map[interface{}]interface{})
 	err = yaml.Unmarshal(result, &m)
 	if err != nil {
 		return nil, err
 	}
 	// Merge extra values via deep merge
-	r := MergeMaps(m, secret.ExtraValues)
-	// Remarshal to byte[]
+	r := MergeMaps(m, extraValues)
+	// Re-marshal to byte[]
 	result, err = yaml.Marshal(r)
 	if err != nil {
 		return nil, err

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -1,31 +1,33 @@
 package helm
 
 import (
-    v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
-    "github.com/stretchr/testify/assert"
-    "gopkg.in/yaml.v2"
-    "testing"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 )
 
 func TestKlusterToHelmValues(t *testing.T) {
-    kluster := &v1.Kluster{}
-    secret := &v1.Secret{}
-    secret.ExtraValues = make(map[interface{}]interface{})
-    secret.ExtraValues["a"] = "a"
-    secret.ExtraValues["etcd"] = map[interface{}]interface{}{"backup": "b"}
-    b, err := KlusterToHelmValues(kluster, secret, "v1.10.4", nil, "doof")
-    // There should be no error converting this
-    assert.NoError(t, err)
-    m := make(map[interface{}]interface{})
-    err = yaml.Unmarshal(b, m)
-    // There shold be no error reconverting this
-    assert.NoError(t, err)
-    // Make sure easy stuff is in
-    assert.Equal(t, m["a"], "a")
-    bck := m["etcd"]
-    // The etcd entry should stay an object
-    assert.IsType(t, map[interface{}]interface{}{}, bck)
-    mbck := bck.(map[interface{}]interface{})
-    // Make sure the object was overwritten
-    assert.Equal(t, mbck["backup"], "b")
+	kluster := &v1.Kluster{}
+	secret := &v1.Secret{}
+	secret.ExtraValues = make(map[interface{}]interface{})
+	secret.ExtraValues["a"] = "a"
+	secret.ExtraValues["etcd"] = map[interface{}]interface{}{"backup": "b"}
+	b, err := KlusterToHelmValues(kluster, secret, "v1.10.4", nil, "doof")
+	// There should be no error converting this
+	assert.NoError(t, err)
+	m := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(b, m)
+	// There shold be no error reconverting this
+	assert.NoError(t, err)
+	// Make sure easy stuff is in
+	assert.Equal(t, m["a"], "a")
+	bck := m["etcd"]
+	// The etcd entry should stay an object
+	assert.IsType(t, map[interface{}]interface{}{}, bck)
+	mbck := bck.(map[interface{}]interface{})
+	// Make sure the object was overwritten
+	assert.Equal(t, mbck["backup"], "b")
 }

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -12,15 +12,15 @@ import (
 func TestKlusterToHelmValues(t *testing.T) {
 	kluster := &v1.Kluster{}
 	secret := &v1.Secret{}
-	secret.ExtraValues = make(map[interface{}]interface{})
-	secret.ExtraValues["a"] = "a"
-	secret.ExtraValues["etcd"] = map[interface{}]interface{}{"backup": "b"}
+	secret.ExtraValues = "a: a\n" +
+		"etcd:\n" +
+		"  backup: b\n"
 	b, err := KlusterToHelmValues(kluster, secret, "v1.10.4", nil, "doof")
 	// There should be no error converting this
 	assert.NoError(t, err)
 	m := make(map[interface{}]interface{})
 	err = yaml.Unmarshal(b, m)
-	// There shold be no error reconverting this
+	// There should be no error reconverting this
 	assert.NoError(t, err)
 	// Make sure easy stuff is in
 	assert.Equal(t, m["a"], "a")

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -1,0 +1,31 @@
+package helm
+
+import (
+    v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+    "github.com/stretchr/testify/assert"
+    "gopkg.in/yaml.v2"
+    "testing"
+)
+
+func TestKlusterToHelmValues(t *testing.T) {
+    kluster := &v1.Kluster{}
+    secret := &v1.Secret{}
+    secret.ExtraValues = make(map[interface{}]interface{})
+    secret.ExtraValues["a"] = "a"
+    secret.ExtraValues["etcd"] = map[interface{}]interface{}{"backup": "b"}
+    b, err := KlusterToHelmValues(kluster, secret, "v1.10.4", nil, "doof")
+    // There should be no error converting this
+    assert.NoError(t, err)
+    m := make(map[interface{}]interface{})
+    err = yaml.Unmarshal(b, m)
+    // There shold be no error reconverting this
+    assert.NoError(t, err)
+    // Make sure easy stuff is in
+    assert.Equal(t, m["a"], "a")
+    bck := m["etcd"]
+    // The etcd entry should stay an object
+    assert.IsType(t, map[interface{}]interface{}{}, bck)
+    mbck := bck.(map[interface{}]interface{})
+    // Make sure the object was overwritten
+    assert.Equal(t, mbck["backup"], "b")
+}

--- a/pkg/util/helm/merge_map.go
+++ b/pkg/util/helm/merge_map.go
@@ -2,20 +2,20 @@ package helm
 
 // This is taken from helm functionality of merging helm values
 func MergeMaps(a, b map[interface{}]interface{}) map[interface{}]interface{} {
-    out := make(map[interface{}]interface{}, len(a))
-    for aKey, aValue := range a {
-        out[aKey] = aValue
-    }
-    for bKey, bValue := range b {
-        if bValue, ok := bValue.(map[interface{}]interface{}); ok {
-            if outValue, ok := out[bKey]; ok {
-                if outValue, ok := outValue.(map[interface{}]interface{}); ok {
-                    out[bKey] = MergeMaps(outValue, bValue)
-                    continue
-                }
-            }
-        }
-        out[bKey] = bValue
-    }
-    return out
+	out := make(map[interface{}]interface{}, len(a))
+	for aKey, aValue := range a {
+		out[aKey] = aValue
+	}
+	for bKey, bValue := range b {
+		if bValue, ok := bValue.(map[interface{}]interface{}); ok {
+			if outValue, ok := out[bKey]; ok {
+				if outValue, ok := outValue.(map[interface{}]interface{}); ok {
+					out[bKey] = MergeMaps(outValue, bValue)
+					continue
+				}
+			}
+		}
+		out[bKey] = bValue
+	}
+	return out
 }

--- a/pkg/util/helm/merge_map.go
+++ b/pkg/util/helm/merge_map.go
@@ -1,0 +1,21 @@
+package helm
+
+// This is taken from helm functionality of merging helm values
+func MergeMaps(a, b map[interface{}]interface{}) map[interface{}]interface{} {
+    out := make(map[interface{}]interface{}, len(a))
+    for aKey, aValue := range a {
+        out[aKey] = aValue
+    }
+    for bKey, bValue := range b {
+        if bValue, ok := bValue.(map[interface{}]interface{}); ok {
+            if outValue, ok := out[bKey]; ok {
+                if outValue, ok := outValue.(map[interface{}]interface{}); ok {
+                    out[bKey] = MergeMaps(outValue, bValue)
+                    continue
+                }
+            }
+        }
+        out[bKey] = bValue
+    }
+    return out
+}


### PR DESCRIPTION
We need a way to customize the helm-chart values without exposing everything into the API.

This adds a field into the kluster secret to hold a map of extra values which get deep merged into
the helm values used to render to helm.

This lets us customize resources and additional flags on the apiserver, controller-manager, scheduler etc. without exposing them via the API.
