### PR TITLE
Add 1.15.9 to images.yaml

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,4 +1,21 @@
 imagesForVersion:
+    '1.15.9':
+    supported: true
+    hyperkube:
+      repository: 'sapcc/hyperkube'
+      tag: 'v1.15.9'
+    cloudControllerManager:
+      repository: 'sapcc/openstack-cloud-controller-manager'
+      tag: 'v1.15.0-sap.2'
+    dex:
+      repository: 'hub.global.cloud.sap/monsoon/dex'
+      tag: '8373c31b3e2d96ad3a7313227aa1bb8c59ddca39'
+    dashboardProxy:
+      repository: 'quay.io/keycloak/keycloak-gatekeeper'
+      tag: '6.0.1'
+    dashboard:
+      repository: 'kubernetesui/dashboard'
+      tag: 'v2.0.0-beta4'
   '1.15.8':
     supported: false
     hyperkube:
@@ -17,7 +34,7 @@ imagesForVersion:
       repository: 'kubernetesui/dashboard'
       tag: 'v2.0.0-beta4'
   '1.15.2':
-    supported: true
+    supported: false
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.15.2'


### PR DESCRIPTION
```
> docker run --rm sapcc/hyperkube:v1.15.9 /hyperkube kubelet --version
Unable to find image 'sapcc/hyperkube:v1.15.9' locally
v1.15.9: Pulling from sapcc/hyperkube
Digest: sha256:72987a5509186f61a834f0c54f2dca9d24087d399bc8a92d732456ed329d3392
Status: Downloaded newer image for sapcc/hyperkube:v1.15.9
Kubernetes v1.15.9
```