### PR TITLE
Add 1.15.8 support

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,6 +1,23 @@
 imagesForVersion:
-  '1.15.2':
+  '1.15.8':
     supported: true
+    hyperkube:
+      repository: 'sapcc/hyperkube'
+      tag: 'v1.15.8'
+    cloudControllerManager:
+      repository: 'sapcc/openstack-cloud-controller-manager'
+      tag: 'v1.15.0-sap.2'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '8373c31b3e2d96ad3a7313227aa1bb8c59ddca39'
+    dashboardProxy:
+      repository: 'quay.io/keycloak/keycloak-gatekeeper'
+      tag: '6.0.1'
+    dashboard:
+      repository: 'kubernetesui/dashboard'
+      tag: 'v2.0.0-beta4'
+  '1.15.2':
+    supported: false
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.15.2'


### PR DESCRIPTION
This PR adds support for k8s v1.15.8. It fixes regression where the kubelet would fail to update the ready status of pods.