### PR TITLE
Make sure all new clusters have ValidateProxyRedirects enabled

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,5 +1,6 @@
 imagesForVersion:
   '1.15.9':
+    default: true
     supported: true
     hyperkube:
       repository: 'sapcc/hyperkube'
@@ -82,8 +83,6 @@ imagesForVersion:
       repository: 'kubernetesui/dashboard'
       tag: 'v2.0.0-beta1'
   '1.11.9':
-    default: true
-    supported: true
     hyperkube:
       repository: 'sapcc/hyperkube'
       tag: 'v1.11.9'

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -181,6 +181,9 @@ spec:
 {{- end }}
 {{- if (semverCompare ">= 1.14" .Values.version.kubernetes) }}
             - --feature-gates=NodeLease=false
+{{- else if (semverCompare ">= 1.12" .Values.version.kubernetes)}}
+            # https://github.com/kubernetes/kubernetes/issues/85867
+            - --feature-gates=ValidateProxyRedirects=true
 {{- end }}
             #Cert Spratz
             - --client-ca-file=/etc/kubernetes/certs/apiserver-clients-and-nodes-ca.pem

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -40,6 +40,13 @@ func (d *createCluster) Handle(params operations.CreateClusterParams, principal 
 		return NewErrorResponse(&operations.CreateClusterDefault{}, int(err.Code()), err.Error())
 	}
 
+	if params.Body.Spec.Version != "" {
+		selectedVersion, found := d.Images.Versions[params.Body.Spec.Version]
+		if !found || !selectedVersion.Supported {
+			return NewErrorResponse(&operations.CreateClusterDefault{}, 400, "Specified cluster version %s not supported", params.Body.Spec.Version)
+		}
+	}
+
 	var metadata *models.OpenstackMetadata
 	var defaultAVZ string
 	if len(spec.NodePools) > 0 {


### PR DESCRIPTION
This requires a minimum cluster version of 1.12.
The apiserver refuses to create clusters with versions that are not "supported".

In this PR we also bump the default version to 1.15.9