### PR TITLE
Fix Apiserver liveness check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,13 +134,14 @@ build-e2e:
 	CGO_ENABLED=0 go test -v -c -o /dev/null ./test/e2e
 
 .PHONY: test-e2e
+test-e2e: export OS_PASSWORD=$(KS_PASSWORD)
 test-e2e:
 ifndef KUBERNIKUS_URL
 	$(error set KUBERNIKUS_URL)
 else
 	@cd test/e2e && \
 	set -o pipefail && \
-	go test -v -timeout 55m --kubernikus=$(KUBERNIKUS_URL) | \
+	go test -v -timeout 20m --kubernikus=$(KUBERNIKUS_URL) | \
 	grep -v "CONT\|PAUSE"
 endif
 

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -280,14 +280,15 @@ spec:
               port: {{ .Values.advertisePort }}
               scheme: HTTPS
 {{- end }}
-            initialDelaySeconds: 60
+            initialDelaySeconds: 5
             periodSeconds: 60
+            failureThreshold: 2
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.advertisePort }}
               scheme: HTTPS
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             timeoutSeconds: 3
           env:
             - name: ETCD_HOST

--- a/test/e2e/etcdbr_test.go
+++ b/test/e2e/etcdbr_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	podutil "github.com/sapcc/kubernikus/pkg/util/pod"
 	"github.com/sapcc/kubernikus/test/e2e/framework"
 )
 
@@ -39,28 +41,23 @@ func (e *EtcdBackupTests) WaitForBackupRestore(t *testing.T) {
 	require.NoError(t, err, "Error retrieving default secret")
 	require.NotEmpty(t, UID, "ServiceAccount UID should not be empty")
 
-	opts := meta_v1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s-etcd", e.FullKlusterName),
-	}
-	pods, err := e.KubernetesControlPlane.ClientSet.CoreV1().Pods(e.Namespace).List(opts)
+	etcdPod, err := e.GetPod(fmt.Sprintf("app=%s-etcd", e.FullKlusterName))
 	require.NoError(t, err, "Error retrieving etcd pod: %s", err)
-	require.EqualValues(t, 1, len(pods.Items), "There should be exactly one etcd pod, %d found", len(pods.Items))
-	podName := pods.Items[0].GetName()
-	require.NotEmpty(t, podName, "Podname should not be empty")
 
-	pod, err := e.KubernetesControlPlane.ClientSet.CoreV1().Pods(e.Namespace).Get(podName, meta_v1.GetOptions{})
-	require.NoError(t, err, "Error retrieving resource version")
-	rv := pod.GetResourceVersion()
+	rv := etcdPod.GetResourceVersion()
 	require.NotEmpty(t, rv, "ResourceVersion should not be empty")
 
+	apiPod, err := e.GetPod(fmt.Sprintf("app=%s-apiserver", e.FullKlusterName))
+	require.NoError(t, err, "Error retrieving apiserver pod: %s", err)
+
 	cmd := fmt.Sprintf("mv %s %s.bak", EtcdDataDir, EtcdDataDir)
-	_, _, err = e.KubernetesControlPlane.ExecCommandInContainerWithFullOutput(e.Namespace, podName, "backup", "/bin/sh", "-c", cmd)
+	_, _, err = e.KubernetesControlPlane.ExecCommandInContainerWithFullOutput(e.Namespace, etcdPod.Name, "backup", "/bin/sh", "-c", cmd)
 	require.NoError(t, err, "Deletion of etcd data failed: %s", err)
 
 	newRv := string(rv)
 	wait.PollImmediate(EtcdFailPollInterval, EtcdFailTimeout,
 		func() (bool, error) {
-			pod, _ := e.KubernetesControlPlane.ClientSet.CoreV1().Pods(e.Namespace).Get(podName, meta_v1.GetOptions{})
+			pod, _ := e.KubernetesControlPlane.ClientSet.CoreV1().Pods(e.Namespace).Get(etcdPod.Name, meta_v1.GetOptions{})
 			newRv = pod.GetResourceVersion()
 			return (newRv != rv), nil
 		})
@@ -74,6 +71,14 @@ func (e *EtcdBackupTests) WaitForBackupRestore(t *testing.T) {
 		})
 	require.NoError(t, err)
 	require.EqualValues(t, UID, newUID, "Recovery of etcd backup failed")
+
+	err = wait.PollImmediate(EtcdRestorePollInterval, EtcdRestoreTimeout,
+		func() (bool, error) {
+			p, _ := e.KubernetesControlPlane.ClientSet.CoreV1().Pods(e.Namespace).Get(apiPod.Name, meta_v1.GetOptions{})
+
+			return p.Status.ContainerStatuses[0].RestartCount > apiPod.Status.ContainerStatuses[0].RestartCount && podutil.IsPodReady(p), nil
+		})
+	require.NoError(t, err, "apiserver did not restart efter etcd restore")
 }
 
 func (e *EtcdBackupTests) getServiceAccountUID(namespace, serviceAccountName string) (string, error) {
@@ -83,4 +88,19 @@ func (e *EtcdBackupTests) getServiceAccountUID(namespace, serviceAccountName str
 	}
 
 	return string(serviceAccount.GetUID()), nil
+}
+
+func (e *EtcdBackupTests) GetPod(labelSelector string) (*v1.Pod, error) {
+	opts := meta_v1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	pods, err := e.KubernetesControlPlane.ClientSet.CoreV1().Pods(e.Namespace).List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list pods: %w", err)
+	}
+	if len(pods.Items) != 1 {
+		return nil, fmt.Errorf("Expected to find one pod for selector %s, found %d", labelSelector, len(pods.Items))
+	}
+	return &pods.Items[0], nil
 }

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -51,7 +51,7 @@ func (f *Kubernetes) ExecWithOptions(options ExecOptions) (string, string, error
 	}, scheme.ParameterCodec)
 
 	var stdout, stderr bytes.Buffer
-	err := execute("POST", req.URL(), f.restClientConfig, options.Stdin, &stdout, &stderr, tty)
+	err := execute("POST", req.URL(), f.RestConfig, options.Stdin, &stdout, &stderr, tty)
 
 	if options.PreserveWhitespace {
 		return stdout.String(), stderr.String(), err

--- a/test/e2e/framework/kubernetes.go
+++ b/test/e2e/framework/kubernetes.go
@@ -24,8 +24,8 @@ const (
 )
 
 type Kubernetes struct {
-	ClientSet        *kubernetes.Clientset
-	restClientConfig *restclient.Config
+	ClientSet  *kubernetes.Clientset
+	RestConfig *restclient.Config
 }
 
 func NewKubernetesFramework(kubernikus *Kubernikus, kluster string) (*Kubernetes, error) {
@@ -53,8 +53,8 @@ func NewKubernetesFramework(kubernikus *Kubernikus, kluster string) (*Kubernetes
 	}
 
 	return &Kubernetes{
-		ClientSet:        clientset,
-		restClientConfig: restConfig,
+		ClientSet:  clientset,
+		RestConfig: restConfig,
 	}, nil
 }
 

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -50,6 +50,7 @@ func (n *NetworkTests) Run(t *testing.T) {
 	var err error
 	n.Nodes, err = n.Kubernetes.ClientSet.CoreV1().Nodes().List(meta_v1.ListOptions{})
 	require.NoError(t, err, "There must be no error while listing the kluster's nodes")
+	require.NotEmpty(t, n.Nodes.Items, "No nodes returned by list")
 
 	defer t.Run("Cleanup", n.DeleteNamespace)
 	t.Run("CreateNamespace", n.CreateNamespace)

--- a/test/e2e/volume_test.go
+++ b/test/e2e/volume_test.go
@@ -34,6 +34,7 @@ func (v *VolumeTests) Run(t *testing.T) {
 	var err error
 	v.Nodes, err = v.Kubernetes.ClientSet.CoreV1().Nodes().List(meta_v1.ListOptions{})
 	require.NoError(t, err, "There must be no error while listing the kluster's nodes")
+	require.NotEmpty(t, v.Nodes.Items, "No nodes returned by list")
 
 	//defer t.Run("Cleanup", v.DeleteNamespace)
 	t.Run("CreateNamespace", v.CreateNamespace)


### PR DESCRIPTION
The apiserver liveness check was broken and not working.

Primarily `if _, err := os.Stat(LastFile); os.IsExist(err)` was incorrect for checking if a file exists.
But while debugging this I noticed that the overall logic was flawed as the metric only appears after the first restart.

This let me to rewrite the logic completely.

TODO: publish not apiserver images for 1.19/1.20 and update images.yaml