### PR TITLE
Add support for custom root disks

### DIFF
--- a/pkg/api/models/node_pool.go
+++ b/pkg/api/models/node_pool.go
@@ -25,6 +25,11 @@ type NodePool struct {
 	// config
 	Config *NodePoolConfig `json:"config,omitempty"`
 
+	// Create servers with custom (cinder based) root disked. Size in GB
+	// Maximum: 1024
+	// Minimum: 64
+	CustomRootDiskSize int64 `json:"customRootDiskSize"`
+
 	// flavor
 	// Required: true
 	Flavor string `json:"flavor"`
@@ -55,6 +60,10 @@ func (m *NodePool) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateConfig(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCustomRootDiskSize(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -97,6 +106,23 @@ func (m *NodePool) validateConfig(formats strfmt.Registry) error {
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *NodePool) validateCustomRootDiskSize(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.CustomRootDiskSize) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("customRootDiskSize", "body", int64(m.CustomRootDiskSize), 64, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("customRootDiskSize", "body", int64(m.CustomRootDiskSize), 1024, false); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -722,6 +722,12 @@ func init() {
         "config": {
           "$ref": "#/definitions/NodePoolConfig"
         },
+        "customRootDiskSize": {
+          "description": "Create servers with custom (cinder based) root disked. Size in GB",
+          "type": "integer",
+          "maximum": 1024,
+          "minimum": 64
+        },
         "flavor": {
           "type": "string",
           "x-nullable": false
@@ -1752,6 +1758,12 @@ func init() {
         },
         "config": {
           "$ref": "#/definitions/NodePoolConfig"
+        },
+        "customRootDiskSize": {
+          "description": "Create servers with custom (cinder based) root disked. Size in GB",
+          "type": "integer",
+          "maximum": 1024,
+          "minimum": 64
         },
         "flavor": {
           "type": "string",

--- a/swagger.yml
+++ b/swagger.yml
@@ -569,6 +569,11 @@ definitions:
       availabilityZone:
         type: string
         x-nullable: false
+      customRootDiskSize:
+        type: integer
+        minimum: 64
+        maximum: 1024
+        description: Create servers with custom (cinder based) root disked. Size in GB
       taints:
         description: The specified taints will be added to members of this pool once during initial registration of the node
         type: array

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -1,0 +1,152 @@
+/*
+Package bootfromvolume extends a server create request with the ability to
+specify block device options. This can be used to boot a server from a block
+storage volume as well as specify multiple ephemeral disks upon creation.
+
+It is recommended to refer to the Block Device Mapping documentation to see
+all possible ways to configure a server's block devices at creation time:
+
+https://docs.openstack.org/nova/latest/user/block-device-mapping.html
+
+Note that this package implements `block_device_mapping_v2`.
+
+Example of Creating a Server From an Image
+
+This example will boot a server from an image and use a standard ephemeral
+disk as the server's root disk. This is virtually no different than creating
+a server without using block device mappings.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From a New Volume
+
+This example will create a block storage volume based on the given Image. The
+server will use this volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          2,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From an Existing Volume
+
+This example will create a server with an existing volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceVolume,
+			UUID:                "volume-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server with Multiple Ephemeral Disks
+
+This example will create a server with multiple ephemeral disks. The first
+block device will be based off of an existing Image. Each additional
+ephemeral disks must have an index of -1.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          5,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package bootfromvolume

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -1,0 +1,132 @@
+package bootfromvolume
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+type (
+	// DestinationType represents the type of medium being used as the
+	// destination of the bootable device.
+	DestinationType string
+
+	// SourceType represents the type of medium being used as the source of the
+	// bootable device.
+	SourceType string
+)
+
+const (
+	// DestinationLocal DestinationType is for using an ephemeral disk as the
+	// destination.
+	DestinationLocal DestinationType = "local"
+
+	// DestinationVolume DestinationType is for using a volume as the destination.
+	DestinationVolume DestinationType = "volume"
+
+	// SourceBlank SourceType is for a "blank" or empty source.
+	SourceBlank SourceType = "blank"
+
+	// SourceImage SourceType is for using images as the source of a block device.
+	SourceImage SourceType = "image"
+
+	// SourceSnapshot SourceType is for using a volume snapshot as the source of
+	// a block device.
+	SourceSnapshot SourceType = "snapshot"
+
+	// SourceVolume SourceType is for using a volume as the source of block
+	// device.
+	SourceVolume SourceType = "volume"
+)
+
+// BlockDevice is a structure with options for creating block devices in a
+// server. The block device may be created from an image, snapshot, new volume,
+// or existing volume. The destination may be a new volume, existing volume
+// which will be attached to the instance, ephemeral disk, or boot device.
+type BlockDevice struct {
+	// SourceType must be one of: "volume", "snapshot", "image", or "blank".
+	SourceType SourceType `json:"source_type" required:"true"`
+
+	// UUID is the unique identifier for the existing volume, snapshot, or
+	// image (see above).
+	UUID string `json:"uuid,omitempty"`
+
+	// BootIndex is the boot index. It defaults to 0.
+	BootIndex int `json:"boot_index"`
+
+	// DeleteOnTermination specifies whether or not to delete the attached volume
+	// when the server is deleted. Defaults to `false`.
+	DeleteOnTermination bool `json:"delete_on_termination"`
+
+	// DestinationType is the type that gets created. Possible values are "volume"
+	// and "local".
+	DestinationType DestinationType `json:"destination_type,omitempty"`
+
+	// GuestFormat specifies the format of the block device.
+	GuestFormat string `json:"guest_format,omitempty"`
+
+	// VolumeSize is the size of the volume to create (in gigabytes). This can be
+	// omitted for existing volumes.
+	VolumeSize int `json:"volume_size,omitempty"`
+
+	// DeviceType specifies the device type of the block devices.
+	// Examples of this are disk, cdrom, floppy, lun, etc.
+	DeviceType string `json:"device_type,omitempty"`
+
+	// DiskBus is the bus type of the block devices.
+	// Examples of this are ide, usb, virtio, scsi, etc.
+	DiskBus string `json:"disk_bus,omitempty"`
+
+	// VolumeType is the volume type of the block device.
+	// This requires Compute API microversion 2.67 or later.
+	VolumeType string `json:"volume_type,omitempty"`
+}
+
+// CreateOptsExt is a structure that extends the server `CreateOpts` structure
+// by allowing for a block device mapping.
+type CreateOptsExt struct {
+	servers.CreateOptsBuilder
+	BlockDevice []BlockDevice `json:"block_device_mapping_v2,omitempty"`
+}
+
+// ToServerCreateMap adds the block device mapping option to the base server
+// creation options.
+func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(opts.BlockDevice) == 0 {
+		err := gophercloud.ErrMissingInput{}
+		err.Argument = "bootfromvolume.CreateOptsExt.BlockDevice"
+		return nil, err
+	}
+
+	serverMap := base["server"].(map[string]interface{})
+
+	blockDevice := make([]map[string]interface{}, len(opts.BlockDevice))
+
+	for i, bd := range opts.BlockDevice {
+		b, err := gophercloud.BuildRequestBody(bd, "")
+		if err != nil {
+			return nil, err
+		}
+		blockDevice[i] = b
+	}
+	serverMap["block_device_mapping_v2"] = blockDevice
+
+	return base, nil
+}
+
+// Create requests the creation of a server from the given block device mapping.
+func Create(client *gophercloud.ServiceClient, opts servers.CreateOptsBuilder) (r servers.CreateResult) {
+	b, err := opts.ToServerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
@@ -1,0 +1,12 @@
+package bootfromvolume
+
+import (
+	os "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+// CreateResult temporarily contains the response from a Create call.
+// It embeds the standard servers.CreateResults type and so can be used the
+// same way as a standard server request result.
+type CreateResult struct {
+	os.CreateResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/urls.go
@@ -1,0 +1,7 @@
+package bootfromvolume
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-volumes_boot")
+}


### PR DESCRIPTION
This PR adds a `customRootDiskSize` field to the nodepool spec. If set the vms get an ephemeral cinder based root disk that is deleted when the vm is deleted.

Has been requested a couple of times and was quite easy to implement. We can also use this for our concourse installation.

Example vm with a `customRootDiskSize: 1024`:
```
core@kks-class-pool1-6qv4n ~ $ df -h
Filesystem       Size  Used Avail Use% Mounted on
devtmpfs         959M     0  959M   0% /dev
tmpfs            985M     0  985M   0% /dev/shm
tmpfs            394M  5.5M  389M   2% /run
tmpfs            4.0M     0  4.0M   0% /sys/fs/cgroup
/dev/sda9        990G  1.3G  948G   1% /                    <--- :)
/dev/mapper/usr  985M  764M  171M  82% /usr
none             450M  312M  139M  70% /run/torcx/unpack
tmpfs            985M     0  985M   0% /media
tmpfs            985M     0  985M   0% /tmp
/dev/sr0         910K  910K     0 100% /media/configdrive
/dev/sda6        108M  108K   99M   1% /usr/share/oem
tmpfs            197M     0  197M   0% /run/user/500
core@kks-class-pool1-6qv4n ~ $
```