### PR TITLE
Bump occm to v1.25.5

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2327,7 +2327,7 @@ imagesForVersion:
       tag: v1.25.3
     cloudControllerManager:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/k8scloudprovider/openstack-cloud-controller-manager
-      tag: v1.25.3
+      tag: v1.25.5
     cniPlugins:
       repository: keppel.global.cloud.sap/ccloud/cni-plugins
       tag: v1.1.1

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2161,7 +2161,7 @@ imagesForVersion:
       tag: v1.25.3
     cloudControllerManager:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/k8scloudprovider/openstack-cloud-controller-manager
-      tag: v1.25.3
+      tag: v1.25.5
     cniPlugins:
       repository: keppel.global.cloud.sap/ccloud/cni-plugins
       tag: v1.1.1


### PR DESCRIPTION
Bump occm image version to v1.25.5. This includes @kayrus route optimization fixes https://github.com/kubernetes/cloud-provider-openstack/pull/2090 and https://github.com/kubernetes/cloud-provider-openstack/pull/2134