### PR TITLE
Raise sysctl max_user settings

### DIFF
--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -346,6 +346,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/kube-flannel/net-conf.json
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.11.go
+++ b/pkg/templates/node_1.11.go
@@ -344,6 +344,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/kube-flannel/net-conf.json
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.12.go
+++ b/pkg/templates/node_1.12.go
@@ -345,6 +345,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/kube-flannel/net-conf.json
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.14.go
+++ b/pkg/templates/node_1.14.go
@@ -345,6 +345,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/kube-flannel/net-conf.json
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.7.go
+++ b/pkg/templates/node_1.7.go
@@ -287,6 +287,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/coreos/docker-1.12
       filesystem: root
       contents:

--- a/pkg/templates/node_1.8.go
+++ b/pkg/templates/node_1.8.go
@@ -289,6 +289,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.9.go
+++ b/pkg/templates/node_1.9.go
@@ -289,6 +289,13 @@ storage:
       contents:
         inline: |-
           net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
     - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
       filesystem: root
       mode: 0644


### PR DESCRIPTION
This PR raises conservative settings for `fs.inotify.max_user_watches` and `fs.inotify.max_user_instances`. Default values could lead to problems eg. when running `kubectl logs -f` and max. values are reached on that node. New values are taken from Gardener: https://github.com/gardener/gardener/blob/a21316678614cf6b46b3792c90a5abd1e80755fd/charts/seed-operatingsystemconfig/original/templates/config/_99-k8s-general.conf#L46:L47