### PR TITLE
Allow to override resource limits to null to remove them

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -113,8 +113,7 @@ spec:
                 - ETCDCTL_API=3 etcdctl get foo
             initialDelaySeconds: 5
             periodSeconds: 5
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ include "resource.requirements" .Values.resources | indent 10 }}
 {{- if .Values.backup.enabled }}
         - name: backup
           command:

--- a/charts/kube-master/templates/_helpers.tpl
+++ b/charts/kube-master/templates/_helpers.tpl
@@ -71,3 +71,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "dex.url" -}}
 {{- printf "auth-%s" ( .Values.api.apiserverHost | replace (include "master.fullname" .) (printf "%s.ingress" (include "master.fullname" .) ) ) -}}
 {{- end -}}
+
+
+{{- define "resource.requirements" -}}
+{{ if or .limits .requests -}}
+resources:
+{{- with .limits }}
+  limits:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+{{- with .requests }}
+  requests:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -215,8 +215,7 @@ spec:
               value: {{ include "etcd.fullname" . }}
             - name: ETCD_BACKUP_PORT
               value: "8080" 
-          resources:
-{{ toYaml .Values.api.resources | indent 12 }}
+{{ include "resource.requirements" .Values.api.resources | indent 10 }}
         - name: wormhole
           image: sapcc/kubernikus:{{ required ".version.kubernikus missing" .Values.version.kubernikus }}
           args:

--- a/charts/kube-master/templates/cloud-controller-manager.yaml
+++ b/charts/kube-master/templates/cloud-controller-manager.yaml
@@ -88,7 +88,6 @@ spec:
             - mountPath: /etc/kubernetes/cloudprovider
               name: cloudprovider
               readOnly: true
-          resources:
-{{ toYaml .Values.cloudControllerManager.resources | indent 12 }}
+{{ include "resource.requirements" .Values.cloudControllerManager.resources | indent 10 }}
 {{- end }}
 {{- end }}

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -144,8 +144,7 @@ spec:
               name: openstack-hacks
               readOnly: true
             {{- end }}
-          resources:
-{{ toYaml .Values.controllerManager.resources | indent 12 }}
+{{ include "resource.requirements" .Values.controllerManager.resources | indent 10 }}
 {{- if .Values.openstack }}
 ---
 apiVersion: v1

--- a/charts/kube-master/templates/scheduler.yaml
+++ b/charts/kube-master/templates/scheduler.yaml
@@ -74,5 +74,4 @@ spec:
             - mountPath: /etc/kubernetes/config
               name: config
               readOnly: true
-          resources:
-{{ toYaml .Values.scheduler.resources | indent 12 }}
+{{ include "resource.requirements" .Values.scheduler.resources | indent 10 }}


### PR DESCRIPTION
Helm is a little stupid when it comes to removing values in a nested hash.