### PR TITLE
Disable broken hyperkube 1.15.8

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,6 +1,6 @@
 imagesForVersion:
   '1.15.8':
-    supported: true
+    supported: false
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.15.8'
@@ -17,7 +17,7 @@ imagesForVersion:
       repository: 'kubernetesui/dashboard'
       tag: 'v2.0.0-beta4'
   '1.15.2':
-    supported: false
+    supported: true
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.15.2'


### PR DESCRIPTION
This PR disables broken 1.15.8 release. Hyperkube docker image is messed up.