### PR TITLE
Remove coreos os upgrade from servicing controller

### DIFF
--- a/pkg/controller/servicing/controller_test.go
+++ b/pkg/controller/servicing/controller_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
-	"github.com/sapcc/kubernikus/pkg/controller/servicing/coreos"
 	"github.com/sapcc/kubernikus/pkg/controller/servicing/flatcar"
 	kubernikusfake "github.com/sapcc/kubernikus/pkg/generated/clientset/fake"
 )
@@ -304,8 +303,6 @@ func TestServicingControllerReconcile(t *testing.T) {
 			listers := &NodeListerFactory{
 				Logger:          logger,
 				NodeObservatory: nodeobservatory.NewFakeController(kluster, nodes...),
-				CoreOSVersion:   coreos.NewFakeVersion(t, "2023.4.0"),
-				CoreOSRelease:   coreos.NewFakeRelease(t, "2023.4.0"),
 				FlatcarVersion:  flatcar.NewFakeVersion(t, "2303.4.0"),
 				FlatcarRelease:  flatcar.NewFakeRelease(t, "2303.4.0"),
 			}

--- a/pkg/controller/servicing/lister.go
+++ b/pkg/controller/servicing/lister.go
@@ -125,23 +125,6 @@ func (d *NodeLister) All() []*core_v1.Node {
 func (d *NodeLister) Reboot() []*core_v1.Node {
 	var rebootable, found []*core_v1.Node
 
-	latestCoreOS, err := d.CoreOSVersion.Stable()
-	if err != nil {
-		d.Logger.Log(
-			"msg", "Couldn't get CoreOS version.",
-			"err", err,
-		)
-		return found
-	}
-
-	releasedCoreOS, err := d.CoreOSRelease.GrownUp(latestCoreOS)
-	if err != nil {
-		d.Logger.Log(
-			"msg", "Couldn't get CoreOS releases.",
-			"err", err,
-		)
-	}
-
 	latestFlatcar, err := d.FlatcarVersion.Stable()
 	if err != nil {
 		d.Logger.Log(
@@ -182,10 +165,6 @@ func (d *NodeLister) Reboot() []*core_v1.Node {
 		if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Flatcar Container Linux") {
 			if releasedFlatcar {
 				uptodate, err = d.FlatcarVersion.IsNodeUptodate(node)
-			}
-		} else if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Container Linux by CoreOS") {
-			if releasedCoreOS {
-				uptodate, err = d.CoreOSVersion.IsNodeUptodate(node)
 			}
 		} else {
 			d.Logger.Log(

--- a/pkg/controller/servicing/lister_test.go
+++ b/pkg/controller/servicing/lister_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
-	"github.com/sapcc/kubernikus/pkg/controller/servicing/coreos"
 	"github.com/sapcc/kubernikus/pkg/controller/servicing/flatcar"
 )
 
@@ -32,10 +31,8 @@ func NewFakeNodeLister(t *testing.T, logger log.Logger, kluster *v1.Kluster, nod
 		Logger:         logger,
 		Kluster:        kluster,
 		Lister:         kl,
-		CoreOSVersion:  coreos.NewFakeVersion(t, "2023.4.0"),
-		CoreOSRelease:  coreos.NewFakeRelease(t, "2023.4.0"),
-		FlatcarVersion: flatcar.NewFakeVersion(t, "2303.4.0"),
-		FlatcarRelease: flatcar.NewFakeRelease(t, "2303.4.0"),
+		FlatcarVersion: flatcar.NewFakeVersion(t, "2605.7.0"),
+		FlatcarRelease: flatcar.NewFakeRelease(t, "2605.7.0"),
 	}
 
 	lister = &LoggingLister{

--- a/pkg/controller/servicing/testing.go
+++ b/pkg/controller/servicing/testing.go
@@ -115,9 +115,9 @@ func NewFakeKluster(opts *FakeKlusterOptions) (*v1.Kluster, []runtime.Object) {
 			}
 
 			if p.NodeOSOutdated {
-				node.Status.NodeInfo.OSImage = "Container Linux by CoreOS 1800.6.0 (Rhyolite)"
+				node.Status.NodeInfo.OSImage = "Flatcar Container Linux by Kinvolk 1000.0.0 (Oklo)"
 			} else {
-				node.Status.NodeInfo.OSImage = "Container Linux by CoreOS 2023.4.0 (Rhyolite)"
+				node.Status.NodeInfo.OSImage = "Flatcar Container Linux by Kinvolk 2605.7.0 (Oklo)"
 			}
 
 			if p.NodeKubeletOutdated {


### PR DESCRIPTION
This PR removes CoreOS node upgrade from servicing controller. The reboot fails because latest CoreOS version can't be determined anymore.