### PR TITLE
Add flatcar support

### DIFF
--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -668,7 +668,7 @@ func init() {
         },
         "image": {
           "type": "string",
-          "default": "coreos-stable-amd64",
+          "default": "flatcar-stable-amd64",
           "x-nullable": false
         },
         "labels": {
@@ -1628,7 +1628,7 @@ func init() {
         },
         "image": {
           "type": "string",
-          "default": "coreos-stable-amd64",
+          "default": "flatcar-stable-amd64",
           "x-nullable": false
         },
         "labels": {

--- a/pkg/controller/servicing/controller_test.go
+++ b/pkg/controller/servicing/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
 	"github.com/sapcc/kubernikus/pkg/controller/servicing/coreos"
+	"github.com/sapcc/kubernikus/pkg/controller/servicing/flatcar"
 	kubernikusfake "github.com/sapcc/kubernikus/pkg/generated/clientset/fake"
 )
 
@@ -305,6 +306,8 @@ func TestServicingControllerReconcile(t *testing.T) {
 				NodeObservatory: nodeobservatory.NewFakeController(kluster, nodes...),
 				CoreOSVersion:   coreos.NewFakeVersion(t, "2023.4.0"),
 				CoreOSRelease:   coreos.NewFakeRelease(t, "2023.4.0"),
+				FlatcarVersion:  flatcar.NewFakeVersion(t, "2303.4.0"),
+				FlatcarRelease:  flatcar.NewFakeRelease(t, "2303.4.0"),
 			}
 
 			reconcilers := &KlusterReconcilerFactory{

--- a/pkg/controller/servicing/flatcar/releases.go
+++ b/pkg/controller/servicing/flatcar/releases.go
@@ -1,0 +1,91 @@
+package flatcar
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sapcc/kubernikus/pkg/util/version"
+)
+
+var (
+	versionURL   = "https://%s.release.flatcar-linux.net/amd64-usr/%s/version.txt"
+	timeREString = `%s\s*FLATCAR_BUILD_ID="(.+)"`
+	holdoff      = 7 * 24 * time.Hour
+)
+
+type Release struct {
+	Client       *http.Client
+	ReleaseDates map[channel]*releaseDate
+}
+
+type releaseDate struct {
+	Releases map[string]time.Time
+}
+
+func (r *Release) releasedAt(c channel, v *version.Version) (time.Time, error) {
+	if r.Client == nil {
+		r.Client = &http.Client{
+			Timeout: time.Second * 10,
+		}
+	}
+
+	if r.ReleaseDates == nil {
+		r.ReleaseDates = make(map[channel]*releaseDate)
+	}
+
+	if _, ok := r.ReleaseDates[c]; !ok {
+		r.ReleaseDates[c] = &releaseDate{
+			Releases: map[string]time.Time{},
+		}
+	}
+
+	_, ok := r.ReleaseDates[c].Releases[v.String()]
+	if !ok {
+		result, err := r.fetch(c, v)
+		if err != nil {
+			return now(), errors.Wrapf(err, "Couldn't fetch release %s/%s", c, v.String())
+		}
+		r.ReleaseDates[c].Releases[v.String()] = result
+	}
+
+	return r.ReleaseDates[c].Releases[v.String()], nil
+}
+
+func (r *Release) fetch(c channel, v *version.Version) (time.Time, error) {
+	result, err := r.Client.Get(fmt.Sprintf(versionURL, c, v.String()))
+	if err != nil {
+		return now(), fmt.Errorf("Couldn't fetch flatcar version.txt: %s", err)
+	}
+
+	defer result.Body.Close()
+
+	body, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return now(), fmt.Errorf("Couldn't read flatcar version.txt: %s", err)
+	}
+
+	timeRE := regexp.MustCompile(fmt.Sprintf(timeREString, v.String()))
+	ts := timeRE.FindSubmatch(body)
+	if len(ts) < 2 {
+		return now(), fmt.Errorf("Couldn't parse flatcar timestamp %v", ts)
+	}
+
+	t, err := time.Parse("2006-01-02", string(ts[1])[0:10])
+	if err != nil {
+		return now(), fmt.Errorf("Couldn't extract flatcar timestamp: %v", t)
+	}
+
+	return t, nil
+}
+
+func (r *Release) GrownUp(v *version.Version) (bool, error) {
+	released, err := r.releasedAt(stable, v)
+	if err != nil {
+		return false, err
+	}
+	return released.Add(holdoff).Before(now()), nil
+}

--- a/pkg/controller/servicing/flatcar/releases.go
+++ b/pkg/controller/servicing/flatcar/releases.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/sapcc/kubernikus/pkg/util/version"
 )
 

--- a/pkg/controller/servicing/flatcar/releases_test.go
+++ b/pkg/controller/servicing/flatcar/releases_test.go
@@ -1,0 +1,58 @@
+package flatcar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sapcc/kubernikus/pkg/util/version"
+)
+
+func TestReleaseGrownup(t *testing.T) {
+	now = func() time.Time { return time.Date(2020, 2, 9, 10, 11, 0, 0, time.UTC) }
+	count := 0
+
+	subject := &Release{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2303.4.0/version.txt", ReleasesStable, &count)
+	t.Run("fetches versions", func(t *testing.T) {
+		_, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"))
+		assert.NoError(t, err)
+	})
+
+	subject = &Release{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2079.99.0/version.txt", ReleasesStable, &count)
+	t.Run("unknown version", func(t *testing.T) {
+		result, err := subject.GrownUp(version.MustParseSemantic("2079.99.0"))
+		assert.Error(t, err)
+		assert.False(t, result)
+	})
+
+	subject = &Release{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2303.4.0/version.txt", ReleasesStable, &count)
+	t.Run("holdoff time not up yet", func(t *testing.T) {
+		result, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"))
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	subject = &Release{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2303.4.0/version.txt", ReleasesStable, &count)
+	t.Run("holdoff time up", func(t *testing.T) {
+		now = func() time.Time { return time.Date(2020, 2, 15, 10, 11, 0, 0, time.UTC) }
+		result, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"))
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+}
+
+const (
+	ReleasesStable = `
+		FLATCAR_BUILD=2303
+		FLATCAR_BRANCH=4
+		FLATCAR_PATCH=0
+		FLATCAR_VERSION=2303.4.0
+		FLATCAR_VERSION_ID=2303.4.0
+		FLATCAR_BUILD_ID="2020-02-08-0830"
+		FLATCAR_SDK_VERSION=2303.3.0`
+)

--- a/pkg/controller/servicing/flatcar/testing.go
+++ b/pkg/controller/servicing/flatcar/testing.go
@@ -1,0 +1,56 @@
+package flatcar
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func NewFakeVersion(t *testing.T, version string) *Version {
+	body := fmt.Sprintf("FLATCAR_VERSION=%s", version)
+	subject := &Version{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt", body, nil)
+	return subject
+}
+
+func NewFakeRelease(t *testing.T, version string) *Release {
+	body := fmt.Sprintf(`
+		FLATCAR_BUILD=xxxx
+		FLATCAR_BRANCH=x
+		FLATCAR_PATCH=x
+		FLATCAR_VERSION=%s
+		FLATCAR_VERSION_ID=%s
+		FLATCAR_BUILD_ID="2020-02-08-0830"
+		FLATCAR_SDK_VERSION=%s`, version, version, version)
+	subject := &Release{}
+	subject.Client = NewTestClient(t, fmt.Sprintf("https://stable.release.flatcar-linux.net/amd64-usr/%s/version.txt", version), body, nil)
+	return subject
+}
+
+func NewTestClient(t *testing.T, baseURL, body string, count *int) *http.Client {
+	fn := func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), baseURL)
+		if count != nil {
+			*count = *count + 1
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Header:     make(http.Header),
+		}
+	}
+
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}

--- a/pkg/controller/servicing/flatcar/version.go
+++ b/pkg/controller/servicing/flatcar/version.go
@@ -1,0 +1,136 @@
+package flatcar
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/sapcc/kubernikus/pkg/util/version"
+)
+
+const (
+	stable channel = "stable"
+	beta   channel = "beta"
+	alpha  channel = "alpha"
+)
+
+var (
+	now = time.Now
+
+	flatcarVersionBaseURL       = "https://%s.release.flatcar-linux.net/amd64-usr/current/version.txt"
+	flatcarVersionRE            = regexp.MustCompile(`FLATCAR_VERSION=(.+)`)
+	flatcarVersionIdentifierRE  = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
+	flatcarVersionFetchInterval = 1 * time.Hour
+)
+
+type channel string
+
+// Version is a helper that fetches and caches flatcar versions
+type Version struct {
+	Client    *http.Client
+	versions  map[channel]*version.Version
+	fetchedAt map[channel]time.Time
+}
+
+// Stable returns version of flatcar stable channel
+func (d *Version) Stable() (*version.Version, error) {
+	return d.latest(stable)
+}
+
+// Beta returns version of flatcar beta channel
+func (d *Version) Beta() (*version.Version, error) {
+	return d.latest(beta)
+}
+
+// Alpha returns version of flatcar alpha channel
+func (d *Version) Alpha() (*version.Version, error) {
+	return d.latest(alpha)
+}
+
+// IsNodeUptodate checkes whether a Kubernetes Node is a flatcar that needs updating
+func (d *Version) IsNodeUptodate(node *v1.Node) (bool, error) {
+	var availableVersion, nodeVersion *version.Version
+	var err error
+
+	availableVersion, err = d.Stable()
+	if err != nil {
+		return false, errors.Wrap(err, "flatcar version couldn't be retrieved.")
+	}
+
+	nodeVersion, err = ExractVersion(node)
+	if err != nil {
+		return false, err
+	}
+
+	return nodeVersion.AtLeast(availableVersion), nil
+}
+
+// ExractVersion returns a semantic version of the node
+func ExractVersion(node *v1.Node) (*version.Version, error) {
+	match := flatcarVersionIdentifierRE.FindSubmatch([]byte(node.Status.NodeInfo.OSImage))
+	if len(match) < 2 {
+		return nil, fmt.Errorf("Couldn't match flatcar version from NodeInfo.OSImage: %s", node.Status.NodeInfo.OSImage)
+	}
+
+	nodeVersion, err := version.ParseSemantic(string(match[1]))
+	if err != nil {
+		return nil, errors.Wrapf(err, "Node version can't be parsed from %s", match[1])
+	}
+
+	return nodeVersion, nil
+}
+
+func (d *Version) latest(c channel) (*version.Version, error) {
+	var err error
+
+	if d.Client == nil {
+		d.Client = &http.Client{
+			Timeout: time.Second * 10,
+		}
+	}
+
+	if d.versions == nil {
+		d.versions = make(map[channel]*version.Version)
+	}
+
+	if d.fetchedAt == nil {
+		d.fetchedAt = make(map[channel]time.Time)
+	}
+
+	if d.versions[c] == nil || now().After(d.fetchedAt[c].Add(flatcarVersionFetchInterval)) {
+		d.versions[c], err = d.fetch(c)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Couldn't fetch latest %s version", c)
+		}
+	}
+
+	return d.versions[c], nil
+}
+
+func (d *Version) fetch(c channel) (*version.Version, error) {
+	r, err := d.Client.Get(fmt.Sprintf(flatcarVersionBaseURL, c))
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't fetch flatcar version: %s", err)
+	}
+
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't read flatcar version: %s", err)
+	}
+
+	v := flatcarVersionRE.FindSubmatch(body)
+	if len(v) < 2 {
+		return nil, fmt.Errorf("Couldn't parse flatcar version: %s", err)
+	}
+
+	d.fetchedAt[c] = now()
+
+	return version.ParseSemantic(string(v[1]))
+}

--- a/pkg/controller/servicing/flatcar/version_test.go
+++ b/pkg/controller/servicing/flatcar/version_test.go
@@ -1,0 +1,168 @@
+package flatcar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+const (
+	Stable2303_3_1 = `
+		FLATCAR_BUILD=2303
+		FLATCAR_BRANCH=3
+		FLATCAR_PATCH=1
+		FLATCAR_VERSION=2303.3.1
+		FLATCAR_VERSION_ID=2303.3.1
+		FLATCAR_BUILD_ID="2019-12-17-1953"
+		FLATCAR_SDK_VERSION=2303.3.0`
+
+	Stable2303_4_0 = `
+		FLATCAR_BUILD=2303
+		FLATCAR_BRANCH=4
+		FLATCAR_PATCH=0
+		FLATCAR_VERSION=2303.4.0
+		FLATCAR_VERSION_ID=2303.4.0
+		FLATCAR_BUILD_ID="2020-02-08-0830"
+		FLATCAR_SDK_VERSION=2303.4.0`
+
+	Beta2345_2_0 = `
+		FLATCAR_BUILD=2345
+		FLATCAR_BRANCH=2
+		FLATCAR_PATCH=0
+		FLATCAR_VERSION=2345.2.0
+		FLATCAR_VERSION_ID=2345.2.0
+		FLATCAR_BUILD_ID="2020-02-08-0832"
+		FLATCAR_SDK_VERSION=2345.2.0`
+
+	Alpha2387_0_0 = ` 
+		FLATCAR_BUILD=2387
+		FLATCAR_BRANCH=0
+		FLATCAR_PATCH=0
+		FLATCAR_VERSION=2387.0.0
+		FLATCAR_VERSION_ID=2387.0.0
+		FLATCAR_BUILD_ID="2020-01-21-0017"
+		FLATCAR_SDK_VERSION=2387.0.0`
+
+	UnexpectedResponse = `404 CoreOS is now EOL`
+)
+
+func TestVersionStable(t *testing.T) {
+	now = func() time.Time { return time.Date(2019, 2, 3, 4, 0, 0, 0, time.UTC) }
+	count := 0
+	subject := &Version{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt", Stable2303_3_1, &count)
+
+	t.Run("fetches correct version", func(t *testing.T) {
+		version, err := subject.Stable()
+		assert.NoError(t, err)
+		assert.NotNil(t, version)
+		assert.Equal(t, "2303.3.1", version.String())
+	})
+
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt", Stable2303_4_0, &count)
+
+	t.Run("caches result", func(t *testing.T) {
+		version, err := subject.Stable()
+		assert.NoError(t, err)
+		assert.NotNil(t, version)
+		assert.Equal(t, "2303.3.1", version.String())
+		assert.Equal(t, 1, count)
+	})
+
+	now = func() time.Time {
+		return time.Date(2019, 2, 3, 4, 0, 0, 0, time.UTC).Add(flatcarVersionFetchInterval).Add(1 * time.Minute)
+	}
+
+	t.Run("invalidates cached result", func(t *testing.T) {
+		version, err := subject.Stable()
+		assert.NoError(t, err)
+		assert.NotNil(t, version)
+		assert.Equal(t, "2303.4.0", version.String())
+		assert.Equal(t, 2, count)
+	})
+
+	subject = &Version{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt", UnexpectedResponse, &count)
+
+	t.Run("garble from flatcar servers", func(t *testing.T) {
+		version, err := subject.Stable()
+		assert.Error(t, err)
+		assert.Nil(t, version)
+	})
+}
+
+func TestVersionBeta(t *testing.T) {
+	now = func() time.Time { return time.Date(2019, 2, 3, 4, 0, 0, 0, time.UTC) }
+	subject := &Version{}
+	subject.Client = NewTestClient(t, "https://beta.release.flatcar-linux.net/amd64-usr/current/version.txt", Beta2345_2_0, nil)
+
+	t.Run("fetches correct version", func(t *testing.T) {
+		version, err := subject.Beta()
+		assert.NoError(t, err)
+		assert.NotNil(t, version)
+		assert.Equal(t, "2345.2.0", version.String())
+	})
+}
+
+func TestVersionAlpha(t *testing.T) {
+	now = func() time.Time { return time.Date(2019, 2, 3, 4, 0, 0, 0, time.UTC) }
+	subject := &Version{}
+	subject.Client = NewTestClient(t, "https://alpha.release.flatcar-linux.net/amd64-usr/current/version.txt", Alpha2387_0_0, nil)
+
+	t.Run("fetches correct version", func(t *testing.T) {
+		version, err := subject.Alpha()
+		assert.NoError(t, err)
+		assert.NotNil(t, version)
+		assert.Equal(t, "2387.0.0", version.String())
+	})
+}
+
+func TestVersionIsNodeUptodate(t *testing.T) {
+	subject := &Version{}
+	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt", Stable2303_3_1, nil)
+
+	t.Run("outdated node", func(t *testing.T) {
+		node := &core_v1.Node{
+			Status: core_v1.NodeStatus{
+				NodeInfo: core_v1.NodeSystemInfo{
+					OSImage: "Flatcar Container Linux by Kinvolk 2000.0.0 (Rhyolite)",
+				},
+			},
+		}
+
+		result, err := subject.IsNodeUptodate(node)
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("recent node", func(t *testing.T) {
+		node := &core_v1.Node{
+			Status: core_v1.NodeStatus{
+				NodeInfo: core_v1.NodeSystemInfo{
+					OSImage: "Flatcar Container Linux by Kinvolk 2303.3.1 (Rhyolite)",
+				},
+			},
+		}
+
+		result, err := subject.IsNodeUptodate(node)
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("unknown OS", func(t *testing.T) {
+		node := &core_v1.Node{
+			Status: core_v1.NodeStatus{
+				NodeInfo: core_v1.NodeSystemInfo{
+					OSImage: "SLES11SP3",
+				},
+			},
+		}
+
+		result, err := subject.IsNodeUptodate(node)
+		assert.Error(t, err)
+		assert.False(t, result)
+	})
+
+}

--- a/pkg/controller/servicing/lister_test.go
+++ b/pkg/controller/servicing/lister_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
 	"github.com/sapcc/kubernikus/pkg/controller/servicing/coreos"
+	"github.com/sapcc/kubernikus/pkg/controller/servicing/flatcar"
 )
 
 type MockNodeListerFactory struct {
@@ -28,11 +29,13 @@ func NewFakeNodeLister(t *testing.T, logger log.Logger, kluster *v1.Kluster, nod
 
 	var lister Lister
 	lister = &NodeLister{
-		Logger:        logger,
-		Kluster:       kluster,
-		Lister:        kl,
-		CoreOSVersion: coreos.NewFakeVersion(t, "2023.4.0"),
-		CoreOSRelease: coreos.NewFakeRelease(t, "2023.4.0"),
+		Logger:         logger,
+		Kluster:        kluster,
+		Lister:         kl,
+		CoreOSVersion:  coreos.NewFakeVersion(t, "2023.4.0"),
+		CoreOSRelease:  coreos.NewFakeRelease(t, "2023.4.0"),
+		FlatcarVersion: flatcar.NewFakeVersion(t, "2303.4.0"),
+		FlatcarRelease: flatcar.NewFakeRelease(t, "2303.4.0"),
 	}
 
 	lister = &LoggingLister{

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -12,7 +12,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/util/netutil"
+)
+
+const (
+	NODE_COREOS_PREFIX     = "Container Linux by CoreOS"
+	NODE_FLATCAR_PREFIX    = "Flatcar Container Linux"
+	NODEPOOL_COREOS_IMAGE  = "coreos-stable-amd64"
+	NODEPOOL_FLATCAR_IMAGE = "flatcar-stable-amd64"
 )
 
 //Taken from https://github.com/kubernetes/kubernetes/blob/886e04f1fffbb04faf8a9f9ee141143b2684ae68/pkg/api/v1/node/util.go
@@ -123,4 +131,20 @@ func RemoveNodeAnnotation(nodeName, key string, client kubernetes.Interface) err
 	}
 	_, err = client.CoreV1().Nodes().Patch(nodeName, types.MergePatchType, data)
 	return err
+}
+
+func IsCoreOSNode(node *v1.Node) bool {
+	return strings.HasPrefix(node.Status.NodeInfo.OSImage, NODE_COREOS_PREFIX)
+}
+
+func IsFlatcarNode(node *v1.Node) bool {
+	return strings.HasPrefix(node.Status.NodeInfo.OSImage, NODE_FLATCAR_PREFIX)
+}
+
+func IsCoreOSNodePool(pool *models.NodePool) bool {
+	return pool.Image == NODEPOOL_COREOS_IMAGE
+}
+
+func IsFlatcarNodePool(pool *models.NodePool) bool {
+	return pool.Image == NODEPOOL_FLATCAR_IMAGE
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -515,7 +515,7 @@ definitions:
       image:
         x-nullable: false
         type: string
-        default: coreos-stable-amd64
+        default: flatcar-stable-amd64
       availabilityZone:
         type: string
         x-nullable: false

--- a/swagger.yml
+++ b/swagger.yml
@@ -515,7 +515,7 @@ definitions:
       image:
         x-nullable: false
         type: string
-        default: flatcar-stable-amd64
+        default: coreos-stable-amd64
       availabilityZone:
         type: string
         x-nullable: false

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -117,7 +117,7 @@ func (k NodeTests) LatestStableContainerLinux(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	resp, err := http.Get("https://stable.release.core-os.net/amd64-usr/current/version.txt")
+	resp, err := http.Get("https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -131,14 +131,14 @@ func (k NodeTests) LatestStableContainerLinux(t *testing.T) {
 	for scanner.Scan() {
 		keyval := strings.Split(scanner.Text(), "=")
 
-		if len(keyval) == 2 && keyval[0] == "COREOS_VERSION" {
+		if len(keyval) == 2 && keyval[0] == "FLATCAR_VERSION" {
 			version = keyval[1]
 			if !assert.NotEmpty(t, version, "Failed to detect latest stable Container Linux version") {
 				return
 			}
 		}
 
-		if len(keyval) == 2 && keyval[0] == "COREOS_BUILD_ID" {
+		if len(keyval) == 2 && keyval[0] == "FLATCAR_BUILD_ID" {
 			date, err = time.Parse("2006-01-02", keyval[1][1:11])
 			if !assert.NoError(t, err) {
 				return

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -46,7 +46,6 @@ func (s *SetupTests) CreateCluster(t *testing.T) {
 				{
 					Name:             "small",
 					Flavor:           "m1.small",
-					Image:            "coreos-stable-amd64",
 					Size:             SmokeTestNodeCount,
 					AvailabilityZone: os.Getenv("NODEPOOL_AVZ"),
 				},


### PR DESCRIPTION
This PR adds Flatcar Linux support:
- reboot outdated nodes
- replace nodes if image has changed in nodepool
- ~~use Flatcar image by default~~
- fixes e2e test