### PR TITLE
Add pvc resize snapshot tests

### DIFF
--- a/test/e2e/volume_test.go
+++ b/test/e2e/volume_test.go
@@ -143,11 +143,11 @@ func (p *VolumeTests) WaitForPVCBound(t *testing.T) {
 
 func (p *VolumeTests) WaitForPVCResize(t *testing.T) {
 	pvc, getErr := p.Kubernetes.ClientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Get(context.Background(), testName, meta_v1.GetOptions{})
-	require.NoError(t, getErr, "There must be no error getting the formerly created PVC: %s", getErr)
+	require.NoError(t, getErr, "There must be no error getting the formerly created PVC")
 
 	pvc.Spec.Resources.Requests["storage"] = resource.MustParse("2Gi")
 	_, updateErr := p.Kubernetes.ClientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Update(context.Background(), pvc, meta_v1.UpdateOptions{})
-	require.NoError(t, updateErr, "There must be no error updating the PVC: %s", updateErr)
+	require.NoError(t, updateErr, "There must be no error updating the PVC")
 
 	waitForResizeErr := wait.PollImmediate(PollInterval, TestWaitForPVCResizeInPlaceTimeOut,
 		func() (bool, error) {
@@ -159,7 +159,7 @@ func (p *VolumeTests) WaitForPVCResize(t *testing.T) {
 			storageResized := *pvc.Status.Capacity.Storage() == resource.MustParse("2Gi") && pvc.Status.Phase == v1.PersistentVolumeClaimPhase("Bound")
 			return storageResized, nil
 		})
-	require.NoError(t, waitForResizeErr, "There must be no error waiting for the PVC to be resized: %s", waitForResizeErr)
+	require.NoError(t, waitForResizeErr, "There must be no error waiting for the PVC to be resized")
 }
 
 func (p *VolumeTests) WaitForSnapshot(t *testing.T) {


### PR DESCRIPTION
The following tests are added here:

1. `WaitForPVCResize`: 
The pvc created in the `CreatePVC` test is resized (`1Gi` -> `2Gi`) and we poll until 
`pvc.Status.Capacity.Storage == "2Gi" && pvc.Status.Phase == "Bound"`.
2. `WaitForSnapshot`:
A Snapshot of the above pvc is triggered. The respective pod (from the `CreatePod` test) is deleted, to allow the snapshot to happen. 
We poll until `snapshot.status == "readyToUse"`.
We delete the snapshot for cleanup to run through successfully.

The tests are rearranged to ensure the following tests run in serial:
1. `WaitPVCBound`
2. `WaitPodRunning`
3. `WaitPVCResize`
4. `WaitSnapshot`

See also: https://convergedcloud.slack.com/archives/C6HHGQZG8/p1671715584842789