### PR TITLE
Waits for Load Balancer Deletions via Finalizers

### DIFF
--- a/pkg/controller/deorbit/deorbiter.go
+++ b/pkg/controller/deorbit/deorbiter.go
@@ -35,13 +35,6 @@ const (
 	// load balancers or floating IPs.
 	DeorbitHangingTimeout = 24 * time.Hour
 
-	// As of this writing services are not yet migrated to make use of
-	// finalizers. In effect there's no feedback loop and a deleted service
-	// disappears immediately - even though the cloud provider isn't finished yet
-	// with the decomissioning of existing load balancers. We guess that it takes
-	// around this duration until the clean-up was successful.
-	ServiceDeletionGracePeriod = 2 * time.Minute
-
 	// While waiting for deletion use this interval for rechecks
 	PollInterval = 15 * time.Second
 )
@@ -218,5 +211,16 @@ func (d *ConcreteDeorbiter) isPersistentVolumesCleanupFinished() (bool, error) {
 }
 
 func (d *ConcreteDeorbiter) isServiceCleanupFinished() (bool, error) {
-	return d.Kluster.ObjectMeta.DeletionTimestamp.Add(ServiceDeletionGracePeriod).Before(time.Now()), nil
+	services, err := d.Client.CoreV1().Services(meta_v1.NamespaceAll).List(context.TODO(), meta_v1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, service := range services.Items {
+		if service.Spec.Type != "LoadBalancer" {
+			continue
+		}
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/controller/deorbit/deorbiter_test.go
+++ b/pkg/controller/deorbit/deorbiter_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -110,7 +109,7 @@ var (
 		},
 	}
 
-	svcLB0 = &core_v1.Service{
+	svcLB0 *core_v1.Service = &core_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "svc-lb0",
 		},
@@ -140,23 +139,21 @@ var (
 
 func TestIsServiceCleanupFinished(testing *testing.T) {
 	type test_case struct {
-		message   string
-		expected  bool
-		deletedAt time.Time
+		expected bool
+		message  string
+		objects  []runtime.Object
 	}
 
 	for i, t := range []test_case{
-		{"true if grace period is not expired.", false, time.Now()},
-		{"true if grace period is expired.", true, time.Now().Add(-1 * ServiceDeletionGracePeriod)},
+		{true, "true if no services with type LoadBalancer exist", []runtime.Object{svcCIP}},
+		{false, "false if service with type LoadBalancer exists", []runtime.Object{svcLB0, svcLB1, svcCIP}},
 	} {
 
-		k := kluster.DeepCopy()
-		k.DeletionTimestamp = &meta_v1.Time{Time: t.deletedAt}
 		done := make(chan struct{})
-		client := fake.NewSimpleClientset()
+		client := fake.NewSimpleClientset(t.objects...)
 		logger := log.NewNopLogger()
 
-		deorbiter := &ConcreteDeorbiter{k, done, client, logger, nil}
+		deorbiter := &ConcreteDeorbiter{kluster, done, client, logger, nil}
 		finished, err := deorbiter.isServiceCleanupFinished()
 
 		assert.Equal(testing, t.expected, finished, "Test %d failed: %v", i, t.message)


### PR DESCRIPTION
This commit changes the wait behaviour when deleteing load balancers.
Previously service deleteion didn't use finalizers and no feedback was
given. The service disapeared immediately. The deorbiter used a fixed
timeout of 2min to wait for load balancer cleanup.

Since the loadbalancer driver in CCEE was changed to Octavia, that grace
period is not enough anymore. Deleteion takes longer and in case of 1.16
never completes if the LoadBalancer is not completely provisioned, e.g.
due to quota limitations. Especially a FIP is expected to be attached
and causes the deletion to never complete.

This fix depends on Kubernetes 1.17 to be fully functional. For
Kubernetes < 1.17 the Deorbiter will wait 24h for the service to be
deleted. For 1.16 it is possible to set the `use-octavia` flag as
a workaround.