### PR TITLE
add support to scrape k8s metrics

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.0.4
+version: 2.0.5

--- a/charts/kube-master/charts/etcd/Chart.yaml
+++ b/charts/kube-master/charts/etcd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: etcd
-version: 0.1.0
+version: 0.1.1

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -127,6 +127,9 @@ spec:
       containers:
         - name: etcd
           ports:
+          - containerPort: 2379
+            name: etcd
+            protocol: TCP
           - containerPort: 8081
             name: metrics
             protocol: TCP

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -49,7 +49,8 @@ data:
       --client-cert-auth=true \
       --trusted-ca-file=/etc/kubernetes/certs/etcd-clients-ca.pem \
       --advertise-client-urls=https://${ETCD_IP}:2379 \
-      --listen-client-urls=https://0.0.0.0:2379
+      --listen-client-urls=https://0.0.0.0:2379 \
+      --listen-metrics-urls=http://0.0.0.0:8081
 {{- else }}
       --advertise-client-urls=http://${ETCD_IP}:2379 \
       --listen-client-urls=http://0.0.0.0:2379 \

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -52,7 +52,8 @@ data:
       --listen-client-urls=https://0.0.0.0:2379
 {{- else }}
       --advertise-client-urls=http://${ETCD_IP}:2379 \
-      --listen-client-urls=http://0.0.0.0:2379
+      --listen-client-urls=http://0.0.0.0:2379 \
+      --listen-metrics-urls=http://0.0.0.0:8081
 {{- end }}
 ---
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
@@ -76,6 +77,7 @@ spec:
       labels:
         app: {{ include "fullname" . }}
         release: {{ .Release.Name }}
+        component: etcd
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
@@ -124,6 +126,10 @@ spec:
 {{- end }}
       containers:
         - name: etcd
+          ports:
+          - containerPort: 8081
+            name: metrics
+            protocol: TCP
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: ETCD_IP

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app: {{ include "master.fullname" . }}-apiserver
         release: {{ .Release.Name }}
+        component: apiserver
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
@@ -139,6 +140,10 @@ spec:
 {{- end }}
       containers:
         - name: apiserver
+          ports:
+          - containerPort: 443
+            name: server
+            protocol: TCP
           image: {{ include "hyperkube.image" . | quote }}
           args:
             - /hyperkube

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -83,10 +83,12 @@ spec:
               readOnly: true
       containers:
         - name: controller-manager
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
           ports:
-          - containerPort: 10252
+          - containerPort: 10257
             name: metrics
             protocol: TCP
+{{- end }}
           image: {{ include "hyperkube.image" . | quote }}
           args:
             - /hyperkube

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       labels:
+        component: controller-manager
         app: controller-manager
         kluster: {{ .Values.name }}
         account: {{ .Values.account }}
@@ -82,6 +83,10 @@ spec:
               readOnly: true
       containers:
         - name: controller-manager
+          ports:
+          - containerPort: 10252
+            name: metrics
+            protocol: TCP
           image: {{ include "hyperkube.image" . | quote }}
           args:
             - /hyperkube

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -83,7 +83,7 @@ spec:
               readOnly: true
       containers:
         - name: controller-manager
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
           ports:
           - containerPort: 10257
             name: metrics

--- a/charts/kube-master/templates/scheduler.yaml
+++ b/charts/kube-master/templates/scheduler.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       labels:
+        component: scheduler
         app: {{ include "master.fullname" . }}-scheduler
         release: {{ .Release.Name }}
       annotations:
@@ -45,6 +46,10 @@ spec:
             name: {{ include "master.fullname" . }}
       containers:
         - name: scheduler
+          ports:
+          - containerPort: 10259
+            name: metrics
+            protocol: TCP
           image: {{ include "hyperkube.image" . | quote }}
           args:
             - /hyperkube

--- a/charts/kube-master/templates/scheduler.yaml
+++ b/charts/kube-master/templates/scheduler.yaml
@@ -46,7 +46,7 @@ spec:
             name: {{ include "master.fullname" . }}
       containers:
         - name: scheduler
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
           ports:
           - containerPort: 10259
             name: metrics

--- a/charts/kube-master/templates/scheduler.yaml
+++ b/charts/kube-master/templates/scheduler.yaml
@@ -46,10 +46,12 @@ spec:
             name: {{ include "master.fullname" . }}
       containers:
         - name: scheduler
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
           ports:
           - containerPort: 10259
             name: metrics
             protocol: TCP
+{{- end }}
           image: {{ include "hyperkube.image" . | quote }}
           args:
             - /hyperkube

--- a/charts/kube-master/templates/service-metrics.yaml
+++ b/charts/kube-master/templates/service-metrics.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: cmanager-metrics
+  name: cmanager-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 10252
+    protocol: TCP
+    targetPort: 10252
+  selector:
+    component: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: scheduler-metrics
+  name: scheduler-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 10259
+    protocol: TCP
+    targetPort: 10259
+  selector:
+    component: scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: etcd-metrics
+  name: etcd-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    component: etcd

--- a/charts/kube-master/templates/service-metrics.yaml
+++ b/charts/kube-master/templates/service-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kube-master/templates/service-metrics.yaml
+++ b/charts/kube-master/templates/service-metrics.yaml
@@ -1,15 +1,16 @@
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    component: cmanager-metrics
-  name: cmanager-metrics
+    component: controller-manager-metrics
+  name: controller-manager-metrics
 spec:
   ports:
   - name: metrics
-    port: 10252
+    port: 10257
     protocol: TCP
-    targetPort: 10252
+    targetPort: 10257
   selector:
     component: controller-manager
 ---
@@ -42,3 +43,4 @@ spec:
     targetPort: 8081
   selector:
     component: etcd
+{{- end }}

--- a/charts/kube-master/templates/service-metrics.yaml
+++ b/charts/kube-master/templates/service-metrics.yaml
@@ -29,6 +29,7 @@ spec:
   selector:
     component: scheduler
 ---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -43,4 +44,3 @@ spec:
     targetPort: 8081
   selector:
     component: etcd
-{{- end }}

--- a/charts/kube-master/templates/service.yaml
+++ b/charts/kube-master/templates/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "master.fullname" . }}
   labels:
+    component: apiserver
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
Prepare Kubernetes API components to be scraped with `ServiceMonitor` of Prometheus Operator in `kube-monitoring-virtual`.

Hence, metrics ports are exposed with additional services for metrics.

Additional labels were added because I didn't want to edit existing `app` labels.