### PR TITLE
Add CSIInlineVolume support

### DIFF
--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -163,7 +163,7 @@ spec:
             - --enable-admission-plugins=PersistentVolumeLabel
 {{- end }}
 {{- if (semverCompare ">= 1.14" .Values.version.kubernetes) }}
-            - --feature-gates=NodeLease=false
+            - --feature-gates=NodeLease=false,CSIInlineVolume=true
 {{- end }}
             #Cert Spratz
             - --client-ca-file=/etc/kubernetes/certs/apiserver-clients-and-nodes-ca.pem

--- a/pkg/templates/node_1.14.go
+++ b/pkg/templates/node_1.14.go
@@ -456,6 +456,7 @@ storage:
           rotateCertificates: true
           featureGates:
             NodeLease: false
+            CSIInlineVolume: true
     - path: /etc/kubernetes/kube-proxy/config
       filesystem: root
       mode: 0644


### PR DESCRIPTION
This PR enables CSI inline volume support in apiserver and kubelet for Kubernetes >=v1.15. See https://kubernetes.io/blog/2020/01/21/csi-ephemeral-inline-volumes/ for more details.