### PR TITLE
Add static socat to apiserver image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -3,7 +3,7 @@ imagesForVersion:
     supported: true
     apiserver:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
-      tag: 'v1.20.8-sap.1'
+      tag: 'v1.20.8-sap.2'
     controllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.20.8'
@@ -139,7 +139,7 @@ imagesForVersion:
     supported: true
     apiserver:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
-      tag: 'v1.19.11-sap.1'
+      tag: 'v1.19.11-sap.2'
     controllerManager:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.19.11'

--- a/contrib/all/Dockerfile.apiserver
+++ b/contrib/all/Dockerfile.apiserver
@@ -4,8 +4,22 @@ FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/golang:1.16-alpine
  
 WORKDIR /
 ADD api-liveness.go .
-RUN CGO_ENABLED=0 go build -o /api-liveness /api-liveness.go 
+RUN CGO_ENABLED=0 go build -o /api-liveness /api-liveness.go
+
+FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine AS socat
+RUN apk --update add build-base bash automake git curl linux-headers
+ARG SOCAT_VERSION=1.7.4.1
+WORKDIR /build
+RUN curl -LO http://www.dest-unreach.org/socat/download/socat-${SOCAT_VERSION}.tar.gz \
+    && tar xzvf socat-${SOCAT_VERSION}.tar.gz \
+    && cd socat-${SOCAT_VERSION} \
+    && CC='/usr/bin/gcc -static' CFLAGS='-fPIC' CPPFLAGS='-I/build -DNETDB_INTERNAL=-1' ./configure \
+    && make -j4 \
+    && strip socat \
+    && mv socat /socat
 
 FROM $IMAGE
 COPY --from=builder /api-liveness /api-liveness
+COPY --from=socat /socat /usr/bin/socat
+RUN ["socat", "-V"]
 LABEL source_repository="https://github.com/kubernetes/kubernetes"


### PR DESCRIPTION
Haven't tested if this actually works with spore drill but the socat binary can be executed inside the container. Needs some manual testing and ultimately a bump in the images.yaml 