### PR TITLE
Add support for Kubernetes 1.22.12

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -73,8 +73,82 @@ imagesForVersion:
     fluentd:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
       tag: 'v1.14.6-1.1'
-  '1.22.4':
+  '1.22.12':
     supported: true
+    apiserver:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
+      tag: 'v1.22.12'
+    controllerManager:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-controller-manager'
+      tag: 'v1.22.12'
+    scheduler:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-scheduler'
+      tag: 'v1.22.12'
+    etcd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcd'
+      tag: 'v3.3.14'
+    etcdBackup:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/etcdbrctl'
+      tag: '0.5.2'
+    kubelet:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kubelet'
+      tag: 'v1.22.12'
+    kubeProxy:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kube-proxy'
+      tag: 'v1.22.12'
+    cloudControllerManager:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/openstack-cloud-controller-manager'
+      tag: 'v1.22.0'
+    dex:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/dex'
+      tag: '38f4f8ea8d487470a1dd5b83d66b428d8b502f81'
+    dashboardProxy:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/keycloak-gatekeeper'
+      tag: '6.0.1'
+    dashboard:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard'
+      tag: 'v2.0.4'
+    coreDNS:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/coredns'
+      tag: '1.6.2'
+    pause:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64'
+      tag: '3.1'
+    wormhole:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus'
+      tag: 'changeme' #this is injected to match the operator so far
+    csiAttacher:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-attacher'
+      tag: 'v3.3.0'
+    csiProvisioner:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-provisioner'
+      tag: 'v3.0.0'
+    csiSnapshotter:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshotter'
+      tag: 'v4.2.1'
+    csiSnapshotController:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-snapshot-controller'
+      tag: 'v4.2.1'
+    csiResizer:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-resizer'
+      tag: 'v1.3.0'
+    csiLivenessProbe:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-livenessprobe'
+      tag: 'v2.4.0'
+    csiNodeDriver:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/csi-node-driver-registrar'
+      tag: 'v2.3.0'
+    cinderCSIPlugin:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/cinder-csi-plugin'
+      tag: 'v1.22.0'
+    flannel:
+      repository: 'keppel.$REGION.cloud.sap/ccloud-quay-mirror/coreos/flannel'
+      tag: 'v0.12.0'
+    fluentd:
+      repository: 'keppel.$REGION.cloud.sap/ccloud/kubernikus-fluentd'
+      tag: 'v1.14-1'
+  '1.22.4':
+    supported: false
     apiserver:
       repository: 'keppel.$REGION.cloud.sap/ccloud/kube-apiserver'
       tag: 'v1.22.4'

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
-	google.golang.org/grpc v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	helm.sh/helm/v3 v3.6.3

--- a/go.sum
+++ b/go.sum
@@ -365,7 +365,6 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
This includes a fix for https://github.com/kubernetes/kubernetes/issues/105204 which a customer stumbled upon. To my knowledge the issue does not break anything but is very misleading. I believe the version of 1.23 we deliver is affected as well.