### PR TITLE
Skip servicing if maintenance-controller is assumed

### DIFF
--- a/pkg/controller/servicing/controller_test.go
+++ b/pkg/controller/servicing/controller_test.go
@@ -281,6 +281,26 @@ func TestServicingControllerReconcile(t *testing.T) {
 			expectedReboot:  false,
 			expectedReplace: false,
 		},
+		{
+			message: "Klusters assumed to be maintained by the maintenance-controller should neither be rebooted nor replaced",
+			options: &FakeKlusterOptions{
+				Phase: models.KlusterPhaseRunning,
+				NodePools: []FakeNodePoolOptions{
+					{
+						AllowReboot:         true,
+						AllowReplace:        true,
+						NodeHealthy:         true,
+						NodeOSOutdated:      true,
+						NodeKubeletOutdated: true,
+						Size:                2,
+						Labels:              []string{"cloud.sap/maintenance-profile=flatcar"},
+					},
+				},
+			},
+			expectedDrain:   false,
+			expectedReboot:  false,
+			expectedReplace: false,
+		},
 	} {
 		t.Run(string(subject.message), func(t *testing.T) {
 			kluster, nodes := NewFakeKluster(subject.options, true)

--- a/pkg/controller/servicing/reconciler.go
+++ b/pkg/controller/servicing/reconciler.go
@@ -118,7 +118,12 @@ func (r *KlusterReconciler) Do() error {
 	}
 
 	if util.DisabledValue(r.Kluster.ObjectMeta.Annotations[AnnotationServicingSafeguard]) {
-		r.Logger.Log("msg", "Skippig upgrades. Manually disabled with safeguard annotation.")
+		r.Logger.Log("msg", "Skippig upgrades. Manually disabled with safeguard annotation.", "v", 2)
+		return nil
+	}
+
+	if len(r.Lister.Maintained()) > 0 {
+		r.Logger.Log("msg", "Skipping upgrades. At least one node seems to be maintained by the maintenance-controller.", "v", 2)
 		return nil
 	}
 

--- a/pkg/controller/servicing/testing.go
+++ b/pkg/controller/servicing/testing.go
@@ -3,6 +3,7 @@ package servicing
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -47,6 +48,7 @@ type FakeNodePoolOptions struct {
 	NodeKubeletOutdated bool
 	NodeUpdating        *time.Time
 	Size                int
+	Labels              []string
 }
 
 // NewFakeKluster creates a Kluster Object for tests
@@ -81,15 +83,23 @@ func NewFakeKluster(opts *FakeKlusterOptions, afterFlatCarRktRemoval bool) (*v1.
 				AllowReplace: &allowReboot,
 				AllowReboot:  &allowReplace,
 			},
+			Labels: p.Labels,
 		}
 		kluster.Spec.NodePools = append(kluster.Spec.NodePools, pool)
 
 		for j := 0; j < p.Size; j++ {
+			labels := make(map[string]string)
+			for _, label := range p.Labels {
+				splitted := strings.Split(label, "=")
+				labels[splitted[0]] = splitted[1]
+			}
+
 			nodeName := fmt.Sprintf("test-%s-0000%d", poolName, j)
 			node := &core_v1.Node{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:        nodeName,
 					Annotations: map[string]string{},
+					Labels:      labels,
 				},
 				Status: core_v1.NodeStatus{
 					Phase:    core_v1.NodeRunning,


### PR DESCRIPTION
The servicing controller now skips clusters, which have at least one node
with the "cloud.sap/maintenance-profile" label set, which in turn indicates
the presence of sapcc/maintenance-controller.