### PR TITLE
Add new line to kluster prints

### DIFF
--- a/pkg/api/models/kluster_print.go
+++ b/pkg/api/models/kluster_print.go
@@ -50,11 +50,11 @@ func (k *Kluster) printTable(options printers.PrintOptions) {
 	if options.WithHeaders {
 		fmt.Print("NAME")
 		fmt.Print("\t")
-		fmt.Print("STATUS")
+		fmt.Println("STATUS")
 	}
 	fmt.Print(k.Name)
 	fmt.Print("\t")
-	fmt.Print(k.Status.Phase)
+	fmt.Println(k.Status.Phase)
 }
 
 func (p NodePool) GetFormats() map[printers.PrintFormat]struct{} {


### PR DESCRIPTION
`kubernikusctl get cluster` results in only one line, because new lines are not added

Not sure whether any test needs to be changed because of this.
Changing the table print for `get cluster` command output.

To compare see [func (p NodePool) printTable](https://github.com/sapcc/kubernikus/blob/master/pkg/api/models/kluster_print.go#L91).