### PR TITLE
launch controller cleanup needs to wait on deorbiter

### DIFF
--- a/pkg/apis/kubernikus/v1/kluster.go
+++ b/pkg/apis/kubernikus/v1/kluster.go
@@ -64,10 +64,6 @@ func (k *Kluster) NeedsFinalizer(finalizer string) bool {
 }
 
 func (k *Kluster) HasFinalizer(finalizer string) bool {
-	if k.ObjectMeta.DeletionTimestamp == nil {
-		// not deleted. do not remove finalizers at this time
-		return false
-	}
 
 	for _, f := range k.ObjectMeta.Finalizers {
 		if f == finalizer {

--- a/pkg/controller/deorbit/controller.go
+++ b/pkg/controller/deorbit/controller.go
@@ -82,6 +82,9 @@ func (d *DeorbitReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {
 		if kluster.TerminationProtection() {
 			return false, nil
 		}
+		if kluster.ObjectMeta.DeletionTimestamp == nil {
+			return false, nil //wait until the kluster is marked for deletion
+		}
 		if kluster.HasFinalizer(DeorbiterFinalizer) {
 			if err := d.deorbit(kluster); err != nil {
 				return false, err

--- a/pkg/controller/launch/controller.go
+++ b/pkg/controller/launch/controller.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/controller/base"
 	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/deorbit"
 	"github.com/sapcc/kubernikus/pkg/controller/metrics"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
 	informers_kubernikus "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
@@ -90,6 +91,9 @@ func (lr *LaunchReconciler) Reconcile(kluster *v1.Kluster) (requeue bool, err er
 	case models.KlusterPhaseTerminating:
 		if kluster.TerminationProtection() {
 			return false, nil
+		}
+		if kluster.HasFinalizer(deorbit.DeorbiterFinalizer) {
+			return false, nil //Wait for dorbiter so that volumes are detached before deleting nodes
 		}
 
 		return lr.terminatePools(kluster)


### PR DESCRIPTION
At least the volume cleanup in the deorbiter needs the csi daemonset on the nodes to unmount the volumes.

So we should just wait with the termination of nodes until the deorbiter is done