### PR TITLE
Switch to keppel.global for container images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,826 +2,826 @@ imagesForVersion:
   '1.22.4':
     supported: true
     apiserver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.22.4'
     controllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.22.4'
     scheduler:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.22.4'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     kubelet:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      repository: 'keppel.global.cloud.sap/ccloud/kubelet'
       tag: 'v1.22.4'
     kubeProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-proxy'
       tag: 'v1.22.4'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.22.0'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     csiAttacher:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-attacher'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-attacher'
       tag: 'v3.3.0'
     csiProvisioner:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-provisioner'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-provisioner'
       tag: 'v3.0.0'
     csiSnapshotter:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshotter'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshotter'
       tag: 'v4.2.1'
     csiSnapshotController:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshot-controller'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshot-controller'
       tag: 'v4.2.1'
     csiResizer:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-resizer'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-resizer'
       tag: 'v1.3.0'
     csiLivenessProbe:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-livenessprobe'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-livenessprobe'
       tag: 'v2.4.0'
     csiNodeDriver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-node-driver-registrar'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-node-driver-registrar'
       tag: 'v2.3.0'
     cinderCSIPlugin:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
+      repository: 'keppel.global.cloud.sap/ccloud/cinder-csi-plugin'
       tag: 'v1.22.0'
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.21.5':
     supported: true
     apiserver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.21.5'
     controllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.21.5'
     scheduler:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.21.5'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     kubelet:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      repository: 'keppel.global.cloud.sap/ccloud/kubelet'
       tag: 'v1.21.5'
     kubeProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-proxy'
       tag: 'v1.21.5'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.22.0'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     csiAttacher:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-attacher'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-attacher'
       tag: 'v3.3.0'
     csiProvisioner:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-provisioner'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-provisioner'
       tag: 'v3.0.0'
     csiSnapshotter:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshotter'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshotter'
       tag: 'v4.2.1'
     csiSnapshotController:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshot-controller'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshot-controller'
       tag: 'v4.2.1'
     csiResizer:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-resizer'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-resizer'
       tag: 'v1.3.0'
     csiLivenessProbe:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-livenessprobe'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-livenessprobe'
       tag: 'v2.4.0'
     csiNodeDriver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-node-driver-registrar'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-node-driver-registrar'
       tag: 'v2.3.0'
     cinderCSIPlugin:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
+      repository: 'keppel.global.cloud.sap/ccloud/cinder-csi-plugin'
       tag: 'v1.22.0'
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.20.8':
     default: true
     supported: true
     apiserver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.20.8-sap.2'
     controllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.20.8'
     scheduler:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.20.8'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     kubelet:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      repository: 'keppel.global.cloud.sap/ccloud/kubelet'
       tag: 'v1.20.8-sap.1'
     kubeProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-proxy'
       tag: 'v1.20.8'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.21.0'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     csiAttacher:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-attacher'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-attacher'
       tag: 'v2.2.1'
     csiProvisioner:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-provisioner'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-provisioner'
       tag: 'v2.1.0'
     csiSnapshotter:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshotter'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshotter'
       tag: 'v2.1.3'
     csiSnapshotController:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshot-controller'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshot-controller'
       tag: 'v2.1.3'
     csiResizer:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-resizer'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-resizer'
       tag: 'v0.5.1'
     csiLivenessProbe:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-livenessprobe'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-livenessprobe'
       tag: 'v2.4.0'
     csiNodeDriver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-node-driver-registrar'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-node-driver-registrar'
       tag: 'v1.3.0'
     cinderCSIPlugin:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
+      repository: 'keppel.global.cloud.sap/ccloud/cinder-csi-plugin'
       tag: 'v1.21.0'
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.20.6':
     supported: false
     apiserver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.20.6'
     controllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.20.6'
     scheduler:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.20.6'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     kubelet:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      repository: 'keppel.global.cloud.sap/ccloud/kubelet'
       tag: 'v1.20.6'
     kubeProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-proxy'
       tag: 'v1.20.6'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.20.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     csiAttacher:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-attacher'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-attacher'
       tag: 'v2.2.1'
     csiProvisioner:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-provisioner'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-provisioner'
       tag: 'v2.1.0'
     csiSnapshotter:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshotter'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshotter'
       tag: 'v2.1.3'
     csiSnapshotController:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshot-controller'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-snapshot-controller'
       tag: 'v2.1.3'
     csiResizer:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-resizer'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-resizer'
       tag: 'v0.5.1'
     csiLivenessProbe:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-livenessprobe'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-livenessprobe'
       tag: 'v2.4.0'
     csiNodeDriver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-node-driver-registrar'
+      repository: 'keppel.global.cloud.sap/ccloud/csi-node-driver-registrar'
       tag: 'v1.3.0'
     cinderCSIPlugin:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
+      repository: 'keppel.global.cloud.sap/ccloud/cinder-csi-plugin'
       tag: 'v1.20.3'
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.19.11':
     supported: true
     apiserver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.19.11-sap.2'
     controllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.19.11'
     scheduler:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.19.11'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     kubelet:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      repository: 'keppel.global.cloud.sap/ccloud/kubelet'
       tag: 'v1.19.11-sap.1'
     kubeProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-proxy'
       tag: 'v1.19.11'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.19.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.19.4':
     supported: false
     apiserver:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.19.4'
     controllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-controller-manager'
       tag: 'v1.19.4'
     scheduler:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-scheduler'
       tag: 'v1.19.4'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     kubelet:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      repository: 'keppel.global.cloud.sap/ccloud/kubelet'
       tag: 'v1.19.4'
     kubeProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      repository: 'keppel.global.cloud.sap/ccloud/kube-proxy'
       tag: 'v1.19.4'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.19.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.18.10':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.18.10'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.18.0'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.17.13':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.17.13'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud/openstack-cloud-controller-manager'
       tag: 'v1.17.0'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.16.14':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.16.14'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.16.0'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.16.9':
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.16.9'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.16.0'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.15.9':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.15.9'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.15.0-sap.2'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.15.2':
     supported: false
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.15.2'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.15.0-sap.2'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta4'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.14.5':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.14.5'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.14.0-sap.0'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta1'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.13.9':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.13.9'
     cloudControllerManager:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/openstack-cloud-controller-manager'
       tag: 'v1.13.1'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta1'
     coreDNS:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
       tag: '1.6.2'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.12.10':
     supported: true
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.12.10'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
       tag: 'v2.0.0-beta1'
     pause:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
       tag: '3.1'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.11.9':
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.11.9'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     dashboardProxy:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      repository: 'keppel.global.cloud.sap/ccloud/keycloak-gatekeeper'
       tag: '6.0.1'
     dashboard:
       repository: 'sapcc/kubernetes-dashboard-amd64'
       tag: 'v1.10.1'
     wormhole:
-      repository: keppel.$REGION.cloud.sap/ccloud/kubernikus
+      repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.10.11':
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.10.11'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.10.7':
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.10.7'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'
   '1.10.1':
     hyperkube:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/hyperkube'
       tag: 'v1.10.1'
     etcd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
       tag: 'v3.3.14'
     etcdBackup:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      repository: 'keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
       tag: '0.5.2'
     dex:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      repository: 'keppel.global.cloud.sap/ccloud/dex'
       tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
     wormhole:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus'
       tag: 'changeme' #this is injected to match the operator so far
     flannel:
-      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      repository: 'keppel.global.cloud.sap/ccloud-quay-mirror/coreos/flannel'
       tag: 'v0.12.0'
     fluentd:
-      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      repository: 'keppel.global.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14-1'


### PR DESCRIPTION
- [x] Switch to keppel.global for all regions to get a fallback in case keppel is down in the region.
- [ ] Switch all references to upstream images we currently vendor unchanged keppel/ccloud to use a proper keppel mirror (e.g. `keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror`)
  - kube-scheduler
  - kube-controller-manager
  - kube-proxy
  - openstack-cloud-controller-manger
  - csi-*
  - cinder-csi-plugin 