### PR TITLE
Switch ingress resources to cert-manager

### DIFF
--- a/charts/kubernikus-dex/Chart.yaml
+++ b/charts/kubernikus-dex/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Install global dex related credentials needed for kubernikus clusters
 name: kubernikus-dex
-version: 0.1.2
+version: 0.1.3

--- a/charts/kubernikus-dex/templates/dex-ingress.yaml
+++ b/charts/kubernikus-dex/templates/dex-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    vice-president: "true"
+    kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
   name: kubernikus-dex
   namespace: {{ default .Release.Namespace .Values.namespaceOverride }}

--- a/charts/kubernikus/Chart.yaml
+++ b/charts/kubernikus/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kubernikus
-version: 0.2.11
+version: 0.2.12

--- a/charts/kubernikus/values.yaml
+++ b/charts/kubernikus/values.yaml
@@ -16,7 +16,7 @@ api:
 
 ingress:
   annotations:
-    vice-president: "true"
+    kubernetes.io/tls-acme: "true"
     prometheus.io/probe: "true"
 
 groundctl:


### PR DESCRIPTION
This PR switches Kubernikus API and Dex ingress to use cert-manager for certificate issuance.