### PR TITLE
Add customCNI field to kluster spec

### DIFF
--- a/charts/seed/templates/cni.yaml
+++ b/charts/seed/templates/cni.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">= 1.24" .Capabilities.KubeVersion.Version -}}
+{{- if and (not .Values.customCNI) (semverCompare ">= 1.24" .Capabilities.KubeVersion.Version) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/api/models/kluster_spec.go
+++ b/pkg/api/models/kluster_spec.go
@@ -39,6 +39,9 @@ type KlusterSpec struct {
 	// Pattern: ^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2])))?$
 	ClusterCIDR *string `json:"clusterCIDR,omitempty"`
 
+	// custom c n i
+	CustomCNI bool `json:"customCNI,omitempty"`
+
 	// dashboard
 	Dashboard *bool `json:"dashboard"`
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -620,6 +620,11 @@ func init() {
           "default": "100.100.0.0/16",
           "pattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2])))?$"
         },
+        "customCNI": {
+          "type": "boolean",
+          "default": false,
+          "x-nullable": false
+        },
         "dashboard": {
           "type": "boolean",
           "x-nullable": true,
@@ -1666,6 +1671,11 @@ func init() {
           "type": "string",
           "default": "100.100.0.0/16",
           "pattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2])))?$"
+        },
+        "customCNI": {
+          "type": "boolean",
+          "default": false,
+          "x-nullable": false
         },
         "dashboard": {
           "type": "boolean",

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -496,7 +496,7 @@ func (op *GroundControl) reconcileSeed(kluster *v1.Kluster, projectClient projec
 	}
 
 	seedReconciler := ground.NewSeedReconciler(&op.Clients, kluster, op.Logger)
-	if err := seedReconciler.EnrichHelmValuesForSeed(projectClient, helmValues); err != nil {
+	if err := seedReconciler.EnrichHelmValuesForSeed(projectClient, helmValues, kluster.Spec.CustomCNI); err != nil {
 		if !isNetErr(err) {
 			metrics.SeedReconciliationFailuresTotal.With(prometheus.Labels{"kluster_name": kluster.Spec.Name}).Inc()
 		}

--- a/pkg/controller/ground/reconciler.go
+++ b/pkg/controller/ground/reconciler.go
@@ -56,7 +56,7 @@ type SeedReconciler struct {
 	Logger  log.Logger
 }
 
-func (sr *SeedReconciler) EnrichHelmValuesForSeed(client project.ProjectClient, values map[string]interface{}) error {
+func (sr *SeedReconciler) EnrichHelmValuesForSeed(client project.ProjectClient, values map[string]interface{}, customCNI bool) error {
 	metadata, err := client.GetMetadata()
 	if err != nil {
 		return err
@@ -89,6 +89,7 @@ func (sr *SeedReconciler) EnrichHelmValuesForSeed(client project.ProjectClient, 
 		"domain":  sr.Kluster.Spec.DNSDomain,
 		"kube":    isKubeDns,
 	}
+	values["customCNI"] = customCNI
 	return nil
 }
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -534,6 +534,10 @@ definitions:
         x-nullable: false
         enum: ["on", "off", "externalAWS"]
         default: "on"
+      customCNI:
+        type: boolean
+        x-nullable: false
+        default: false
   OpenstackSpec:
     type: object
     x-nullable: false


### PR DESCRIPTION
If customCNI is true flannel will not be installed. Since we reconcile content in customer cluster now, updating the kluster spec is sufficient to deinstall flannel. 🥳 