### PR TITLE
WIP: Enable basic k8s audit logging

### DIFF
--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -244,6 +244,11 @@ spec:
             - --oidc-username-prefix=-
             - --oidc-username-claim=name
             {{ end }}
+            - --audit-log-path=-
+            - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+            - --audit-log-batch-max-wait=5s
+            - --audit-log-batch-max-size=50
+            - --audit-log-mode=batch
           volumeMounts:
             - mountPath: /etc/kubernetes/certs
               name: certs
@@ -260,6 +265,9 @@ spec:
             {{- end }}
             - mountPath: /etc/kubernetes/bootstrap
               name: bootstrap
+              readOnly: true
+            - mountPath: /etc/kubernetes/config
+              name: config
               readOnly: true
 {{- if and (.Values.etcd.backup.enabled) (semverCompare "< 1.19" .Values.version.kubernetes) }}
             - mountPath: /liveness-probe

--- a/charts/kube-master/templates/configmap.yaml
+++ b/charts/kube-master/templates/configmap.yaml
@@ -85,3 +85,26 @@ data:
     except requests.exceptions.RequestException as e:
       print e
       sys.exit(0)
+  audit-policy.yaml: |-
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    # Don't generate audit events for all requests in Request & RequestReceived stage.
+    omitStages:
+      - RequestReceived
+    rules:
+      - level: None
+        users:
+          - system:serviceaccount:kube-system:generic-garbage-collector
+      - level: Metadata
+        verbs: ["create", "update", "patch"]
+        resources:
+          - group: ""
+            resources: ["namespaces", "persistentvolumeclaims", "persistentvolumes", "configmaps", "secrets", "serviceaccounts", "services"]
+          - group: apps
+            resources: ["deployments", "daemonsets", "statefulsets"]
+          - group: extensions
+            resources: ["deployments", "daemonsets", "statefulsets", "ingresses"]
+          - group: networking.k8s.io
+          - group: rbac.authorization.k8s.io
+      - level: Metadata
+        verbs: ["delete"]


### PR DESCRIPTION
Logging is performed to stdout so it can be shipped with the normal log shipping we use in our clusters.

Open questions:
* refine the policy of what is logged based on tests in a bigger cluster (e.g. scaleout)
* enable by default would mean we generate log output for all customer clusters which might be heavily used and put a burden on our logging stack
  * Maybe we should log to file and upload to swift instead?