### PR TITLE
[kube-master] add release label to scheduler

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.1.7
+version: 2.1.8

--- a/charts/kube-master/templates/scheduler.yaml
+++ b/charts/kube-master/templates/scheduler.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     kluster: {{ .Release.Name }}
+    release: {{ .Release.Name }}
 
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}


### PR DESCRIPTION
need to be able to list all deployments for specific kluster by using release label (only scheduler is missing)