### PR TITLE
Add backup & audit labels to infoMetric

### DIFF
--- a/pkg/controller/metrics/kluster.go
+++ b/pkg/controller/metrics/kluster.go
@@ -66,7 +66,7 @@ func (collector *klusterCollector) Collect(ch chan<- prometheus.Metric) {
 			getCreatorFromAnnotations(kluster.Annotations),
 			getAccountFromLabels(kluster.Labels),
 			kluster.Spec.Backup,
-			*kluster.Spec.Audit,
+			getAuditFromSpec(kluster.Spec),
 		)
 	}
 

--- a/pkg/controller/metrics/kluster.go
+++ b/pkg/controller/metrics/kluster.go
@@ -29,7 +29,7 @@ func NewKlusterCollector(lister kubernikus_lister.KlusterLister) *klusterCollect
 		infoMetric: prometheus.NewDesc(
 			"kubernikus_kluster_info",
 			"Detailed information on a kluster",
-			[]string{"kluster_namespace", "kluster_name", "phase", "api_version", "chart_version", "chart_name", "creator", "project_id"},
+			[]string{"kluster_namespace", "kluster_name", "phase", "api_version", "chart_version", "chart_name", "creator", "project_id", "backup", "audit"},
 			nil,
 		),
 		lister: lister,
@@ -65,6 +65,8 @@ func (collector *klusterCollector) Collect(ch chan<- prometheus.Metric) {
 			kluster.Status.ChartName,
 			getCreatorFromAnnotations(kluster.Annotations),
 			getAccountFromLabels(kluster.Labels),
+			kluster.Spec.Backup,
+			*kluster.Spec.Audit,
 		)
 	}
 

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -133,6 +133,13 @@ func getAccountFromLabels(labels map[string]string) string {
 	return account
 }
 
+func getAuditFromSpec(spec models.KlusterSpec) string {
+	if spec.Audit == nil {
+		return "NA"
+	}
+	return *spec.Audit
+}
+
 func init() {
 	prometheus.MustRegister(
 		klusterStatusPhase,

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -135,7 +135,7 @@ func getAccountFromLabels(labels map[string]string) string {
 
 func getAuditFromSpec(spec models.KlusterSpec) string {
 	if spec.Audit == nil {
-		return "NA"
+		return ""
 	}
 	return *spec.Audit
 }


### PR DESCRIPTION
Adds `Backup` and `Audit` values from `klusterSpec` to `infoMetric` to sort out `KubernikusKlusterLowOnObjectStoreQuota` where no `Audit` or `Backup` to Swift is enabled...

https://github.wdf.sap.corp/cc/ccloud-containers/issues/65