### PR TITLE
move etcd images to images.yaml, bump to 3.3.14

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,6 +10,12 @@ imagesForVersion:
     scheduler:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.19.4'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     kubelet:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
       tag: 'v1.19.4'
@@ -45,6 +51,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.18.0'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -71,6 +83,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.17.0'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -97,6 +115,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.16.0'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -122,6 +146,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.16.0'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -149,6 +179,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.15.0-sap.2'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -175,6 +211,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.15.0-sap.2'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -201,6 +243,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.14.0-sap.0'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -227,6 +275,12 @@ imagesForVersion:
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.13.1'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -250,6 +304,12 @@ imagesForVersion:
     hyperkube:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.12.10'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -269,6 +329,12 @@ imagesForVersion:
     hyperkube:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.11.9'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -285,16 +351,12 @@ imagesForVersion:
     hyperkube:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.10.11'
-    dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
-      tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
-    wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
-      tag: 'changeme' #this is injected to match the operator so far
-  '1.10.8':
-    hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
-      tag: 'v1.10.8'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -305,6 +367,12 @@ imagesForVersion:
     hyperkube:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.10.7'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
@@ -315,6 +383,12 @@ imagesForVersion:
     hyperkube:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.10.1'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
     dex:
       repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
           - containerPort: 2379
             name: etcd
             protocol: TCP
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "etcd.image" . }}"
           env:
             - name: ETCD_IP
               valueFrom:
@@ -197,8 +197,7 @@ spec:
             {{- else }}
             - --insecure-transport=true
             {{- end }}
-          image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
-          imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+          image: "{{ include "etcdBackup.image" . }}"
           ports:
             - containerPort: 8080
               name: server

--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 images:
   etcd:
-    repoitory: sapcc/etcd
-    tag: v3.3.13
+    repository: sapcc/etcd
+    tag: v3.3.14
   etcdBackup:
-    repoitory: sapcc/etcdbrctl
+    repository: sapcc/etcdbrctl
     tag: 0.5.2
 ## Persist data to a persitent volume
 persistence:

--- a/charts/kube-master/charts/etcd/values.yaml
+++ b/charts/kube-master/charts/etcd/values.yaml
@@ -1,10 +1,13 @@
 # Default values for etcd.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-image:
-  repository: sapcc/etcd
-  tag: v3.3.13
-  pullPolicy: IfNotPresent
+images:
+  etcd:
+    repoitory: sapcc/etcd
+    tag: v3.3.13
+  etcdBackup:
+    repoitory: sapcc/etcdbrctl
+    tag: 0.5.2
 ## Persist data to a persitent volume
 persistence:
   enabled: true
@@ -21,10 +24,6 @@ resources:
     memory: 2560Mi
 backup:
   enabled: true
-  image:
-    repository: sapcc/etcdbrctl
-    tag: 0.5.2
-    pullPolicy: IfNotPresent
   # do a full-backup every hour
   schedule: "15 * * * *"
   # keep number of backups

--- a/charts/kube-master/templates/_helpers.tpl
+++ b/charts/kube-master/templates/_helpers.tpl
@@ -66,7 +66,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "wormhole.image" }}
   {{- required "repository for wormhole missing" .Values.images.wormhole.repository }}:
-    {{- required "tag for wormhole/kubernikus missing" .Values.version.kubernikus }}
+    {{- required "tag for wormhole missing" .Values.version.kubernikus }}
+{{- end -}}
+
+{{- define "etcd.image" }}
+  {{- required "repository for etcd missing" .Values.images.etcd.repository }}:
+    {{- required "tag for etcd missing" .Values.images.etcd.tag }}
+{{- end -}}
+
+{{- define "etcdBackup.image" }}
+  {{- required "repository for etcdBackup missing" .Values.images.etcdBackup.repository }}:
+    {{- required "tag for etcdBackup missing" .Values.images.etcdBackup.tag }}
 {{- end -}}
 
 {{- define "dashboard.url" -}}

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -123,7 +123,7 @@ spec:
                 path: kubeconfig
       initContainers:
         - name: etcd-wait
-          image: "{{ required "etcd.image.repository undefined" .Values.etcd.image.repository }}:{{ required "etcd.image.tag undefined" .Values.etcd.image.tag }}"
+          image: "{{ include "etcd.image" . }}"
           command:
             - sh
             - -c

--- a/charts/kube-master/templates/cloud-controller-manager.yaml
+++ b/charts/kube-master/templates/cloud-controller-manager.yaml
@@ -58,6 +58,25 @@ spec:
               - key: openstack.config
 {{- end }}
                 path: openstack.config
+      initContainers:
+        - name: apiserver-wait
+{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+          image: {{ include "kubelet.image" . | quote }}
+{{- else }}
+          image: {{ include "hyperkube.image" . }}
+{{- end }}
+          command:
+            - sh
+            - -c
+          args:
+            - until kubectl version --short --kubeconfig /etc/kubernetes/config/kubeconfig --request-timeout=4s | grep -i "Server.*{{ .Values.version.kubernetes }}"; do sleep 5; done;
+          volumeMounts:
+            - mountPath: /etc/kubernetes/certs/
+              name: certs
+              readOnly: true
+            - mountPath: /etc/kubernetes/config
+              name: config
+              readOnly: true
       containers:
         - name: cloud-controller-manager
           image: {{ include "cloudControllerManager.image" . | quote }}

--- a/charts/kube-master/templates/dex.yaml
+++ b/charts/kube-master/templates/dex.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
       - name: etcd-wait
-        image: "{{ required "etcd.image.repository undefined" .Values.etcd.image.repository }}:{{ required "etcd.image.tag undefined" .Values.etcd.image.tag }}"
+        image: "{{ include "etcd.image" . }}"
         command:
           - sh
           - -c

--- a/charts/kube-master/test-values.yaml
+++ b/charts/kube-master/test-values.yaml
@@ -30,9 +30,11 @@ etcd:
     password: xyz
     domainName: xyz.com
     projectID: xyz
-imagesForVersion:
-  "1.0.0":
-    hyperkube:
+  images:
+    etcd:
+      repository: abc
+      tag: xyz
+    etcdBackup:
       repository: abc
       tag: xyz
 images:
@@ -41,6 +43,13 @@ images:
     tag: xyz
   wormhole:
     repository: abc
+  etcd:
+    repository: abc
+    tag: xyz
+  etcdBackup:
+    repository: abc
+    tag: xyz
+
 dashboard:
   enabled: false
 dex:

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -49,10 +49,11 @@ type persistenceValues struct {
 }
 
 type etcdValues struct {
-	Persistence      persistenceValues `yaml:"persistence,omitempty"`
-	StorageContainer string            `yaml:"storageContainer,omitempty"`
-	Openstack        openstackValues   `yaml:"openstack,omitempty"`
-	Backup           etcdBackupValues  `yaml:"backup"`
+	Persistence      persistenceValues      `yaml:"persistence,omitempty"`
+	StorageContainer string                 `yaml:"storageContainer,omitempty"`
+	Openstack        openstackValues        `yaml:"openstack,omitempty"`
+	Backup           etcdBackupValues       `yaml:"backup"`
+	Images           version.KlusterVersion `yaml:"images"`
 }
 
 type etcdBackupValues struct {
@@ -206,6 +207,9 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 	}
 	if registry != nil {
 		values.Images = registry.Versions[kubernetesVersion]
+		// make etcd images available to subchart
+		values.Etcd.Images.Etcd = values.Images.Etcd
+		values.Etcd.Images.EtcdBackup = values.Images.EtcdBackup
 	}
 	if !kluster.Spec.NoCloud {
 		values.Openstack = openstackValues{

--- a/pkg/version/images.go
+++ b/pkg/version/images.go
@@ -38,6 +38,8 @@ type KlusterVersion struct {
 	CoreDNS                ImageVersion `yaml:"coreDNS,omitempty"`
 	Pause                  ImageVersion `yaml:"pause,omitempty"`
 	Wormhole               ImageVersion `yaml:"wormhole,omitempty"`
+	Etcd                   ImageVersion `yaml:"etcd,omitempty"`
+	EtcdBackup             ImageVersion `yaml:"etcdBackup,omitempty"`
 }
 
 type ImageRegistry struct {


### PR DESCRIPTION
I removed 1.10.8 from the images.yaml because we have no clusters with that version anymore.