### PR TITLE
Increase proxy-buffer-size for Kubernetes dashboard

### DIFF
--- a/charts/kube-master/templates/dashboard.yaml
+++ b/charts/kube-master/templates/dashboard.yaml
@@ -158,6 +158,8 @@ apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
+  annotations:
+    ingress.kubernetes.io/proxy-buffer-size: 8k
   labels:
     app: {{ include "master.fullname" . }}-dashboard
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
With the [default](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) `proxy-buffer-size` the following errors are found in nginx controller logs:
```
2022/10/13 20:54:00 [error] 598124#598124: *97323217 upstream sent too big header while reading response header from upstream, client: 198.18.0.5, server: dashboard-label-test-v2-***, request: "GET /oauth/callback?code=***&state=*** HTTP/2.0", upstream: "http://192.168.0.189:3000/oauth/callback?code=***&state=***", host: "dashboard-label-test-v2-***.ingress.kubernikus.***.sap", referrer: "https://authlabel-test-v2-***.ingress.kubernikus.***.sap/"
```

The change increases the proxy buffer size in ingress annotation.