### PR TITLE
Make node update holdoff configurable

### DIFF
--- a/charts/kubernikus/templates/operator.yaml
+++ b/charts/kubernikus/templates/operator.yaml
@@ -56,6 +56,9 @@ spec:
             - --region={{ .Values.openstack.region }}
             {{- end }}
             {{- end }}
+            {{- if .Values.operator.nodeUpdateHoldoff }}
+            - --node-update-holdoff={{ .Values.operator.nodeUpdateHoldoff }}
+            {{- end }}
           env:
             {{- if .Values.operator.nodeAffinity }}
             - name: NODEPOOL_AFFINITY

--- a/pkg/cmd/kubernikus/operator.go
+++ b/pkg/cmd/kubernikus/operator.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -52,6 +53,7 @@ func NewOperatorOptions() *Options {
 	options.MetricPort = 9091
 	options.Controllers = []string{"groundctl", "launchctl", "deorbiter", "routegc", "flight", "migration", "hammertime", "servicing", "certs"}
 	options.Region = "eu-de-1"
+	options.NodeUpdateHoldoff = 7 * 24 * time.Hour
 	return options
 }
 
@@ -74,6 +76,8 @@ func (o *Options) BindFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.MetricPort, "metric-port", o.MetricPort, "Port on which metrics are exposed")
 	flags.StringSliceVar(&o.Controllers, "controllers", o.Controllers, fmt.Sprintf("A list of controllers to enable.  Default is to enable all. controllers: %s", strings.Join(o.Controllers, ", ")))
 	flags.IntVar(&o.LogLevel, "v", 0, "log level")
+
+	flags.DurationVar(&o.NodeUpdateHoldoff, "node-update-holdoff", o.NodeUpdateHoldoff, "Holdoff duration before node update is applied.")
 }
 
 func (o *Options) Validate(c *cobra.Command, args []string) error {

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -56,6 +56,8 @@ type KubernikusOperatorOptions struct {
 	Controllers         []string
 	MetricPort          int
 	LogLevel            int
+
+	NodeUpdateHoldoff time.Duration
 }
 
 type KubernikusOperator struct {
@@ -194,7 +196,7 @@ func NewKubernikusOperator(options *KubernikusOperatorOptions, logger log.Logger
 		case "hammertime":
 			o.Config.Kubernikus.Controllers["hammertime"] = hammertime.New(10*time.Second, 20*time.Second, o.Factories, o.Clients, recorder, logger)
 		case "servicing":
-			o.Config.Kubernikus.Controllers["servicing"] = servicing.NewController(10, o.Factories, o.Clients, recorder, logger)
+			o.Config.Kubernikus.Controllers["servicing"] = servicing.NewController(10, o.Factories, o.Clients, recorder, options.NodeUpdateHoldoff, logger)
 		case "certs":
 			o.Config.Kubernikus.Controllers["certs"] = certs.New(12*time.Hour, o.Factories, o.Config, o.Clients, logger)
 		}

--- a/pkg/controller/servicing/controller.go
+++ b/pkg/controller/servicing/controller.go
@@ -48,13 +48,13 @@ type Controller struct {
 }
 
 // NewController is a helper to create a Servicing Controller instance
-func NewController(threadiness int, factories config.Factories, clients config.Clients, recorder record.EventRecorder, logger log.Logger) base.Controller {
+func NewController(threadiness int, factories config.Factories, clients config.Clients, recorder record.EventRecorder, holdoff time.Duration, logger log.Logger) base.Controller {
 	logger = log.With(logger, "controller", "servicing")
 
 	var controller base.Reconciler
 	controller = &Controller{
 		Logger:     logger,
-		Reconciler: NewKlusterReconcilerFactory(logger, recorder, factories, clients),
+		Reconciler: NewKlusterReconcilerFactory(logger, recorder, factories, clients, holdoff),
 	}
 
 	RegisterServicingNodesCollector(logger, factories)

--- a/pkg/controller/servicing/flatcar/releases.go
+++ b/pkg/controller/servicing/flatcar/releases.go
@@ -15,7 +15,6 @@ import (
 var (
 	versionURL   = "https://%s.release.flatcar-linux.net/amd64-usr/%s/version.txt"
 	timeREString = `%s\s*FLATCAR_BUILD_ID="(.+)"`
-	holdoff      = 7 * 24 * time.Hour
 )
 
 type Release struct {
@@ -83,7 +82,7 @@ func (r *Release) fetch(c channel, v *version.Version) (time.Time, error) {
 	return t, nil
 }
 
-func (r *Release) GrownUp(v *version.Version) (bool, error) {
+func (r *Release) GrownUp(v *version.Version, holdoff time.Duration) (bool, error) {
 	released, err := r.releasedAt(stable, v)
 	if err != nil {
 		return false, err

--- a/pkg/controller/servicing/flatcar/releases_test.go
+++ b/pkg/controller/servicing/flatcar/releases_test.go
@@ -16,14 +16,14 @@ func TestReleaseGrownup(t *testing.T) {
 	subject := &Release{}
 	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2303.4.0/version.txt", ReleasesStable, &count)
 	t.Run("fetches versions", func(t *testing.T) {
-		_, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"))
+		_, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"), 7*24*time.Hour)
 		assert.NoError(t, err)
 	})
 
 	subject = &Release{}
 	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2079.99.0/version.txt", ReleasesStable, &count)
 	t.Run("unknown version", func(t *testing.T) {
-		result, err := subject.GrownUp(version.MustParseSemantic("2079.99.0"))
+		result, err := subject.GrownUp(version.MustParseSemantic("2079.99.0"), 7*24*time.Hour)
 		assert.Error(t, err)
 		assert.False(t, result)
 	})
@@ -31,7 +31,7 @@ func TestReleaseGrownup(t *testing.T) {
 	subject = &Release{}
 	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2303.4.0/version.txt", ReleasesStable, &count)
 	t.Run("holdoff time not up yet", func(t *testing.T) {
-		result, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"))
+		result, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"), 7*24*time.Hour)
 		assert.NoError(t, err)
 		assert.False(t, result)
 	})
@@ -40,7 +40,7 @@ func TestReleaseGrownup(t *testing.T) {
 	subject.Client = NewTestClient(t, "https://stable.release.flatcar-linux.net/amd64-usr/2303.4.0/version.txt", ReleasesStable, &count)
 	t.Run("holdoff time up", func(t *testing.T) {
 		now = func() time.Time { return time.Date(2020, 2, 15, 10, 11, 0, 0, time.UTC) }
-		result, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"))
+		result, err := subject.GrownUp(version.MustParseSemantic("2303.4.0"), 7*24*time.Hour)
 		assert.NoError(t, err)
 		assert.True(t, result)
 	})

--- a/pkg/controller/servicing/reconciler.go
+++ b/pkg/controller/servicing/reconciler.go
@@ -67,10 +67,10 @@ type (
 )
 
 // NewKlusterReconcilerFactory produces a new Factory
-func NewKlusterReconcilerFactory(logger log.Logger, recorder record.EventRecorder, factories config.Factories, clients config.Clients) ReconcilerFactory {
+func NewKlusterReconcilerFactory(logger log.Logger, recorder record.EventRecorder, factories config.Factories, clients config.Clients, holdoff time.Duration) ReconcilerFactory {
 	return &KlusterReconcilerFactory{
 		Logger:            logger,
-		ListerFactory:     NewNodeListerFactory(logger, recorder, factories, clients),
+		ListerFactory:     NewNodeListerFactory(logger, recorder, factories, clients, holdoff),
 		LifeCyclerFactory: NewNodeLifeCyclerFactory(logger, recorder, factories, clients),
 		KlusterLister:     factories.Kubernikus.Kubernikus().V1().Klusters().Lister(),
 		KubernikusClient:  clients.Kubernikus.KubernikusV1(),


### PR DESCRIPTION
This PR makes node update holdoff time configurable. Default is still 7 days.