### PR TITLE
Switch to golangci-lint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,7 @@ jobs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.42.1
+        args: -v --timeout 5m
     - name: Tests
       run: /bin/bash -c make gotest
     - name: Build e2e

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,13 +8,6 @@ on:
 name: Tests
 jobs:
   test:
-    env:
-      GOPATH: ${{ github.workspace }}
-      GO111MODULE: off
-      GOMETALINTER_BIN: /home/runner/bin/gometalinter
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/sapcc/kubernikus
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x, 1.17.x]
@@ -27,20 +20,12 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
-      with:
-        path: ${{ env.GOPATH }}/src/github.com/sapcc/kubernikus
-    - name: Setup
-      run: |
-        mkdir -p ~/bin
-        echo "$HOME/bin" >> $GITHUB_PATH
-        env
     - name: Cache
       uses: actions/cache@v2
       with:
         path: |
-          ${{ env.GOPATH }}/pkg/mod # Module download cache
+          ~/go/pkg/mod
           ~/.cache/go-build         # Build cache (Linux)
-          ~/bin
         key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ matrix.go-version }}-
@@ -51,7 +36,6 @@ jobs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.42.1
-        args: -v --timeout 5m
     - name: Tests
       run: /bin/bash -c make gotest
     - name: Build e2e

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,25 +44,19 @@ jobs:
         key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ matrix.go-version }}-
-    - name: Install tooling
-      run: |
-        if [ ! -f "$GOMETALINTER_BIN" ]; then
-          curl -Lf https://github.com/alecthomas/gometalinter/releases/download/v2.0.11/gometalinter-2.0.11-linux-amd64.tar.gz | tar --strip-components=1 -C ~/bin -zxv
-        fi
     - name: Build
       run: make all
-    - name: gofmt
-      run: make gofmt
-    - name: Linters
-      run: make linters
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+        version: v1.42.1
     - name: Tests
       run: /bin/bash -c make gotest
     - name: Build e2e
       run: make build-e2e
     - name: Charts
       run: make test-charts
-    - name: Loopref
-      run: make test-loopref
 #    - name: Slack
 #      uses: 8398a7/action-slack@v3
 #      with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,18 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+  - deadcode
+  - exportloopref
+  - gci
+  - gofmt
+  disable:
+  - errcheck
+  - gosimple
+issues:
+  fix: false
+linters-settings:
+  gci:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/sapcc/kubernikus

--- a/Dockerfile.kubernikus
+++ b/Dockerfile.kubernikus
@@ -1,14 +1,11 @@
 ARG DOCS_IMAGE=keppel.eu-de-1.cloud.sap/ccloud/kubernikus-docs-builder:latest
 FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/golang:1.16-alpine3.13 as builder
-WORKDIR /go/src/github.com/sapcc/kubernikus/
-RUN apk add --no-cache make git curl
-RUN curl -Lf https://github.com/alecthomas/gometalinter/releases/download/v2.0.11/gometalinter-2.0.11-linux-amd64.tar.gz \
-		| tar --strip-components=1 -C /usr/local/bin -zxv \
-		&& gometalinter --version
+WORKDIR /app
+RUN apk add --no-cache make git curl gcc musl-dev
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
 COPY . .
 ARG VERSION
-#We run gofmt and linter before compiling for faster feedback
-RUN make gofmt linters
+RUN make linters
 RUN make all
 RUN make gotest
 RUN make build-e2e
@@ -28,6 +25,5 @@ COPY charts/ /etc/kubernikus/charts
 COPY --from=builder /go/src/github.com/sapcc/kubernikus/bin/linux/kubernikus \
 	                  /go/src/github.com/sapcc/kubernikus/bin/linux/apiserver \
 										/go/src/github.com/sapcc/kubernikus/bin/linux/wormhole /usr/local/bin/
-#COPY --from=kubernikus-binaries /kubernikusctl /static/binaries/linux/amd64/kubernikusctl
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["apiserver"]

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ endif
 GO_SWAGGER_VERSION := v0.18.0
 SWAGGER_BIN        ?= bin/$(GOOS)/swagger-$(GO_SWAGGER_VERSION)
 
-GOMETALINTER_BIN ?= gometalinter
-
 .PHONY: all test clean code-gen vendor
 
 all: $(BINARIES:%=bin/$(GOOS)/%)

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ bin/$(GOOS)/swagger-%:
 bin/%: $(GOFILES) Makefile
 	GOOS=$(*D) GOARCH=amd64 go build $(GOFLAGS) -v -o $(@D)/$(@F) ./cmd/$(basename $(@F))
 
-test: gofmt linters gotest build-e2e
+test: linters gotest build-e2e
 
 gofmt:
 	test/gofmt.sh pkg/ cmd/ test/
 
 linters:
-	$(GOMETALINTER_BIN) --deadline=60s --vendor -s generated --disable-all -E vet -E ineffassign -E misspell ./cmd/... ./pkg/... ./test/...
+	golangci-lint run -v
 
 gotest:
 	# go 1.11 requires gcc for go test because of reasons: https://github.com/golang/go/issues/28065 (CGO_ENABLED=0 fixes this)

--- a/pkg/api/handlers/create_cluster.go
+++ b/pkg/api/handlers/create_cluster.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/validate"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/api/handlers/terminate_cluster.go
+++ b/pkg/api/handlers/terminate_cluster.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/api/models/flavor_sorter.go
+++ b/pkg/api/models/flavor_sorter.go
@@ -22,8 +22,8 @@ func (fs *flavorSorter) Swap(i, j int) {
 }
 
 func (fs *flavorSorter) Less(i, j int) bool {
-	if fs.flavors[i].RAM <= fs.flavors[j].RAM {
-		return true
+	if fs.flavors[i].RAM == fs.flavors[j].RAM {
+		return fs.flavors[i].Vcpus < fs.flavors[j].Vcpus
 	}
-	return fs.flavors[i].Vcpus < fs.flavors[i].Vcpus
+	return fs.flavors[i].RAM < fs.flavors[j].RAM
 }

--- a/pkg/api/rest/configure_kubernikus.go
+++ b/pkg/api/rest/configure_kubernikus.go
@@ -33,9 +33,3 @@ func configureTLS(tlsConfig *tls.Config) {
 // scheme value will be set accordingly: "http", "https" or "unix"
 func configureServer(s *http.Server, scheme, addr string) {
 }
-
-// The middleware configuration is for the handler executors. These do not apply to the swagger.json document.
-// The middleware executes after routing but before authentication, binding and validation
-func setupMiddlewares(handler http.Handler) http.Handler {
-	return handler
-}

--- a/pkg/apis/kubernikus/v1/kluster.go
+++ b/pkg/apis/kubernikus/v1/kluster.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	"github.com/sapcc/kubernikus/pkg/util/ip"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var TerminationProtectionAnnotationKey = "kubernikus.cloud.sap/termination-protection"

--- a/pkg/client/openstack/admin/client.go
+++ b/pkg/client/openstack/admin/client.go
@@ -73,13 +73,13 @@ func (c *adminClient) CreateKlusterServiceUser(username, password, domainName, p
 	//Do we need to update or create?
 	description := "Kubernikus kluster service user"
 	if user != nil {
-		user, err = users.Update(c.IdentityClient, user.ID, users.UpdateOpts{
+		_, err = users.Update(c.IdentityClient, user.ID, users.UpdateOpts{
 			Password:         password,
 			DefaultProjectID: projectID,
 			Description:      &description,
 		}).Extract()
 	} else {
-		user, err = users.Create(c.IdentityClient, users.CreateOpts{
+		_, err = users.Create(c.IdentityClient, users.CreateOpts{
 			Name:             username,
 			DomainID:         domainID,
 			Password:         password,

--- a/pkg/cmd/errors.go
+++ b/pkg/cmd/errors.go
@@ -9,7 +9,7 @@ import (
 func CheckError(err error) {
 	if err != nil {
 		if err != context.Canceled {
-			fmt.Fprintf(os.Stderr, fmt.Sprintf("An error occurred: %v\n", err))
+			fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		}
 		os.Exit(1)
 	}

--- a/pkg/cmd/kubernikusctl/common/kubecontext.go
+++ b/pkg/cmd/kubernikusctl/common/kubecontext.go
@@ -117,6 +117,7 @@ func (ktx *KubernikusContext) ProjectID() (string, error) {
 		return "", err
 	}
 	if len(cert.Subject.Province) < 2 {
+		return "", errors.New("Client certificate is missing kubernikus metadata")
 	}
 	//With go 1.16, the order of multivalued fields in parsed certs became unreliable: https://github.com/golang/go/issues/45882
 	for _, p := range cert.Subject.Province {
@@ -124,7 +125,7 @@ func (ktx *KubernikusContext) ProjectID() (string, error) {
 			return p, nil
 		}
 	}
-	return "", errors.Errorf("Client certificate didn't contain OpenStack metadata")
+	return "", errors.New("Client certificate didn't contain OpenStack metadata")
 }
 
 func (ktx *KubernikusContext) MergeAndPersist(rawConfig string) error {

--- a/pkg/cmd/kubernikusctl/common/util.go
+++ b/pkg/cmd/kubernikusctl/common/util.go
@@ -12,7 +12,7 @@ func CheckError(err error) {
 	if err != nil {
 		if err != context.Canceled {
 			klog.V(3).Infof("%+v", err)
-			fmt.Fprintf(os.Stderr, fmt.Sprintf("An error occurred: %v\n", err))
+			fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		}
 		os.Exit(1)
 	}

--- a/pkg/controller/deorbit/deorbiter_test.go
+++ b/pkg/controller/deorbit/deorbiter_test.go
@@ -9,7 +9,6 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"k8s.io/client-go/kubernetes/fake"
 
 	kubernikus_v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -696,7 +696,7 @@ func (op *GroundControl) terminateKluster(kluster *v1.Kluster) error {
 		"project", kluster.Account())
 
 	_, err := op.Clients.Helm.DeleteRelease(kluster.GetName(), helm.DeletePurge(true))
-	if err != nil && !strings.Contains(grpc.ErrorDesc(err), fmt.Sprintf(`release: "%s" not found`, kluster.GetName())) {
+	if err != nil && !strings.Contains(grpc.ErrorDesc(err), fmt.Sprintf(`release: "%s" not found`, kluster.GetName())) { //nolint:staticcheck
 		return err
 	}
 

--- a/pkg/controller/ground/bootstrap/csi/csi.go
+++ b/pkg/controller/ground/bootstrap/csi/csi.go
@@ -209,24 +209,6 @@ func createSecret(client clientset.Interface, secret *v1.Secret) error {
 	return nil
 }
 
-func createService(client clientset.Interface, manifest string) error {
-	template, err := bootstrap.RenderManifest(manifest, nil)
-	if err != nil {
-		return err
-	}
-
-	service, _, err := serializer.NewCodecFactory(clientsetscheme.Scheme).UniversalDeserializer().Decode(template, nil, &v1.Service{})
-	if err != nil {
-		return err
-	}
-
-	if err := bootstrap.CreateOrUpdateService(client, service.(*v1.Service)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func createClusterRoleBinding(client clientset.Interface, manifest string) error {
 	template, err := bootstrap.RenderManifest(manifest, nil)
 	if err != nil {

--- a/pkg/controller/hammertime/hammertime.go
+++ b/pkg/controller/hammertime/hammertime.go
@@ -9,7 +9,6 @@ import (
 	coord_v1beta1 "k8s.io/api/coordination/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -175,5 +174,5 @@ func nodeReadyCondition(node *core_v1.Node) *core_v1.NodeCondition {
 
 func getNodeLease(node *core_v1.Node, clientset kubernetes.Interface) (*coord_v1beta1.Lease, error) {
 	leaseClient := clientset.CoordinationV1beta1().Leases(core_v1.NamespaceNodeLease)
-	return leaseClient.Get(node.Name, meta_v1.GetOptions{})
+	return leaseClient.Get(node.Name, metav1.GetOptions{})
 }

--- a/pkg/controller/launch/pool_manager.go
+++ b/pkg/controller/launch/pool_manager.go
@@ -3,6 +3,10 @@ package launch
 import (
 	"fmt"
 
+	"github.com/go-kit/kit/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	openstack_kluster "github.com/sapcc/kubernikus/pkg/client/openstack/kluster"
@@ -14,10 +18,6 @@ import (
 	"github.com/sapcc/kubernikus/pkg/util"
 	"github.com/sapcc/kubernikus/pkg/util/generator"
 	"github.com/sapcc/kubernikus/pkg/version"
-
-	"github.com/go-kit/kit/log"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type PoolManager interface {

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -91,32 +91,18 @@ func SetMetricKlusterTerminated(klusterName string) {
 }
 
 /*
-kubernikus_node_pool_size{"kluster_id"="<id", "node_pool"="<name>", "image_name"="<name>", "flavor_name"="<name>"} <node_pool_size>
-*/
-func setMetricNodePoolSize(klusterID, nodePoolName, imageName, flavorName string, size int64) {
-	nodePoolSize.With(prometheus.Labels{
-		"kluster_id":  klusterID,
-		"node_pool":   nodePoolName,
-		"image_name":  imageName,
-		"flavor_name": flavorName,
-	}).Set(float64(size))
-}
-
-/*
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="<status>"} < number of nodes in that status >
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="schedulable"} 1
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="running"} 1
 kubernikus_node_pool_status{"kluster_id"="<id", "node_pool"="<name>", "status"="healthy"} 1
 */
 func SetMetricNodePoolStatus(klusterID, nodePoolName string, status map[string]int64) {
-	if status != nil {
-		for s, v := range status {
-			nodePoolStatus.With(prometheus.Labels{
-				"kluster_id": klusterID,
-				"node_pool":  nodePoolName,
-				"status":     s,
-			}).Set(float64(v))
-		}
+	for s, v := range status {
+		nodePoolStatus.With(prometheus.Labels{
+			"kluster_id": klusterID,
+			"node_pool":  nodePoolName,
+			"status":     s,
+		}).Set(float64(v))
 	}
 }
 

--- a/pkg/controller/nodeobservatory/nodeInformer.go
+++ b/pkg/controller/nodeobservatory/nodeInformer.go
@@ -1,7 +1,6 @@
 package nodeobservatory
 
 import (
-	"fmt"
 	"time"
 
 	api_v1 "k8s.io/api/core/v1"
@@ -57,15 +56,4 @@ func (ni *NodeInformer) run() {
 
 func (ni *NodeInformer) close() {
 	close(ni.stopCh)
-}
-
-func (ni *NodeInformer) getNodeByKey(key string) (*api_v1.Node, error) {
-	obj, exists, err := ni.SharedIndexInformer.GetIndexer().GetByKey(key)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, fmt.Errorf("node %s in kluster %s/%s not found", key, ni.kluster.GetNamespace(), ni.kluster.GetName())
-	}
-	return obj.(*api_v1.Node), nil
 }

--- a/pkg/controller/servicing/drain/cordon.go
+++ b/pkg/controller/servicing/drain/cordon.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"

--- a/pkg/controller/servicing/lister.go
+++ b/pkg/controller/servicing/lister.go
@@ -481,23 +481,6 @@ func (d *NodeLister) hasAnnotation(name string) []*core_v1.Node {
 	return found
 }
 
-func (d *NodeLister) withAnnotation(name, expected string) []*core_v1.Node {
-	var found []*core_v1.Node
-
-	for _, node := range d.All() {
-		value, ok := node.ObjectMeta.Annotations[name]
-		if !ok {
-			continue
-		}
-
-		if value == expected {
-			found = append(found, node)
-		}
-	}
-
-	return found
-}
-
 // All logs
 func (l *LoggingLister) All() (nodes []*core_v1.Node) {
 	defer func(begin time.Time) {

--- a/pkg/controller/servicing/testing.go
+++ b/pkg/controller/servicing/testing.go
@@ -5,12 +5,11 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/go-kit/kit/log"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/sapcc/kubernikus/pkg/api/models"
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -592,7 +592,6 @@ const (
 	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
 	rsaKeySize             = 2048
-	duration365d           = time.Hour * 24 * 365
 )
 
 func EncodeCertPEM(cert *x509.Certificate) []byte {

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -15,9 +15,6 @@ import (
 	"github.com/sapcc/kubernikus/pkg/version"
 )
 
-//contains unamibious characters for generic random passwords
-var randomPasswordChars = []rune("abcdefghjkmnpqrstuvwxABCDEFGHJKLMNPQRSTUVWX23456789")
-
 var ETCDBackupAnnotation = "kubernikus.cloud.sap/backup"
 
 var crc64ISOTable = crc64.MakeTable(crc64.ISO)

--- a/pkg/util/icmp/icmp.go
+++ b/pkg/util/icmp/icmp.go
@@ -15,8 +15,6 @@ const (
 	ProtocolIP       = 0  // IPv4 encapsulation, pseudo protocol number
 	ProtocolICMP     = 1  //Internet Control Message
 	ProtocolIPv6ICMP = 58 // ICMP for IPv6
-
-	sysIP_STRIPHDR = 0x17 // for now only darwin supports this option
 )
 
 var random = rand.New(rand.NewSource(int64(os.Getpid())))
@@ -69,7 +67,7 @@ func (l *Listener) Read() (*Message, error) {
 
 	switch msg.Type {
 	case ipv4.ICMPTypeRedirect:
-		msg.Body, err = parseRedirectMessageBody(ProtocolICMP, msg.Body.(*icmp.DefaultMessageBody).Data)
+		msg.Body, err = parseRedirectMessageBody(ProtocolICMP, msg.Body.(*icmp.RawBody).Data)
 	}
 
 	return &Message{Message: msg, Peer: peer}, err

--- a/pkg/util/icmp/redirect.go
+++ b/pkg/util/icmp/redirect.go
@@ -36,6 +36,7 @@ func parseRedirectMessageBody(proto int, b []byte) (icmp.MessageBody, error) {
 	p := &Redirect{NextHop: net.IPv4(b[0], b[1], b[2], b[3])}
 	header, err := ipv4.ParseHeader(b[4:])
 	if err != nil {
+		return nil, err
 	}
 	p.Header = header
 	p.Data = b[4+header.Len:]

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -11,12 +11,11 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"k8s.io/apimachinery/pkg/util/sets"
-	utilexec "k8s.io/utils/exec"
-
 	"golang.org/x/sys/unix"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilexec "k8s.io/utils/exec"
 
 	utilversion "github.com/sapcc/kubernikus/pkg/util/version"
 )
@@ -462,7 +461,7 @@ const (
 	opCreateChain operation = "-N"
 	opFlushChain  operation = "-F"
 	opDeleteChain operation = "-X"
-	opAppendRule  operation = "-A"
+	opAppendRule  operation = "-A" //nolint:deadcode,varcheck
 	opCheckRule   operation = "-C"
 	opDeleteRule  operation = "-D"
 )
@@ -595,15 +594,6 @@ func getIPTablesRestoreVersionString(exec utilexec.Interface) (string, error) {
 // AddReloadFunc is part of Interface
 func (runner *runner) AddReloadFunc(reloadFunc func()) {
 	runner.reloadFuncs = append(runner.reloadFuncs, reloadFunc)
-}
-
-// runs all reload funcs to re-sync iptables rules
-func (runner *runner) reload() {
-	runner.logger.Log(
-		"msg", "reloading iptables rules")
-	for _, f := range runner.reloadFuncs {
-		f()
-	}
 }
 
 // IsNotFoundError returns true if the error indicates "not found".  It parses

--- a/pkg/util/log/middleware.go
+++ b/pkg/util/log/middleware.go
@@ -39,7 +39,7 @@ func LoggingHandler(logger kitlog.Logger, next http.Handler) http.Handler {
 			id := fmt.Sprintf("%s", reqId)
 			inner_logger = kitlog.With(inner_logger, "id", id)
 		}
-		request = request.WithContext(context.WithValue(request.Context(), "logger", inner_logger))
+		request = request.WithContext(context.WithValue(request.Context(), "logger", inner_logger)) //nolint:staticcheck
 
 		defer func(begin time.Time) {
 			var keyvals = make([]interface{}, 0, 4)
@@ -102,7 +102,7 @@ func makeWrapper(w http.ResponseWriter) loggingResponseWriter {
 		logger = &hijackLogger{responseLogger{w: w, status: http.StatusOK}}
 	}
 	h, ok1 := logger.(http.Hijacker)
-	c, ok2 := w.(http.CloseNotifier)
+	c, ok2 := w.(http.CloseNotifier) //nolint:staticcheck
 	if ok1 && ok2 {
 		return hijackCloseNotifier{logger, h, c}
 	}

--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -17,10 +17,9 @@ limitations under the License.
 package prometheus
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Package prometheus sets the workqueue DefaultMetricsFactory to produce

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/sapcc/kubernikus/pkg/util/generator"
 	"github.com/sapcc/kubernikus/test/e2e/framework"

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -29,7 +29,6 @@ const (
 	RegisteredTimeout                  = 15 * time.Minute // Time from node created to registered
 	StateSchedulableTimeout            = 1 * time.Minute  // Time from registered to schedulable
 	StateHealthyTimeout                = 1 * time.Minute
-	ConditionRouteBrokenTimeout        = 1 * time.Minute
 	ConditionNetworkUnavailableTimeout = 1 * time.Minute
 	ConditionReadyTimeout              = 1 * time.Minute
 )


### PR DESCRIPTION
gometalinter is deprecated for a while now.

golangci-lint contains more linters and also included gofmt,goimmports and exportloopref so no need to run those seperatly 

~I'm not sure how to test the GitHub action thingy. I just copied the example from golanglint-ci~ Tested it and it works!