### PR TITLE
Remove deprecated spec.template.spec.nodeSelector

### DIFF
--- a/pkg/controller/ground/bootstrap/dns/coredns.go
+++ b/pkg/controller/ground/bootstrap/dns/coredns.go
@@ -260,7 +260,7 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: coredns
         image: {{ .Image }}
@@ -385,7 +385,7 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: coredns
         image: {{ .Image }}

--- a/scripts/coredns/deployment.yaml
+++ b/scripts/coredns/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           readOnly: true
       dnsPolicy: Default
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
spec.template.spec.nodeSelector[beta.kubernetes.io/os] is deprecated since v1.14, so it might be good to replace it with `kubernetes.io/os`