### PR TITLE
Adds Exceptions for FlatCar Replacements

### DIFF
--- a/pkg/controller/servicing/lister.go
+++ b/pkg/controller/servicing/lister.go
@@ -143,17 +143,19 @@ func (d *NodeLister) Reboot() []*core_v1.Node {
 	}
 
 	for _, pool := range d.Kluster.Spec.NodePools {
-		if *pool.Config.AllowReboot == false {
-			continue
-		}
-
 		prefix := fmt.Sprintf("%v-%v-", d.Kluster.Spec.Name, pool.Name)
 		for _, node := range d.All() {
 			if !strings.HasPrefix(node.GetName(), prefix) {
 				continue
 			}
 			if len(node.GetName()) == len(prefix)+generator.RandomLength {
-				rebootable = append(rebootable, node)
+				if util.IsFlatcarNodeWithRkt(node) && latestFlatcar.Major() >= 2905 {
+					continue
+				}
+
+				if *pool.Config.AllowReboot == true {
+					rebootable = append(rebootable, node)
+				}
 			}
 		}
 	}
@@ -195,11 +197,24 @@ func (d *NodeLister) Replace() []*core_v1.Node {
 	var nodeNameToPool map[string]*models.NodePool
 	nodeNameToPool = make(map[string]*models.NodePool)
 
-	for i, pool := range d.Kluster.Spec.NodePools {
-		if *pool.Config.AllowReplace == false {
-			continue
-		}
+	latestFlatcar, err := d.FlatcarVersion.Stable()
+	if err != nil {
+		d.Logger.Log(
+			"msg", "Couldn't get Flatcar version.",
+			"err", err,
+		)
+		return found
+	}
 
+	releasedFlatcar, err := d.FlatcarRelease.GrownUp(latestFlatcar)
+	if err != nil {
+		d.Logger.Log(
+			"msg", "Couldn't get Flatcar releases.",
+			"err", err,
+		)
+	}
+
+	for i, pool := range d.Kluster.Spec.NodePools {
 		prefix := fmt.Sprintf("%v-%v-", d.Kluster.Spec.Name, pool.Name)
 		for _, node := range d.All() {
 			if !strings.HasPrefix(node.GetName(), prefix) {
@@ -208,9 +223,11 @@ func (d *NodeLister) Replace() []*core_v1.Node {
 
 			if len(node.GetName()) == len(prefix)+generator.RandomLength {
 				nodeNameToPool[node.GetName()] = &d.Kluster.Spec.NodePools[i]
-				upgradable = append(upgradable, node)
-			}
 
+				if *pool.Config.AllowReplace == true || (util.IsFlatcarNodeWithRkt(node) && latestFlatcar.Major() >= 2905) {
+					upgradable = append(upgradable, node)
+				}
+			}
 		}
 	}
 
@@ -262,6 +279,33 @@ func (d *NodeLister) Replace() []*core_v1.Node {
 		if kubeProxyVersion.LessThan(klusterVersion) {
 			found = append(found, node)
 			continue
+		}
+
+		if util.IsFlatcarNodeWithRkt(node) && latestFlatcar.Major() >= 2905 {
+			uptodate := true
+
+			if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Flatcar Container Linux") {
+				if releasedFlatcar {
+					uptodate, err = d.FlatcarVersion.IsNodeUptodate(node)
+				}
+			} else {
+				d.Logger.Log(
+					"msg", "Unsupported OS on node. Skipping OS upgrade.",
+					"os", node.Status.NodeInfo.OSImage,
+				)
+				continue
+			}
+			if err != nil {
+				d.Logger.Log(
+					"msg", "Couldn't get OS version from Node. Skipping OS upgrade.",
+					"err", err,
+				)
+				continue
+			}
+
+			if !uptodate {
+				found = append(found, node)
+			}
 		}
 	}
 

--- a/pkg/controller/servicing/testing.go
+++ b/pkg/controller/servicing/testing.go
@@ -117,7 +117,7 @@ func NewFakeKluster(opts *FakeKlusterOptions) (*v1.Kluster, []runtime.Object) {
 			if p.NodeOSOutdated {
 				node.Status.NodeInfo.OSImage = "Flatcar Container Linux by Kinvolk 1000.0.0 (Oklo)"
 			} else {
-				node.Status.NodeInfo.OSImage = "Flatcar Container Linux by Kinvolk 2605.7.0 (Oklo)"
+				node.Status.NodeInfo.OSImage = "Flatcar Container Linux by Kinvolk 3000.0.0 (Oklo)"
 			}
 
 			if p.NodeKubeletOutdated {

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
+	"github.com/sapcc/kubernikus/pkg/controller/servicing/flatcar"
 	"github.com/sapcc/kubernikus/pkg/util/netutil"
 )
 
@@ -141,6 +142,14 @@ func IsCoreOSNode(node *v1.Node) bool {
 
 func IsFlatcarNode(node *v1.Node) bool {
 	return strings.HasPrefix(node.Status.NodeInfo.OSImage, NODE_FLATCAR_PREFIX)
+}
+
+func IsFlatcarNodeWithRkt(node *v1.Node) bool {
+	extractVersion, err := flatcar.ExractVersion(node)
+	if err != nil {
+		return false
+	}
+	return extractVersion.Major() < 2905
 }
 
 func IsCoreOSNodePool(pool *models.NodePool) bool {


### PR DESCRIPTION
A breaking change in FlatCar requires us to replace nodes even for an OS
update. This change allows nodes to be marked as "replacable" even if
under normal circumstances a reboot would be enough.

Specifically, all nodes with FlatCar < 2905 will be replaced if an OS or
Kubernetes upgrade is necessary.