### PR TITLE
Migrate kubedns to coredns

### DIFF
--- a/charts/seed/templates/coredns.yaml
+++ b/charts/seed/templates/coredns.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.dns.kube }}
+{{ if semverCompare ">= 1.13" .Capabilities.KubeVersion.Version }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/seed/templates/kubedns.yaml
+++ b/charts/seed/templates/kubedns.yaml
@@ -1,6 +1,6 @@
 # More or less ported to adapt kube-dns resources
 # to get them later replced with coredns
-{{ if .Values.dns.kube }}
+{{ if semverCompare "< 1.13" .Capabilities.KubeVersion.Version }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Since we reconcile content in customer clusters now, we can migrate people from kubedns to coredns with ease. 🥳 