### PR TITLE
[dex] Remove trailing slash in redirect URIs

### DIFF
--- a/charts/kube-master/templates/dex-configmap.yaml
+++ b/charts/kube-master/templates/dex-configmap.yaml
@@ -105,7 +105,7 @@ data:
       redirectURIs:
       - https://{{ include "dashboard.url" . }}/oauth/callback # for dashboard access
       - http://localhost:33768/auth/callback
-      - http://localhost:33768/ # for https://github.com/int128/kubelogin access
+      - http://localhost:33768 # for https://github.com/int128/kubelogin access
       name: kubernetes
       secret: {{ required "dex.staticClientSecret" .Values.dex.staticClientSecret }}
 


### PR DESCRIPTION
Remove trailing slash in redirect URIs.

Currently, dex fails to complete the authentication with error
> Bad Request
>
> Unregistered redirect_uri ("http://localhost:33768").
