### PR TITLE
Additional redirect URI for dex so that kubelogin can work

### DIFF
--- a/charts/kube-master/templates/dex-configmap.yaml
+++ b/charts/kube-master/templates/dex-configmap.yaml
@@ -4,14 +4,14 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    app: {{ include "master.fullname" . }}-dex 
+    app: {{ include "master.fullname" . }}-dex
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
   name: {{ include "master.fullname" . }}-dex
 data:
   config.yaml: |
     issuer: https://{{ include "dex.url" . }}
-    
+
     storage:
       type: etcd
       config:
@@ -27,10 +27,10 @@ data:
           - http://{{ include "etcd.fullname" . }}:2379
 {{- end }}
         namespace: dex/
-    
+
     web:
       http: 0.0.0.0:80
-    
+
     frontend:
       theme: ccloud
       issuer: "Converged Cloud Kubernetes"
@@ -38,7 +38,7 @@ data:
     expiry:
       signingKeys: "48h"
       idTokens: "24h"
-    
+
     logger:
       level: debug
 
@@ -78,7 +78,7 @@ data:
             emailAttr: mail
             nameAttr: cn
             # workaround for technical users without email address in LDAP:
-            emailSuffix: cloud.sap 
+            emailSuffix: cloud.sap
 
           # Group search queries for groups given a user entry.
           groupSearch:
@@ -93,21 +93,22 @@ data:
       skipApprovalScreen: true
       responseTypes: ["code", "token", "id_token"]
       {{ if .Values.dex.connectors.keystone.enabled }}
-      passwordConnector: keystone 
+      passwordConnector: keystone
       {{ else if .Values.dex.connectors.ldap.enabled }}
-      passwordConnector: ldap 
+      passwordConnector: ldap
       {{ else if .Values.dex.staticPasword.enabled }}
-      passwordConnector: local 
+      passwordConnector: local
       {{ end }}
-    
+
     staticClients:
-    - id: kubernetes 
+    - id: kubernetes
       redirectURIs:
       - https://{{ include "dashboard.url" . }}/oauth/callback # for dashboard access
       - http://localhost:33768/auth/callback
-      name: kubernetes 
+      - http://localhost:33768/ # for https://github.com/int128/kubelogin access
+      name: kubernetes
       secret: {{ required "dex.staticClientSecret" .Values.dex.staticClientSecret }}
-    
+
     {{ if .Values.dex.staticPasword.enabled }}
     staticPasswords:
     - email: {{ required "dex.staticPasword.email" .Values.dex.staticPasword.email }}


### PR DESCRIPTION
Additional redirect URI for dex so that kubelogin can be used for authentication to a kubernikus cluster.

Fixes #565 