### PR TITLE
Add support for 1.19.11

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -67,6 +67,50 @@ imagesForVersion:
     cinderCSIPlugin:
       repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
       tag: 'v1.20.3'
+  '1.19.10':
+    supported: true
+    apiserver:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      tag: 'v1.19.10'
+    controllerManager:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      tag: 'v1.19.10'
+    scheduler:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      tag: 'v1.19.10'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
+    kubelet:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      tag: 'v1.19.10'
+    kubeProxy:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      tag: 'v1.19.10'
+    cloudControllerManager:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      tag: 'v1.19.2'
+    dex:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
+    dashboardProxy:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      tag: '6.0.1'
+    dashboard:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      tag: 'v2.0.4'
+    coreDNS:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      tag: '1.6.2'
+    pause:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      tag: '3.1'
+    wormhole:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      tag: 'changeme' #this is injected to match the operator so far
   '1.19.4':
     supported: true
     apiserver:

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -67,17 +67,17 @@ imagesForVersion:
     cinderCSIPlugin:
       repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
       tag: 'v1.20.3'
-  '1.19.10':
+  '1.19.11':
     supported: true
     apiserver:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
-      tag: 'v1.19.10'
+      tag: 'v1.19.11'
     controllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
-      tag: 'v1.19.10'
+      tag: 'v1.19.11'
     scheduler:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
-      tag: 'v1.19.10'
+      tag: 'v1.19.11'
     etcd:
       repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
@@ -86,10 +86,10 @@ imagesForVersion:
       tag: '0.5.2'
     kubelet:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
-      tag: 'v1.19.10'
+      tag: 'v1.19.11'
     kubeProxy:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
-      tag: 'v1.19.10'
+      tag: 'v1.19.11'
     cloudControllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.19.2'


### PR DESCRIPTION
This PR adds support for ~~1.19.10~~ 1.19.11 which has HTTP/2 health check enabled by default. This hopefully fixes problems with stalling watches.