### PR TITLE
Use flatcar by default

### DIFF
--- a/pkg/api/handlers/update_cluster.go
+++ b/pkg/api/handlers/update_cluster.go
@@ -126,7 +126,7 @@ func (d *updateCluster) Handle(params operations.UpdateClusterParams, principal 
 		if params.Body.Spec.Version != "" && params.Body.Spec.Version != kluster.Status.ApiserverVersion {
 			newVersion, err := semver.NewVersion(params.Body.Spec.Version)
 			if err != nil {
-				return apierrors.NewBadRequest(fmt.Sprintf("Invalid version (%s) specified for kluser: %s", params.Body.Spec.Version, err))
+				return apierrors.NewBadRequest(fmt.Sprintf("Invalid version (%s) specified for kluster: %s", params.Body.Spec.Version, err))
 			}
 			currentVersion, err := semver.NewVersion(kluster.Status.ApiserverVersion)
 			if err != nil {
@@ -140,6 +140,12 @@ func (d *updateCluster) Handle(params operations.UpdateClusterParams, principal 
 			}
 			kluster.Spec.Version = params.Body.Spec.Version
 
+			// Update existing nodepools to use flatcar image
+			for i, specPool := range kluster.Spec.NodePools {
+				if specPool.Image == "coreos-stable-amd64" {
+					kluster.Spec.NodePools[i].Image = DEFAULT_IMAGE
+				}
+			}
 		}
 
 		// If dex is disabled

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -668,7 +668,7 @@ func init() {
         },
         "image": {
           "type": "string",
-          "default": "coreos-stable-amd64",
+          "default": "flatcar-stable-amd64",
           "x-nullable": false
         },
         "labels": {
@@ -1628,7 +1628,7 @@ func init() {
         },
         "image": {
           "type": "string",
-          "default": "coreos-stable-amd64",
+          "default": "flatcar-stable-amd64",
           "x-nullable": false
         },
         "labels": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -515,7 +515,7 @@ definitions:
       image:
         x-nullable: false
         type: string
-        default: coreos-stable-amd64
+        default: flatcar-stable-amd64
       availabilityZone:
         type: string
         x-nullable: false


### PR DESCRIPTION
From now on flatcar will be used as default node image. A kluster upgrade will switch nodepools from coreos to flatcar.