### PR TITLE
Keep nodes while deorbiter is running

### DIFF
--- a/pkg/apis/kubernikus/v1/kluster.go
+++ b/pkg/apis/kubernikus/v1/kluster.go
@@ -64,10 +64,6 @@ func (k *Kluster) NeedsFinalizer(finalizer string) bool {
 }
 
 func (k *Kluster) HasFinalizer(finalizer string) bool {
-	if k.ObjectMeta.DeletionTimestamp == nil {
-		// not deleted. do not remove finalizers at this time
-		return false
-	}
 
 	for _, f := range k.ObjectMeta.Finalizers {
 		if f == finalizer {

--- a/pkg/controller/deorbit/controller.go
+++ b/pkg/controller/deorbit/controller.go
@@ -82,6 +82,9 @@ func (d *DeorbitReconciler) Reconcile(kluster *v1.Kluster) (bool, error) {
 		if kluster.TerminationProtection() {
 			return false, nil
 		}
+		if kluster.ObjectMeta.DeletionTimestamp == nil {
+			return false, nil //wait until the kluster is marked for deletion
+		}
 		if kluster.HasFinalizer(DeorbiterFinalizer) {
 			if err := d.deorbit(kluster); err != nil {
 				return false, err

--- a/pkg/controller/deorbit/deorbiter.go
+++ b/pkg/controller/deorbit/deorbiter.go
@@ -106,11 +106,25 @@ func (d *ConcreteDeorbiter) DeletePersistentVolumeClaims() (deleted []core_v1.Pe
 		if pv.Spec.Cinder == nil && pv.Spec.CSI == nil {
 			continue
 		}
-		deleted = append(deleted, pvc)
 
 		err = d.Client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, meta_v1.DeleteOptions{})
 		if err != nil {
 			return deleted, err
+		}
+		deleted = append(deleted, pvc)
+		//delete pods holding a reference to the pvc
+		pods, err := d.Client.CoreV1().Pods(pvc.Namespace).List(context.TODO(), meta_v1.ListOptions{})
+		if err != nil {
+			return deleted, err
+		}
+		for _, pod := range pods.Items {
+			for _, volume := range pod.Spec.Volumes {
+				if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc.Name {
+					if err := d.Client.CoreV1().Pods(pvc.Namespace).Delete(context.TODO(), pod.Name, meta_v1.DeleteOptions{}); err != nil {
+						return deleted, fmt.Errorf("Failed to delete pod %s/%s: %w", pod.Namespace, pod.Name, err)
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/launch/controller.go
+++ b/pkg/controller/launch/controller.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
 	"github.com/sapcc/kubernikus/pkg/controller/base"
 	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/controller/deorbit"
 	"github.com/sapcc/kubernikus/pkg/controller/metrics"
 	"github.com/sapcc/kubernikus/pkg/controller/nodeobservatory"
 	informers_kubernikus "github.com/sapcc/kubernikus/pkg/generated/informers/externalversions/kubernikus/v1"
@@ -90,6 +91,9 @@ func (lr *LaunchReconciler) Reconcile(kluster *v1.Kluster) (requeue bool, err er
 	case models.KlusterPhaseTerminating:
 		if kluster.TerminationProtection() {
 			return false, nil
+		}
+		if kluster.HasFinalizer(deorbit.DeorbiterFinalizer) {
+			return false, nil //Wait for dorbiter so that volumes are detached before deleting nodes
 		}
 
 		return lr.terminatePools(kluster)


### PR DESCRIPTION
deleting volumes in the deorbiter is failing for multiple minutes because the nodes are gone and the csi daemonset is not unmounting the volumes.

This changes lets the launch controller wait for the deorbiter to finish work before starting to terminate nodes.

For the volumes to actually be deleted we need to remove pods that hold a reference to the pvc.

Open question:
- [ ] What about deployments/replicasets/statefulsets creating new pods with pvc references