### PR TITLE
limit ssh key field to 10k, ensure userdata stays < 60k bytes

### DIFF
--- a/pkg/api/models/kluster_spec.go
+++ b/pkg/api/models/kluster_spec.go
@@ -65,6 +65,7 @@ type KlusterSpec struct {
 	ServiceCIDR string `json:"serviceCIDR,omitempty"`
 
 	// SSH public key that is injected into spawned nodes.
+	// Max Length: 10000
 	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 
 	// Kubernetes version
@@ -97,6 +98,10 @@ func (m *KlusterSpec) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateServiceCIDR(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSSHPublicKey(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -225,6 +230,19 @@ func (m *KlusterSpec) validateServiceCIDR(formats strfmt.Registry) error {
 	}
 
 	if err := validate.Pattern("serviceCIDR", "body", string(m.ServiceCIDR), `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$`); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *KlusterSpec) validateSSHPublicKey(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SSHPublicKey) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("sshPublicKey", "body", string(m.SSHPublicKey), 10000); err != nil {
 		return err
 	}
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -654,7 +654,8 @@ func init() {
         },
         "sshPublicKey": {
           "description": "SSH public key that is injected into spawned nodes.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 10000
         },
         "version": {
           "description": "Kubernetes version",
@@ -1677,7 +1678,8 @@ func init() {
         },
         "sshPublicKey": {
           "description": "SSH public key that is injected into spawned nodes.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 10000
         },
         "version": {
           "description": "Kubernetes version",

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -227,8 +227,7 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 		}
 	}
 
-	dataOut, err = json.MarshalIndent(&ignitionConfig2_0, "", "  ")
-	dataOut = append(dataOut, '\n')
+	dataOut, err = json.Marshal(&ignitionConfig2_0)
 
 	if err != nil {
 		return nil, err

--- a/swagger.yml
+++ b/swagger.yml
@@ -512,6 +512,7 @@ definitions:
       sshPublicKey:
         description: SSH public key that is injected into spawned nodes.
         type: string
+        maxLength: 10000
       version:
         description: Kubernetes version
         pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'


### PR DESCRIPTION
This PR limits the maximum length of the ssh key field in the kubernikus api to 10k bytes which should allow to add at least 10 ssh keys to a cluster.
I also removed the json indenting for the ignition output and added a test that all ignition templates stay below 60k bytes (nova allows up to 65k) with a maxed out ssh key field.
