### PR TITLE
email suffix for technical users

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.0.3
+version: 2.0.4

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -181,7 +181,7 @@ spec:
             - --oidc-client-id=kubernetes
             - --oidc-groups-claim=groups
             - --oidc-username-prefix=-
-            - --oidc-username-claim=sub
+            - --oidc-username-claim=name
             {{ end }}
           volumeMounts:
             - mountPath: /etc/kubernetes/certs

--- a/charts/kube-master/templates/dex-configmap.yaml
+++ b/charts/kube-master/templates/dex-configmap.yaml
@@ -67,7 +67,9 @@ data:
             username: cn
             idAttr: distinguishedName
             emailAttr: mail
-            nameAttr: displayName
+            nameAttr: cn
+            # workaround for technical users without email address in LDAP:
+            emailSuffix: cloud.sap 
 
           # Group search queries for groups given a user entry.
           groupSearch:


### PR DESCRIPTION
Background:
Technical users have no email addresses and they cannot login to dex due to the missing attributes: https://github.com/sapcc/dex/blob/master/connector/ldap/ldap.go#L344

With this PR, three changes are done:
- email suffix (`cloud.sap`) is added as a workaround, so that email addresses will be structured with `username@cloud.sap` for every users including technical users: https://github.com/sapcc/dex/blob/master/connector/ldap/ldap.go#L345
- `nameAttr` is switched to `cn`  (such as I/D/Technical User)
- `oidc-username-claim` flag switched to `name` (such as I/D/Technical User) so that they can be referenced in RBAC.

Follow-up tasks:
- Extend groupSearch in `cc/kube-secrets` to allow logging in users who are also not in `CP_CONV_K8S_USERS`.
- Allow adding additional users in `cc-rbac` chart inside values: https://github.com/sapcc/helm-charts/tree/master/system/cc-rbac
