### PR TITLE
Add flags to toggle dex & dashboard spin up

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -23,6 +23,8 @@ var (
 	reuse         = flag.Bool("reuse", false, "Reuse exisiting Kluster")
 	cleanup       = flag.Bool("cleanup", true, "Cleanup after tests have been run")
 	isolate       = flag.Bool("isolate", false, "Do not destroy or depend on resources of other tests running in the same project")
+	dex           = flag.Bool("dex", true, "Spin up dex pod on cluster creation")
+	dashboard     = flag.Bool("dashboard", true, "Spin up dashboard pod on cluster creation")
 )
 
 const (
@@ -108,6 +110,8 @@ func TestRunner(t *testing.T) {
 	fmt.Printf("Reuse:                     %v\n", *reuse)
 	fmt.Printf("Cleanup:                   %v\n", *cleanup)
 	fmt.Printf("Isolate:                   %v\n", *isolate)
+	fmt.Printf("Spin up dex:               %v\n", *dex)
+	fmt.Printf("Spin up k8s dashboard:     %v\n", *dashboard)
 	fmt.Println("")
 	fmt.Printf("Dashboard:                 https://dashboard.%s.cloud.sap/%s/%s/kubernetes\n", os.Getenv("OS_REGION_NAME"), os.Getenv("OS_PROJECT_DOMAIN_NAME"), os.Getenv("OS_PROJECT_NAME"))
 	if os.Getenv("CP_KLUSTER") != "" {
@@ -192,7 +196,7 @@ func TestRunner(t *testing.T) {
 		defer t.Run("Cleanup", cleanupTests.Run)
 	}
 
-	setupTests := &SetupTests{kubernikus, openstack, klusterName, *reuse}
+	setupTests := &SetupTests{kubernikus, openstack, klusterName, *reuse, *dex, *dashboard}
 	if !t.Run("Setup", setupTests.Run) {
 		return
 	}

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -25,6 +25,8 @@ type SetupTests struct {
 	OpenStack   *framework.OpenStack
 	KlusterName string
 	Reuse       bool
+	Dex         bool
+	Dashboard   bool
 }
 
 func (s *SetupTests) Run(t *testing.T) {
@@ -80,6 +82,8 @@ func (s *SetupTests) CreateCluster(t *testing.T) {
 			Openstack: models.OpenstackSpec{
 				RouterID: os.Getenv("KLUSTER_ROUTER"),
 			},
+			Dex:       &s.Dex,
+			Dashboard: &s.Dashboard,
 		},
 	}
 


### PR DESCRIPTION
There are cases where we do not want to spin up the `dex` and/or `dashboard` pods when creating clusters in `e2e` tests. These flags allow disabling them.