### PR TITLE
Mount resolv.conf in rkt container

### DIFF
--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -27,7 +27,7 @@ var Ignition = &ignition{}
 
 var passwordHashRounds = 1000000
 
-const TEMPLATE_VERSION = "1"
+const TEMPLATE_VERSION = "2"
 
 func (i *ignition) getIgnitionTemplate(kluster *kubernikusv1.Kluster) (string, error) {
 	switch {

--- a/pkg/templates/node_1.11.go
+++ b/pkg/templates/node_1.11.go
@@ -90,7 +90,10 @@ systemd:
                                       --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
                                       --mount volume=etc-kubernetes-certs,target=/etc/kubernetes/certs \
                                       --volume etc-kube-flannel,kind=host,source=/etc/kube-flannel,readOnly=true \
-                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel"
+                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel \
+                                      --dns=host \
+                                      --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+                                      --mount volume=dns,target=/etc/resolv.conf"
     - name: flannel-docker-opts.service
       enable: true
       contents: |
@@ -110,8 +113,10 @@ systemd:
         [Service]
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --inherit-env \
-          --dns=host \
           --net=host \
+          --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --volume etc-machine-id,kind=host,source=/etc/machine-id,readOnly=true \
@@ -181,6 +186,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=true \
           --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
           --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
@@ -214,6 +221,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount volume=etc-kubernetes,target=/etc/kubernetes \
           --volume lib-modules,kind=host,source=/lib/modules,readOnly=true \

--- a/pkg/templates/node_1.12.go
+++ b/pkg/templates/node_1.12.go
@@ -90,7 +90,10 @@ systemd:
                                       --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
                                       --mount volume=etc-kubernetes-certs,target=/etc/kubernetes/certs \
                                       --volume etc-kube-flannel,kind=host,source=/etc/kube-flannel,readOnly=true \
-                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel"
+                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel \
+                                      --dns=host \
+                                      --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+                                      --mount volume=dns,target=/etc/resolv.conf"
     - name: flannel-docker-opts.service
       enable: true
       contents: |
@@ -110,8 +113,10 @@ systemd:
         [Service]
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --inherit-env \
-          --dns=host \
           --net=host \
+          --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --volume etc-machine-id,kind=host,source=/etc/machine-id,readOnly=true \
@@ -183,6 +188,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=true \
           --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
           --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
@@ -216,6 +223,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount volume=etc-kubernetes,target=/etc/kubernetes \
           --volume lib-modules,kind=host,source=/lib/modules,readOnly=true \

--- a/pkg/templates/node_1.14.go
+++ b/pkg/templates/node_1.14.go
@@ -90,7 +90,10 @@ systemd:
                                       --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
                                       --mount volume=etc-kubernetes-certs,target=/etc/kubernetes/certs \
                                       --volume etc-kube-flannel,kind=host,source=/etc/kube-flannel,readOnly=true \
-                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel"
+                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel \
+                                      --dns=host \
+                                      --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+                                      --mount volume=dns,target=/etc/resolv.conf"
     - name: flannel-docker-opts.service
       enable: true
       contents: |
@@ -110,8 +113,10 @@ systemd:
         [Service]
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --inherit-env \
-          --dns=host \
           --net=host \
+          --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --volume etc-machine-id,kind=host,source=/etc/machine-id,readOnly=true \
@@ -183,6 +188,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=true \
           --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
           --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
@@ -216,6 +223,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount volume=etc-kubernetes,target=/etc/kubernetes \
           --volume lib-modules,kind=host,source=/lib/modules,readOnly=true \

--- a/pkg/templates/node_1.17.go
+++ b/pkg/templates/node_1.17.go
@@ -90,7 +90,10 @@ systemd:
                                       --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
                                       --mount volume=etc-kubernetes-certs,target=/etc/kubernetes/certs \
                                       --volume etc-kube-flannel,kind=host,source=/etc/kube-flannel,readOnly=true \
-                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel"
+                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel \
+                                      --dns=host \
+                                      --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+                                      --mount volume=dns,target=/etc/resolv.conf"
     - name: flannel-docker-opts.service
       enable: true
       contents: |
@@ -110,8 +113,10 @@ systemd:
         [Service]
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --inherit-env \
-          --dns=host \
           --net=host \
+          --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --volume etc-machine-id,kind=host,source=/etc/machine-id,readOnly=true \
@@ -183,6 +188,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=true \
           --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
           --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
@@ -216,6 +223,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount volume=etc-kubernetes,target=/etc/kubernetes \
           --volume lib-modules,kind=host,source=/lib/modules,readOnly=true \

--- a/pkg/templates/node_1.19.go
+++ b/pkg/templates/node_1.19.go
@@ -90,7 +90,10 @@ systemd:
                                       --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
                                       --mount volume=etc-kubernetes-certs,target=/etc/kubernetes/certs \
                                       --volume etc-kube-flannel,kind=host,source=/etc/kube-flannel,readOnly=true \
-                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel"
+                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel \
+                                      --dns=host \
+                                      --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+                                      --mount volume=dns,target=/etc/resolv.conf"
     - name: flannel-docker-opts.service
       enable: true
       contents: |
@@ -110,8 +113,10 @@ systemd:
         [Service]
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --inherit-env \
-          --dns=host \
           --net=host \
+          --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --volume etc-machine-id,kind=host,source=/etc/machine-id,readOnly=true \
@@ -183,6 +188,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=true \
           --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
           --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
@@ -216,6 +223,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount volume=etc-kubernetes,target=/etc/kubernetes \
           --volume lib-modules,kind=host,source=/lib/modules,readOnly=true \

--- a/pkg/templates/node_1.20.go
+++ b/pkg/templates/node_1.20.go
@@ -90,7 +90,10 @@ systemd:
                                       --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
                                       --mount volume=etc-kubernetes-certs,target=/etc/kubernetes/certs \
                                       --volume etc-kube-flannel,kind=host,source=/etc/kube-flannel,readOnly=true \
-                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel"
+                                      --mount volume=etc-kube-flannel,target=/etc/kube-flannel \
+                                      --dns=host \
+                                      --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+                                      --mount volume=dns,target=/etc/resolv.conf"
     - name: flannel-docker-opts.service
       enable: true
       contents: |
@@ -112,8 +115,10 @@ systemd:
         [Service]
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --inherit-env \
-          --dns=host \
           --net=host \
+          --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --volume etc-machine-id,kind=host,source=/etc/machine-id,readOnly=true \
@@ -184,6 +189,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=true \
           --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
           --volume etc-kubernetes-certs,kind=host,source=/etc/kubernetes/certs,readOnly=true \
@@ -217,6 +224,8 @@ systemd:
           --inherit-env \
           --net=host \
           --dns=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
           --volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount volume=etc-kubernetes,target=/etc/kubernetes \
           --volume lib-modules,kind=host,source=/lib/modules,readOnly=true \


### PR DESCRIPTION
This PR addresses #607. We bind-mount the host `resolv.conf` into the rkt container and changes on the host side are also reflected in the container. This should prevent that a rkt container starts with an empty `resolv.conf`. The change is made for all services run by rkt on the nodes namely kube-proxy, kubelet, wormhole and flannel.