### PR TITLE
Add cgroupsV1 flag to nodepools

### DIFF
--- a/pkg/api/handlers/update_cluster.go
+++ b/pkg/api/handlers/update_cluster.go
@@ -67,6 +67,10 @@ func (d *updateCluster) Handle(params operations.UpdateClusterParams, principal 
 
 				nodePools[i].AvailabilityZone = specPool.AvailabilityZone
 
+				if paramPool.CgroupsV1 == nil {
+					nodePools[i].CgroupsV1 = specPool.CgroupsV1
+				}
+
 				if paramPool.Config == nil {
 					nodePools[i].Config = specPool.Config
 				} else {

--- a/pkg/api/models/node_pool.go
+++ b/pkg/api/models/node_pool.go
@@ -23,6 +23,9 @@ type NodePool struct {
 	// Required: true
 	AvailabilityZone string `json:"availabilityZone"`
 
+	// Fallback to cgroups v1. Ignored for k8s versions < 1.19
+	CgroupsV1 *bool `json:"cgroupsV1"`
+
 	// config
 	Config *NodePoolConfig `json:"config,omitempty"`
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -730,6 +730,12 @@ func init() {
           "type": "string",
           "x-nullable": false
         },
+        "cgroupsV1": {
+          "description": "Fallback to cgroups v1. Ignored for k8s versions \u003c 1.19",
+          "type": "boolean",
+          "x-nullable": true,
+          "x-omitempty": false
+        },
         "config": {
           "$ref": "#/definitions/NodePoolConfig"
         },
@@ -1777,6 +1783,12 @@ func init() {
         "availabilityZone": {
           "type": "string",
           "x-nullable": false
+        },
+        "cgroupsV1": {
+          "description": "Fallback to cgroups v1. Ignored for k8s versions \u003c 1.19",
+          "type": "boolean",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "config": {
           "$ref": "#/definitions/NodePoolConfig"

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -162,6 +162,7 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 		NoCloud                            bool
 		FlannelImage                       string
 		FlannelImageTag                    string
+		CGroupsV1                          bool
 	}{
 		TLSCA:                              secret.TLSCACertificate,
 		KubeletClientsCA:                   secret.KubeletClientsCACertificate,
@@ -203,6 +204,7 @@ func (i *ignition) GenerateNode(kluster *kubernikusv1.Kluster, pool *models.Node
 		NoCloud:                            kluster.Spec.NoCloud,
 		FlannelImage:                       images.Flannel.Repository,
 		FlannelImageTag:                    images.Flannel.Tag,
+		CGroupsV1:                          pool.CgroupsV1 != nil && *pool.CgroupsV1,
 	}
 
 	var dataOut []byte

--- a/pkg/templates/ignition_test.go
+++ b/pkg/templates/ignition_test.go
@@ -93,9 +93,11 @@ func TestGenerateNode(t *testing.T) {
 
 	kluster.Spec.SSHPublicKey = strings.Repeat("a", 10000) //max out ssh key
 
+	pool := &models.NodePool{Name: "some-name"}
+
 	for version := range imageRegistry.Versions {
 		kluster.Spec.Version = version
-		data, err := Ignition.GenerateNode(kluster, nil, "test", &testKlusterSecret, false, imageRegistry, log.NewNopLogger())
+		data, err := Ignition.GenerateNode(kluster, pool, "test", &testKlusterSecret, false, imageRegistry, log.NewNopLogger())
 
 		if assert.NoError(t, err, "Failed to generate node for version %s", version) {
 			//Ensure we rendered the expected template

--- a/pkg/templates/node_1.10.go
+++ b/pkg/templates/node_1.10.go
@@ -17,18 +17,6 @@ passwd:
       system: true
 systemd:
   units:
-    - name: legacy-cgroup-reboot.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Reboot if legacy cgroups are not enabled yet
-        FailureAction=reboot
-        After=extend-filesystems.service
-        [Service]
-        Type=simple
-        ExecStart=/usr/bin/grep 'systemd.unified_cgroup_hierarchy=0' /proc/cmdline
-        [Install]
-        WantedBy=multi-user.target
     - name: iptables-restore.service
       enable: true
     - name: ccloud-metadata-hostname.service
@@ -307,6 +295,9 @@ storage:
       contents:
         inline: |
           set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.11.go
+++ b/pkg/templates/node_1.11.go
@@ -17,18 +17,6 @@ passwd:
       system: true
 systemd:
   units:
-    - name: legacy-cgroup-reboot.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Reboot if legacy cgroups are not enabled yet
-        FailureAction=reboot
-        After=extend-filesystems.service
-        [Service]
-        Type=simple
-        ExecStart=/usr/bin/grep 'systemd.unified_cgroup_hierarchy=0' /proc/cmdline
-        [Install]
-        WantedBy=multi-user.target
     - name: iptables-restore.service
       enable: true
     - name: ccloud-metadata-hostname.service
@@ -293,6 +281,9 @@ storage:
       contents:
         inline: |
           set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.12.go
+++ b/pkg/templates/node_1.12.go
@@ -17,18 +17,6 @@ passwd:
       system: true
 systemd:
   units:
-    - name: legacy-cgroup-reboot.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Reboot if legacy cgroups are not enabled yet
-        FailureAction=reboot
-        After=extend-filesystems.service
-        [Service]
-        Type=simple
-        ExecStart=/usr/bin/grep 'systemd.unified_cgroup_hierarchy=0' /proc/cmdline
-        [Install]
-        WantedBy=multi-user.target
     - name: iptables-restore.service
       enable: true
     - name: ccloud-metadata-hostname.service
@@ -291,6 +279,9 @@ storage:
       contents:
         inline: |
           set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.14.go
+++ b/pkg/templates/node_1.14.go
@@ -17,18 +17,6 @@ passwd:
       system: true
 systemd:
   units:
-    - name: legacy-cgroup-reboot.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Reboot if legacy cgroups are not enabled yet
-        FailureAction=reboot
-        After=extend-filesystems.service
-        [Service]
-        Type=simple
-        ExecStart=/usr/bin/grep 'systemd.unified_cgroup_hierarchy=0' /proc/cmdline
-        [Install]
-        WantedBy=multi-user.target
     - name: iptables-restore.service
       enable: true
     - name: ccloud-metadata-hostname.service
@@ -293,6 +281,9 @@ storage:
       contents:
         inline: |
           set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.17.go
+++ b/pkg/templates/node_1.17.go
@@ -17,18 +17,6 @@ passwd:
       system: true
 systemd:
   units:
-    - name: legacy-cgroup-reboot.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Reboot if legacy cgroups are not enabled yet
-        FailureAction=reboot
-        After=extend-filesystems.service
-        [Service]
-        Type=simple
-        ExecStart=/usr/bin/grep 'systemd.unified_cgroup_hierarchy=0' /proc/cmdline
-        [Install]
-        WantedBy=multi-user.target
     - name: iptables-restore.service
       enable: true
     - name: ccloud-metadata-hostname.service
@@ -294,6 +282,9 @@ storage:
       contents:
         inline: |
           set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644

--- a/pkg/templates/node_1.19.go
+++ b/pkg/templates/node_1.19.go
@@ -43,6 +43,9 @@ systemd:
           contents: |
             [Service]
             Environment="DOCKER_OPTS=--log-opt max-size=5m --log-opt max-file=5 --ip-masq=false --iptables=false --bridge=none"
+            {{- if .CGroupsV1 }}
+            Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs"
+            {{- end }}
     - name: flanneld.service
       enable: true
       contents: |
@@ -275,7 +278,26 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
+  filesystems:
+{{- if .CGroupsV1 }}
+    - name: "OEM"
+      mount:
+        device: "/dev/disk/by-label/OEM"
+        format: "btrfs"
+{{- end }}
   files:
+{{- if .CGroupsV1 }}
+    - filesystem: "OEM"
+      path: "/grub.cfg"
+      mode: 0644
+      append: true
+      contents:
+        inline: |
+          set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
+{{- end }}
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644
@@ -520,7 +542,9 @@ storage:
               enabled: true
           rotateCertificates: true
           nodeLeaseDurationSeconds: 20
+          {{- if not .CGroupsV1 }}
           cgroupDriver: systemd
+          {{- end }}
           featureGates:
     - path: /etc/kubernetes/kube-proxy/config
       filesystem: root

--- a/pkg/templates/node_1.21.go
+++ b/pkg/templates/node_1.21.go
@@ -40,6 +40,9 @@ systemd:
           contents: |
             [Service]
             Environment="DOCKER_OPTS=--log-opt max-size=5m --log-opt max-file=5 --ip-masq=false --iptables=false --bridge=none"
+            {{- if .CGroupsV1 }}
+            Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs"
+            {{- end }}
     - name: flanneld.service
       enable: true
       contents: |
@@ -261,7 +264,26 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 storage:
+  filesystems:
+{{- if .CGroupsV1 }}
+    - name: "OEM"
+      mount:
+        device: "/dev/disk/by-label/OEM"
+        format: "btrfs"
+{{- end }}
   files:
+{{- if .CGroupsV1 }}
+    - filesystem: "OEM"
+      path: "/grub.cfg"
+      mode: 0644
+      append: true
+      contents:
+        inline: |
+          set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
+    - path: /etc/flatcar-cgroupv1
+      filesystem: root
+      mode: 0444
+{{- end }}
     - path: /etc/systemd/resolved.conf
       filesystem: root
       mode: 0644
@@ -506,7 +528,9 @@ storage:
               enabled: true
           rotateCertificates: true
           nodeLeaseDurationSeconds: 20
+          {{- if not .CGroupsV1 }}
           cgroupDriver: systemd
+          {{- end }}
           featureGates:
 {{- if not .NoCloud }}
             CSIMigration: true

--- a/swagger.yml
+++ b/swagger.yml
@@ -580,6 +580,12 @@ definitions:
         minimum: 64
         maximum: 1024
         description: Create servers with custom (cinder based) root disked. Size in GB
+      cgroupsV1:
+        type: boolean
+        description: Fallback to cgroups v1. Ignored for k8s versions < 1.19
+        x-nullable: true
+        x-omitempty: false
+
       taints:
         description: The specified taints will be added to members of this pool once during initial registration of the node
         type: array


### PR DESCRIPTION
This allows falling back to cgroups v1 for clusters > 1.18.

The node pool now has a `cgroupsV1` boolean flag to bring up nodes with cgroups v1 enabled

Fallingback to cgroupv1 is possible without a reboot since flatcar 3033.2.4: https://www.flatcar.org/docs/latest/container-runtimes/switching-to-unified-cgroups/

