### PR TITLE
Fix ingress api version selection

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.1.2
+version: 2.1.3

--- a/charts/kube-master/templates/dashboard.yaml
+++ b/charts/kube-master/templates/dashboard.yaml
@@ -10,17 +10,17 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
-  name: {{ include "master.fullname" . }}-dashboard 
+  name: {{ include "master.fullname" . }}-dashboard
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "master.fullname" . }}-dashboard 
+      app: {{ include "master.fullname" . }}-dashboard
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "master.fullname" . }}-dashboard 
+        app: {{ include "master.fullname" . }}-dashboard
         release: {{ .Release.Name }}
     spec:
       initContainers:
@@ -43,7 +43,7 @@ spec:
               name: config
               readOnly: true
       containers:
-        - image: {{ include "dashboardProxy.image" . | quote }} 
+        - image: {{ include "dashboardProxy.image" . | quote }}
           name: proxy
           args:
             - --discovery-url=https://{{ include "dex.url" . }} # ingress of dex
@@ -53,9 +53,9 @@ spec:
             - "--resources=uri=/*"
             - --scopes=groups
             - --client-id=kubernetes
-            - --upstream-url=http://localhost:9090 # kubernetes-dashboard in sidecar 
+            - --upstream-url=http://localhost:9090 # kubernetes-dashboard in sidecar
             - --redirection-url=https://{{ include "dashboard.url" . }} # ingress of dashboard
-            - --encryption-key={{ randAlphaNum 32 }} 
+            - --encryption-key={{ randAlphaNum 32 }}
           env:
           - name: PROXY_CLIENT_SECRET
             valueFrom:
@@ -77,7 +77,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
         - name: dashboard
-          image: {{ include "dashboard.image" . | quote }} 
+          image: {{ include "dashboard.image" . | quote }}
           ports:
             - containerPort: 9090
               protocol: TCP
@@ -97,7 +97,7 @@ spec:
           {{- if (semverCompare ">= 1.12.10" .Values.version.kubernetes) }}
             - --namespace=kube-system # creates dashboard resources in the namespace, introduced in v2.0.0-beta1
           {{- end }}
-            - --kubeconfig=/etc/kubernetes/config/kubeconfig 
+            - --kubeconfig=/etc/kubernetes/config/kubeconfig
           {{- if (semverCompare ">= 1.15.2" .Values.version.kubernetes) }}
             - --metrics-provider=none  #introduced in v2.0.0-beta3
           {{- else }}
@@ -138,7 +138,7 @@ kind: Service
 metadata:
   name: {{ include "master.fullname" . }}-dashboard
   labels:
-    app: {{ include "master.fullname" . }}-dashboard 
+    app: {{ include "master.fullname" . }}-dashboard
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
 spec:
@@ -149,31 +149,41 @@ spec:
     targetPort: 3000
     name: proxy
   selector:
-    app: {{ include "master.fullname" . }}-dashboard 
+    app: {{ include "master.fullname" . }}-dashboard
 ---
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
   labels:
-    app: {{ include "master.fullname" . }}-dashboard 
+    app: {{ include "master.fullname" . }}-dashboard
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
-  name: {{ include "master.fullname" . }}-dashboard  
+  name: {{ include "master.fullname" . }}-dashboard
 spec:
   rules:
-  - host: {{ include "dashboard.url" . }} 
+  - host: {{ include "dashboard.url" . }}
     http:
       paths:
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
       - backend:
-          serviceName: {{ include "master.fullname" . }}-dashboard  
+          service:
+            name: {{ include "master.fullname" . }}-dashboard
+            port:
+              number: 3000
+        path: /
+        pathType: Prefix
+{{- else}}
+      - backend:
+          serviceName: {{ include "master.fullname" . }}-dashboard
           servicePort: 3000
         path: /
+{{- end }}
   tls:
   - hosts:
-    -  {{ include "dashboard.url" . }} 
+    -  {{ include "dashboard.url" . }}
     secretName: {{ required "dashboard.ingressSecret undefined" .Values.dashboard.ingressSecret }}
 {{ end }}

--- a/charts/kube-master/templates/dex.yaml
+++ b/charts/kube-master/templates/dex.yaml
@@ -175,7 +175,7 @@ spec:
   selector:
     app: {{ include "master.fullname" . }}-dex
 ---
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -193,7 +193,7 @@ spec:
     http:
       paths:
       - path: /
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
         pathType: Prefix
         backend:
           service:

--- a/charts/kube-master/templates/ingress.yaml
+++ b/charts/kube-master/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{/* vim: set filetype=gotexttmpl: */ -}}
 {{- if .Values.api.apiserverHost }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -22,7 +22,7 @@ spec:
       http:
         paths:
         - path: /
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
           pathType: Prefix
           backend:
             service:
@@ -38,7 +38,7 @@ spec:
       http:
         paths:
         - path: /
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
           pathType: Prefix
           backend:
             service:


### PR DESCRIPTION
Turns out using  `.Capabilities.APIVersions.Has "networking.k8s.io/v1”` is flawed because while the api version is already available in 1.15 but does not contain the `Ingress` resource.

Using `.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress”` is only supported with helm >= helm 2.15 and we are still using helm 2.11 in k- controlplanes.

So we have to go by kubernetes version instead to decide if to use networking.k8s.io/v1 for ingress resources.