### PR TITLE
[WIP] Add support for Kubernetes 1.27

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2650,10 +2650,10 @@ imagesForVersion:
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme
-  1.27.2:
+  1.27.5:
     apiserver:
       repository: keppel.global.cloud.sap/ccloud/kube-apiserver
-      tag: v1.27.2
+      tag: v1.27.5
     cinderCSIPlugin:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
       tag: v1.27.1
@@ -2665,7 +2665,7 @@ imagesForVersion:
       tag: v1.1.1
     controllerManager:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-controller-manager
-      tag: v1.27.2
+      tag: v1.27.5
     coreDNS:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/coredns/coredns
       tag: 1.10.1
@@ -2716,10 +2716,10 @@ imagesForVersion:
       tag: v1.14.6-1.1
     kubeProxy:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-proxy
-      tag: v1.27.2
+      tag: v1.27.5
     kubelet:
       repository: keppel.global.cloud.sap/ccloud/kubelet
-      tag: v1.27.2
+      tag: v1.27.5
     pause:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64
       tag: '3.1'
@@ -2728,7 +2728,7 @@ imagesForVersion:
       tag: v2.0.0
     scheduler:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
-      tag: v1.27.2
+      tag: v1.27.5
     supported: true
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2650,25 +2650,25 @@ imagesForVersion:
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme
-  1.27.0-rc.0:
+  1.27.2:
     apiserver:
       repository: keppel.global.cloud.sap/ccloud/kube-apiserver
-      tag: v1.27.0-rc.0
+      tag: v1.27.2
     cinderCSIPlugin:
-      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/k8scloudprovider/cinder-csi-plugin
-      tag: v1.26.2
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+      tag: v1.27.1
     cloudControllerManager:
-      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/k8scloudprovider/openstack-cloud-controller-manager
-      tag: v1.26.2
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+      tag: v1.27.1
     cniPlugins:
       repository: keppel.global.cloud.sap/ccloud/cni-plugins
       tag: v1.1.1
     controllerManager:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-controller-manager
-      tag: v1.27.0-rc.0
+      tag: v1.27.2
     coreDNS:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/coredns/coredns
-      tag: 1.9.1
+      tag: 1.10.1
     csiAttacher:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-attacher
       tag: v3.5.0
@@ -2716,10 +2716,10 @@ imagesForVersion:
       tag: v1.14.6-1.1
     kubeProxy:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-proxy
-      tag: v1.27.0-rc.0
+      tag: v1.27.2
     kubelet:
       repository: keppel.global.cloud.sap/ccloud/kubelet
-      tag: v1.27.0-rc.0
+      tag: v1.27.2
     pause:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64
       tag: '3.1'
@@ -2728,7 +2728,7 @@ imagesForVersion:
       tag: v2.0.0
     scheduler:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
-      tag: v1.27.0-rc.0
+      tag: v1.27.2
     supported: true
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2650,6 +2650,89 @@ imagesForVersion:
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme
+  1.27.0-rc.0:
+    apiserver:
+      repository: keppel.global.cloud.sap/ccloud/kube-apiserver
+      tag: v1.27.0-rc.0
+    cinderCSIPlugin:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/k8scloudprovider/cinder-csi-plugin
+      tag: v1.26.2
+    cloudControllerManager:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/k8scloudprovider/openstack-cloud-controller-manager
+      tag: v1.26.2
+    cniPlugins:
+      repository: keppel.global.cloud.sap/ccloud/cni-plugins
+      tag: v1.1.1
+    controllerManager:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-controller-manager
+      tag: v1.27.0-rc.0
+    coreDNS:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/coredns/coredns
+      tag: 1.9.1
+    csiAttacher:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-attacher
+      tag: v3.5.0
+    csiLivenessProbe:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/livenessprobe
+      tag: v2.7.0
+    csiNodeDriver:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-node-driver-registrar
+      tag: v2.5.1
+    csiProvisioner:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-provisioner
+      tag: v3.2.1
+    csiResizer:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-resizer
+      tag: v1.5.0
+    csiSnapshotController:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/snapshot-controller
+      tag: v5.0.1
+    csiSnapshotter:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-snapshotter
+      tag: v5.0.1
+    dashboard:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/kubernetesui/dashboard
+      tag: v2.7.0
+    dashboardProxy:
+      repository: keppel.global.cloud.sap/ccloud/keycloak-gatekeeper
+      tag: 6.0.1
+    dex:
+      repository: keppel.global.cloud.sap/ccloud/dex
+      tag: 38f4f8ea8d487470a1dd5b83d66b428d8b502f81
+    etcd:
+      repository: keppel.global.cloud.sap/ccloud/etcd
+      tag: v3.4.13-bootstrap-3
+    etcdBackup:
+      repository: keppel.global.cloud.sap/ccloud/etcdbrctl
+      tag: v0.15.4
+    flannel:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/flannelcni/flannel
+      tag: v0.19.1
+    flannelCNIPlugin:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/flannelcni/flannel-cni-plugin
+      tag: v1.1.0
+    fluentd:
+      repository: keppel.global.cloud.sap/ccloud/kubernikus-fluentd
+      tag: v1.14.6-1.1
+    kubeProxy:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-proxy
+      tag: v1.27.0-rc.0
+    kubelet:
+      repository: keppel.global.cloud.sap/ccloud/kubelet
+      tag: v1.27.0-rc.0
+    pause:
+      repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64
+      tag: '3.1'
+    recycler:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/debian-base
+      tag: v2.0.0
+    scheduler:
+      repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
+      tag: v1.27.0-rc.0
+    supported: true
+    wormhole:
+      repository: keppel.global.cloud.sap/ccloud/kubernikus
+      tag: changeme
   1.25.6:
     apiserver:
       repository: keppel.global.cloud.sap/ccloud/kube-apiserver

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -194,7 +194,7 @@ spec:
             {{- end }}
             - --data-dir=/var/lib/etcd/new.etcd
             - --storage-provider={{ .Values.backup.storageProvider | default "Swift" }}
-            {{- if (semverCompare ">= 1.23" .Values.version.kubernetes) }}
+            {{- if (semverCompare ">= 1.23-0" .Values.version.kubernetes) }}
             - --delta-snapshot-period={{ .Values.backup.deltaSnapshotPeriod }}s
             - --garbage-collection-period={{ .Values.backup.garbageCollectionPeriod }}s
             {{- else }}

--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -150,7 +150,7 @@ spec:
 {{- else }}
             - until etcdctl --total-timeout=4s --endpoints http://{{ include "etcd.fullname" . }}:2379 cluster-health; do sleep 5; done;
 {{- end }}
-{{- if and (semverCompare ">= 1.22" .Values.version.kubernetes) .Values.audit }}
+{{- if and (semverCompare ">= 1.22-0" .Values.version.kubernetes) .Values.audit }}
         - name: auditlog-permission-fix
           image: "{{ include "fluentd.image" . }}"
           command:
@@ -168,7 +168,7 @@ spec:
           - containerPort: 443
             name: server
             protocol: TCP
-{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
           image: {{ include "apiserver.image" . | quote }}
 {{- else }}
           image: {{ include "hyperkube.image" . | quote }}
@@ -177,7 +177,7 @@ spec:
 {{- if (semverCompare "< 1.17" .Values.version.kubernetes) }}
             - /hyperkube
 {{- end }}
-{{- if (semverCompare ">= 1.15" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.15-0" .Values.version.kubernetes) }}
             - kube-apiserver
 {{- else }}
             - apiserver
@@ -199,7 +199,7 @@ spec:
             - --cloud-provider=external
             {{- end }}
             {{- end }}
-{{- if (semverCompare ">= 1.8" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.8-0" .Values.version.kubernetes) }}
             - --enable-bootstrap-token-auth=true
             - --external-hostname={{ required "missing .api.apiserverHost" .Values.api.apiserverHost }}
 {{- else }}{{/* 1.7 */}}
@@ -209,7 +209,7 @@ spec:
             - --token-auth-file=/etc/kubernetes/bootstrap/token.csv
             - --service-cluster-ip-range={{ .Values.serviceCIDR }}
             - --kubelet-preferred-address-types=InternalIP
-{{- if (semverCompare ">= 1.10" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.10-0" .Values.version.kubernetes) }}
             - --enable-admission-plugins=ExtendedResourceToleration
             # Aggregation Layer
             - --requestheader-client-ca-file=/etc/kubernetes/certs/aggregation-ca.pem
@@ -224,19 +224,21 @@ spec:
             - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
             - --tls-ca-file=/etc/kubernetes/certs/tls-ca.pem
 {{- end }}
-{{- if and (semverCompare ">= 1.13" .Values.version.kubernetes) (semverCompare "< 1.20" .Values.version.kubernetes) }}
+{{- if and (semverCompare ">= 1.13-0" .Values.version.kubernetes) (semverCompare "< 1.20" .Values.version.kubernetes) }}
             - --enable-admission-plugins=PersistentVolumeLabel
 {{- end }}
-{{- if (semverCompare ">= 1.14" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.14-0" .Values.version.kubernetes) }}
 {{- if (semverCompare "< 1.17" .Values.version.kubernetes) }}
             - --feature-gates=NodeLease=false
 {{- end }}
-{{- else if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
+{{- else if (semverCompare ">= 1.12-0" .Values.version.kubernetes) }}
             # https://github.com/kubernetes/kubernetes/issues/85867
             - --feature-gates=ValidateProxyRedirects=true
 {{- end }}
-{{- if and (.Values.openstack) (semverCompare ">= 1.20" .Values.version.kubernetes) (semverCompare "< 1.26" .Values.version.kubernetes)}}
-            - --feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,ExpandCSIVolumes=true
+{{- if and (.Values.openstack) (semverCompare ">= 1.20-0" .Values.version.kubernetes) }}
+            {{- if semverCompare "< 1.27.0-0" .Values.version.kubernetes }}
+            - --feature-gates=ExpandCSIVolumes=true,CSIMigration=true,CSIMigrationOpenStack=true,
+            {{- end }}
 {{- end }}
             #Cert Spratz
             - --client-ca-file=/etc/kubernetes/certs/apiserver-clients-and-nodes-ca.pem
@@ -248,7 +250,7 @@ spec:
             - --service-account-key-file=/etc/kubernetes/certs/apiserver-clients-ca-key.pem
             - --tls-cert-file=/etc/kubernetes/certs/tls-apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/certs/tls-apiserver-key.pem
-{{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.13-0" .Values.version.kubernetes) }}
             - --service-account-issuer=https://{{ required "missing .api.apiserverHost" .Values.api.apiserverHost }}
             - --service-account-signing-key-file=/etc/kubernetes/certs/apiserver-clients-ca-key.pem
             - --api-audiences=kubernetes
@@ -309,7 +311,7 @@ spec:
 {{- if .Values.etcd.backup.enabled }}
             exec:
               command:
-            {{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+            {{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
                 - /api-liveness
             {{- else }}
                 - /liveness-probe/api-liveness-probe.py

--- a/charts/kube-master/templates/cloud-controller-manager.yaml
+++ b/charts/kube-master/templates/cloud-controller-manager.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.openstack }}
-{{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.13-0" .Values.version.kubernetes) }}
 {{/* vim: set filetype=gotexttmpl: */ -}}
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: "apps/v1"
@@ -52,7 +52,7 @@ spec:
           secret:
             secretName: {{ include "master.fullname" . }}-generated
             items:
-{{- if (semverCompare ">= 1.16" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.16-0" .Values.version.kubernetes) }}
               - key: openstack-ccmanager.config
 {{- else }}
               - key: openstack.config
@@ -60,7 +60,7 @@ spec:
                 path: openstack.config
       initContainers:
         - name: apiserver-wait
-{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
           image: {{ include "kubelet.image" . | quote }}
 {{- else }}
           image: {{ include "hyperkube.image" . }}
@@ -90,7 +90,7 @@ spec:
             - --cluster-cidr={{ .Values.clusterCIDR }}
             - --cluster-name={{ .Values.name }}
             - --configure-cloud-routes=true
-{{- if and (semverCompare ">= 1.14" .Values.version.kubernetes) (semverCompare "< 1.17" .Values.version.kubernetes) }}
+{{- if and (semverCompare ">= 1.14-0" .Values.version.kubernetes) (semverCompare "< 1.17" .Values.version.kubernetes) }}
             - --feature-gates=NodeLease=false
 {{- end }}
             - --kubeconfig=/etc/kubernetes/config/kubeconfig

--- a/charts/kube-master/templates/configmap.yaml
+++ b/charts/kube-master/templates/configmap.yaml
@@ -44,7 +44,7 @@ data:
         user:
           client-certificate: /etc/kubernetes/certs/kube-client.pem
           client-key: /etc/kubernetes/certs/kube-client.key
-{{- if (semverCompare ">= 1.20" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.20-0" .Values.version.kubernetes) }}
   csi-kubeconfig: |-
     apiVersion: v1
     kind: Config

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -68,7 +68,7 @@ spec:
         {{- end }}
       initContainers:
         - name: apiserver-wait
-{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
           image: {{ include "kubelet.image" . | quote }}
 {{- else }}
           image: {{ include "hyperkube.image" . }}
@@ -87,13 +87,13 @@ spec:
               readOnly: true
       containers:
         - name: controller-manager
-{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.12-0" .Values.version.kubernetes) }}
           ports:
           - containerPort: 10257
             name: metrics
             protocol: TCP
 {{- end }}
-{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
           image: {{ include "controllerManager.image" . | quote }}
 {{- else }}
           image: {{ include "hyperkube.image" . | quote }}
@@ -102,7 +102,7 @@ spec:
 {{- if (semverCompare "< 1.17" .Values.version.kubernetes) }}
             - /hyperkube
 {{- end }}
-{{- if (semverCompare ">= 1.15" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.15-0" .Values.version.kubernetes) }}
             - kube-controller-manager
 {{- else }}
             - controller-manager
@@ -115,7 +115,7 @@ spec:
             {{- if (semverCompare "< 1.21" .Values.version.kubernetes) }}
             - --cloud-config=/etc/kubernetes/cloudprovider/openstack.config
             {{- end }}
-{{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.13-0" .Values.version.kubernetes) }}
             {{- if (semverCompare "< 1.21" .Values.version.kubernetes) }}
             - --cloud-provider=external
             - --external-cloud-volume-plugin=openstack
@@ -130,15 +130,17 @@ spec:
             - --cluster-signing-key-file=/etc/kubernetes/certs/apiserver-nodes-ca-key.pem
             - --controllers=*,bootstrapsigner,tokencleaner
             - --kubeconfig=/etc/kubernetes/config/kubeconfig
-{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.12-0" .Values.version.kubernetes) }}
             - --authentication-kubeconfig=/etc/kubernetes/config/kubeconfig
             - --authorization-kubeconfig=/etc/kubernetes/config/kubeconfig
 {{- end }}
-{{- if and (semverCompare ">= 1.14" .Values.version.kubernetes) (semverCompare "< 1.17" .Values.version.kubernetes) }}
+{{- if and (semverCompare ">= 1.14-0" .Values.version.kubernetes) (semverCompare "< 1.17" .Values.version.kubernetes) }}
             - --feature-gates=NodeLease=false
 {{- end }}
-{{- if and (.Values.openstack) (semverCompare ">= 1.20" .Values.version.kubernetes) (semverCompare "< 1.26" .Values.version.kubernetes)}}
+{{- if and (.Values.openstack) (semverCompare ">= 1.20-0" .Values.version.kubernetes) }}
+            {{- if semverCompare "< 1.27.0-0" .Values.version.kubernetes }}
             - --feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,ExpandCSIVolumes=true
+            {{- end }}
 {{- end }}
             - --leader-elect=false
             - --root-ca-file=/etc/kubernetes/certs/tls-ca.pem
@@ -150,7 +152,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-{{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.13-0" .Values.version.kubernetes) }}
               port: 10257
               scheme: HTTPS
 {{- else }}

--- a/charts/kube-master/templates/csi-driver-controller.yaml
+++ b/charts/kube-master/templates/csi-driver-controller.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.openstack }}
-{{- if (semverCompare ">= 1.20" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.20-0" .Values.version.kubernetes) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -186,7 +186,7 @@ spec:
         {{- if .Values.csi.leaderElectionNamespace }}
         - --leader-election-namespace={{ .Values.csi.leaderElectionNamespace }}
         {{- end }}
-        {{- if (semverCompare ">= 1.21" .Values.version.kubernetes) }}
+        {{- if (semverCompare ">= 1.21-0" .Values.version.kubernetes) }}
         - --timeout={{ .Values.csi.timeout }}
         {{- else }}
         - --csiTimeout={{ .Values.csi.timeout }}

--- a/charts/kube-master/templates/dashboard.yaml
+++ b/charts/kube-master/templates/dashboard.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: apiserver-wait
-{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
           image: {{ include "kubelet.image" . | quote }}
 {{- else }}
           image: {{ include "hyperkube.image" . }}
@@ -94,11 +94,11 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
           args:
-          {{- if (semverCompare ">= 1.12.10" .Values.version.kubernetes) }}
+          {{- if (semverCompare ">= 1.12.10-0" .Values.version.kubernetes) }}
             - --namespace=kube-system # creates dashboard resources in the namespace, introduced in v2.0.0-beta1
           {{- end }}
             - --kubeconfig=/etc/kubernetes/config/kubeconfig
-          {{- if (semverCompare ">= 1.15.2" .Values.version.kubernetes) }}
+          {{- if (semverCompare ">= 1.15.2-0" .Values.version.kubernetes) }}
             - --metrics-provider=none  #introduced in v2.0.0-beta3
           {{- else }}
             - --metric-client-check-period=2592000 # 30 days in seconds, since heapster is not installed
@@ -151,7 +151,7 @@ spec:
   selector:
     app: {{ include "master.fullname" . }}-dashboard
 ---
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -170,7 +170,7 @@ spec:
   - host: {{ include "dashboard.url" . }}
     http:
       paths:
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
       - backend:
           service:
             name: {{ include "master.fullname" . }}-dashboard

--- a/charts/kube-master/templates/dex.yaml
+++ b/charts/kube-master/templates/dex.yaml
@@ -175,7 +175,7 @@ spec:
   selector:
     app: {{ include "master.fullname" . }}-dex
 ---
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -193,7 +193,7 @@ spec:
     http:
       paths:
       - path: /
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
         pathType: Prefix
         backend:
           service:

--- a/charts/kube-master/templates/ingress.yaml
+++ b/charts/kube-master/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{/* vim: set filetype=gotexttmpl: */ -}}
 {{- if .Values.api.apiserverHost }}
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -22,7 +22,7 @@ spec:
       http:
         paths:
         - path: /
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
           pathType: Prefix
           backend:
             service:
@@ -38,7 +38,7 @@ spec:
       http:
         paths:
         - path: /
-{{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
           pathType: Prefix
           backend:
             service:

--- a/charts/kube-master/templates/scheduler.yaml
+++ b/charts/kube-master/templates/scheduler.yaml
@@ -51,13 +51,13 @@ spec:
 {{- end }}
       containers:
         - name: scheduler
-{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.12-0" .Values.version.kubernetes) }}
           ports:
           - containerPort: 10259
             name: metrics
             protocol: TCP
 {{- end }}
-{{- if (semverCompare ">= 1.19" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.19-0" .Values.version.kubernetes) }}
           image: {{ include "scheduler.image" . | quote }}
 {{- else }}
           image: {{ include "hyperkube.image" . | quote }}
@@ -66,13 +66,13 @@ spec:
 {{- if (semverCompare "< 1.17" .Values.version.kubernetes) }}
             - /hyperkube
 {{- end }}
-{{- if (semverCompare ">= 1.15" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.15-0" .Values.version.kubernetes) }}
             - kube-scheduler
 {{- else }}
             - scheduler
 {{- end }}
             - --kubeconfig=/etc/kubernetes/config/kubeconfig
-{{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.13-0" .Values.version.kubernetes) }}
             - --authentication-kubeconfig=/etc/kubernetes/config/kubeconfig
             - --authorization-kubeconfig=/etc/kubernetes/config/kubeconfig
 {{- end }}
@@ -83,7 +83,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-{{- if (semverCompare ">= 1.13" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.13-0" .Values.version.kubernetes) }}
               port: 10259
               scheme: HTTPS
 {{- else }}

--- a/charts/kube-master/templates/secrets.yaml
+++ b/charts/kube-master/templates/secrets.yaml
@@ -10,10 +10,10 @@ type: Opaque
 data:
   {{- if .Values.openstack }}
   openstack.config: {{ include (print $.Template.BasePath "/_openstack.config.tpl") . | b64enc}}
-  {{- if (semverCompare ">= 1.16" .Values.version.kubernetes) }}
+  {{- if (semverCompare ">= 1.16-0" .Values.version.kubernetes) }}
   openstack-ccmanager.config: {{ include (print $.Template.BasePath "/_openstack-ccmanager.config.tpl") . | b64enc}}
   {{- end }}
-  {{- if (semverCompare ">= 1.20" .Values.version.kubernetes) }}
+  {{- if (semverCompare ">= 1.20-0" .Values.version.kubernetes) }}
   openstack-csi.config: {{ include (print $.Template.BasePath "/_openstack-csi.config.tpl") . | b64enc}}
   {{- end }}
   {{- end }}

--- a/charts/kube-master/templates/service-metrics.yaml
+++ b/charts/kube-master/templates/service-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if (semverCompare ">= 1.12" .Values.version.kubernetes) }}
+{{- if (semverCompare ">= 1.12-0" .Values.version.kubernetes) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/seed/templates/cni.yaml
+++ b/charts/seed/templates/cni.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.customCNI) (semverCompare ">= 1.24" .Capabilities.KubeVersion.Version) -}}
+{{- if and (not .Values.customCNI) (semverCompare ">= 1.24-0" .Capabilities.KubeVersion.Version) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/seed/templates/coredns.yaml
+++ b/charts/seed/templates/coredns.yaml
@@ -19,7 +19,7 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "services", "pods", "namespaces"]
     verbs: ["list", "watch"]
-  {{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version }}
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["list", "watch"]

--- a/charts/seed/templates/csi.yaml
+++ b/charts/seed/templates/csi.yaml
@@ -10,7 +10,7 @@ region="{{ .Values.openstack.region }}"
 rescan-on-resize = yes
 ` -}}
 
-{{- if semverCompare ">= 1.20" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -47,7 +47,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-role
 rules:
-  {{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "patch"]
@@ -95,7 +95,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-role
 rules:
-  {{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
@@ -182,7 +182,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-snapshotter-role
 rules:
-  {{- if semverCompare ">= 1.23" .Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]

--- a/charts/seed/templates/proxy.yaml
+++ b/charts/seed/templates/proxy.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">= 1.24" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">= 1.24-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/seed/templates/rbac.yaml
+++ b/charts/seed/templates/rbac.yaml
@@ -122,7 +122,7 @@ subjects:
 - kind: Group
   name: openstack_role:kubernetes_member
 {{ end }}
-{{- if semverCompare ">= 1.25" .Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">= 1.25-0" .Capabilities.KubeVersion.Version }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/seed/templates/storageclasses.yaml
+++ b/charts/seed/templates/storageclasses.yaml
@@ -1,12 +1,12 @@
 {{- define "seed.storage-provisioner" -}}
-  {{- if semverCompare ">= 1.20" .Capabilities.KubeVersion.Version -}}
+  {{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.Version -}}
     cinder.csi.openstack.org
   {{- else -}}
     kubernetes.io/cinder
   {{- end -}}
 {{- end -}}
 {{- define "seed.storage-expansion" -}}
-  {{- if semverCompare ">= 1.20" .Capabilities.KubeVersion.Version -}}
+  {{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.Version -}}
     true
   {{- else -}}
     false

--- a/charts/seed/templates/wormhole.yaml
+++ b/charts/seed/templates/wormhole.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">= 1.24" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">= 1.24-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/pkg/api/models/kluster_spec.go
+++ b/pkg/api/models/kluster_spec.go
@@ -76,7 +76,7 @@ type KlusterSpec struct {
 	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 
 	// Kubernetes version
-	// Pattern: ^[0-9]+\.[0-9]+\.[0-9]+$
+	// Pattern: ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
 	Version string `json:"version,omitempty"`
 }
 
@@ -310,7 +310,7 @@ func (m *KlusterSpec) validateVersion(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.Pattern("version", "body", m.Version, `^[0-9]+\.[0-9]+\.[0-9]+$`); err != nil {
+	if err := validate.Pattern("version", "body", m.Version, `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`); err != nil {
 		return err
 	}
 

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -674,7 +674,7 @@ func init() {
         "version": {
           "description": "Kubernetes version",
           "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^(?P\u003cmajor\u003e0|[1-9]\\d*)\\.(?P\u003cminor\u003e0|[1-9]\\d*)\\.(?P\u003cpatch\u003e0|[1-9]\\d*)(?:-(?P\u003cprerelease\u003e(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P\u003cbuildmetadata\u003e[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
         }
       },
       "x-nullable": false
@@ -1726,7 +1726,7 @@ func init() {
         "version": {
           "description": "Kubernetes version",
           "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^(?P\u003cmajor\u003e0|[1-9]\\d*)\\.(?P\u003cminor\u003e0|[1-9]\\d*)\\.(?P\u003cpatch\u003e0|[1-9]\\d*)(?:-(?P\u003cprerelease\u003e(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P\u003cbuildmetadata\u003e[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
         }
       },
       "x-nullable": false

--- a/pkg/templates/ignition.go
+++ b/pkg/templates/ignition.go
@@ -31,6 +31,8 @@ const TEMPLATE_VERSION = "6"
 
 func (i *ignition) getIgnitionTemplate(kluster *kubernikusv1.Kluster) (string, error) {
 	switch {
+	case strings.HasPrefix(kluster.Spec.Version, "1.27"):
+		return Node_1_27, nil // No changes to 1.24
 	case strings.HasPrefix(kluster.Spec.Version, "1.26"):
 		return Node_1_26, nil
 	case strings.HasPrefix(kluster.Spec.Version, "1.25"):

--- a/pkg/templates/node_1.27.go
+++ b/pkg/templates/node_1.27.go
@@ -1,0 +1,343 @@
+/* vim: set filetype=yaml : */
+
+package templates
+
+var Node_1_27 = `
+passwd:
+  users:
+    - name:          core
+      password_hash: {{ .LoginPassword }}
+{{- if .LoginPublicKey }}
+      ssh_authorized_keys:
+        - {{ .LoginPublicKey | quote }}
+{{- end }}
+systemd:
+  units:
+    - name: ccloud-metadata-hostname.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Workaround for coreos-metadata hostname bug
+        [Service]
+        ExecStartPre=/usr/bin/curl -sf http://169.254.169.254/latest/meta-data/hostname
+        ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment COREOS_OPENSTACK_HOSTNAME=$(curl -s http://169.254.169.254/latest/meta-data/hostname)"
+        ExecStart=/usr/bin/hostnamectl set-hostname ${COREOS_OPENSTACK_HOSTNAME}
+        Restart=on-failure
+        RestartSec=5
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+    - name: containerd.service
+      enable: true
+      dropins:
+        - name: 10-custom-config.conf
+          contents: |
+            [Service]
+            ExecStart=
+            ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd
+    - name: docker.service
+      enable: true
+      dropins:
+        - name: 20-docker-opts.conf
+          contents: |
+            [Service]
+            Environment="DOCKER_OPTS=--iptables=false --bridge=none"
+    - name: kubelet.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Kubelet
+        After=network-online.target nss-lookup.target containerd.service
+        Wants=network-online.target nss-lookup.target
+        [Service]
+        Restart=always
+        RestartSec=2s
+        StartLimitInterval=0
+        KillMode=process
+        User=root
+        CPUAccounting=true
+        MemoryAccounting=true
+        ExecStartPre=docker run --rm -v /opt/bin:/opt/bin {{ .KubeletImage }}:{{ .KubeletImageTag }} cp --preserve=mode /usr/local/bin/kubelet /opt/bin/kubelet
+        ExecStart=/opt/bin/kubelet \
+          --cert-dir=/var/lib/kubelet/pki \
+          --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          --cloud-provider=external \
+          --config=/etc/kubernetes/kubelet/config \
+          --bootstrap-kubeconfig=/etc/kubernetes/bootstrap/kubeconfig \
+          --hostname-override={{ .NodeName }} \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --lock-file=/var/run/lock/kubelet.lock \
+          --pod-infra-container-image={{ .PauseImage }}:{{ .PauseImageTag }} \
+          --node-labels=kubernikus.cloud.sap/cni=true{{ if .NodeLabels }},{{ .NodeLabels | join "," }}{{ end }} \
+{{- if .NodeTaints }}
+          --register-with-taints={{ .NodeTaints | join "," }} \
+{{- end }}
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
+          --rotate-certificates \
+          --exit-on-lock-contention
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: updatecertificates.service
+      command: start
+      enable: true
+      contents: |
+        [Unit]
+        Description=Update the certificates w/ self-signed root CAs
+        ConditionPathIsSymbolicLink=!/etc/ssl/certs/381107d7.0
+        Before=early-docker.service docker.service
+        [Service]
+        ExecStart=/usr/sbin/update-ca-certificates
+        RemainAfterExit=yes
+        Type=oneshot
+        [Install]
+        WantedBy=multi-user.target
+storage:
+  files:
+    - path: /etc/crictl.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          runtime-endpoint: unix:///run/containerd/containerd.sock
+    - path: /etc/profile.d/envs.sh
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          export CONTAINERD_NAMESPACE=k8s.io
+      #copied from /run/torcx/unpack/docker/usr/share/containerd/config.toml
+    - path: /etc/containerd/config.toml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          version = 2
+          # persistent data location
+          root = "/var/lib/containerd"
+          # runtime state information
+          state = "/run/containerd"
+          # set containerd as a subreaper on linux when it is not running as PID 1
+          subreaper = true
+          # set containerd's OOM score
+          oom_score = -999
+          disabled_plugins = []
+          # grpc configuration
+          [grpc]
+          address = "/run/containerd/containerd.sock"
+          # socket uid
+          uid = 0
+          # socket gid
+          gid = 0
+          [plugins."containerd.runtime.v1.linux"]
+          # shim binary name/path
+          shim = "containerd-shim"
+          # runtime binary name/path
+          runtime = "runc"
+          # do not use a shim when starting containers, saves on memory but
+          # live restore is not supported
+          no_shim = false
+          [plugins."io.containerd.grpc.v1.cri"]
+          # enable SELinux labeling
+          enable_selinux = true
+          sandbox_image = "{{ .PauseImage }}:{{ .PauseImageTag }}"
+          # compat with previous docker based runtime
+          enable_unprivileged_ports = true
+          enable_unprivileged_icmp = true
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          # setting runc.options unsets parent settings
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+          SystemdCgroup = true
+    - path: /etc/systemd/resolved.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          [Resolve]
+          DNSStubListener=no
+    - path: /etc/systemd/network/50-kubernikus.netdev
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          [NetDev]
+          Description=Kubernikus Dummy Interface
+          Name=kubernikus
+          Kind=dummy
+    - path: /etc/systemd/network/51-kubernikus.network
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          [Match]
+          Name=kubernikus
+          [Network]
+          DHCP=no
+          Address={{ .ApiserverIP }}/32
+    - path: /etc/udev/rules.d/99-vmware-scsi-udev.rules
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware  ", ATTRS{model}=="Virtual disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/timeout'"
+    - path: /etc/ssl/certs/SAPGlobalRootCA.pem
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          -----BEGIN CERTIFICATE-----
+          MIIGTDCCBDSgAwIBAgIQXQPZPTFhXY9Iizlwx48bmTANBgkqhkiG9w0BAQsFADBO
+          MQswCQYDVQQGEwJERTERMA8GA1UEBwwIV2FsbGRvcmYxDzANBgNVBAoMBlNBUCBB
+          RzEbMBkGA1UEAwwSU0FQIEdsb2JhbCBSb290IENBMB4XDTEyMDQyNjE1NDE1NVoX
+          DTMyMDQyNjE1NDYyN1owTjELMAkGA1UEBhMCREUxETAPBgNVBAcMCFdhbGxkb3Jm
+          MQ8wDQYDVQQKDAZTQVAgQUcxGzAZBgNVBAMMElNBUCBHbG9iYWwgUm9vdCBDQTCC
+          AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAOrxJKFFA1eTrZg1Ux8ax6n/
+          LQRHZlgLc2FZpfyAgwvkt71wLkPLiTOaRb3Bd1dyydpKcwJLy0dzGkunzNkPRSFz
+          bKy2IPS0RS45hUCCPzhGnqQM6TcDYWeWpSUvygqujgb/cAG0mSJpvzAD3SMDQ+VJ
+          Az5Ryq4IrP7LkfCb63LKZxLsHEkEcNKoGPsSsd4LTwuEIyM3ZHcCoA97m6hvgLWV
+          GLzLIQMEblkswqX29z7JZH+zJopoqZB6eEogE2YpExkw52PufytEslDY3dyVubjp
+          GlvD4T03F2zm6CYleMwgWbATLVYvk2I9WfqPAP+ln2IU9DZzegSMTWHCE+jizaiq
+          b5f5s7m8f+cz7ndHSrz8KD/S9iNdWpuSlknHDrh+3lFTX/uWNBRs5mC/cdejcqS1
+          v6erflyIfqPWWO6PxhIs49NL9Lix3ou6opJo+m8K757T5uP/rQ9KYALIXvl2uFP7
+          0CqI+VGfossMlSXa1keagraW8qfplz6ffeSJQWO/+zifbfsf0tzUAC72zBuO0qvN
+          E7rSbqAfpav/o010nKP132gbkb4uOkUfZwCuvZjA8ddsQ4udIBRj0hQlqnPLJOR1
+          PImrAFC3PW3NgaDEo9QAJBEp5jEJmQghNvEsmzXgABebwLdI9u0VrDz4mSb6TYQC
+          XTUaSnH3zvwAv8oMx7q7AgMBAAGjggEkMIIBIDAOBgNVHQ8BAf8EBAMCAQYwEgYD
+          VR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUg8dB/Q4mTynBuHmOhnrhv7XXagMw
+          gdoGA1UdIASB0jCBzzCBzAYKKwYBBAGFNgRkATCBvTAmBggrBgEFBQcCARYaaHR0
+          cDovL3d3dy5wa2kuY28uc2FwLmNvbS8wgZIGCCsGAQUFBwICMIGFHoGCAEMAZQBy
+          AHQAaQBmAGkAYwBhAHQAZQAgAFAAbwBsAGkAYwB5ACAAYQBuAGQAIABDAGUAcgB0
+          AGkAZgBpAGMAYQB0AGkAbwBuACAAUAByAGEAYwB0AGkAYwBlACAAUwB0AGEAdABl
+          AG0AZQBuAHQAIABvAGYAIABTAEEAUAAgAEEARzANBgkqhkiG9w0BAQsFAAOCAgEA
+          0HpCIaC36me6ShB3oHDexA2a3UFcU149nZTABPKT+yUCnCQPzvK/6nJUc5I4xPfv
+          2Q8cIlJjPNRoh9vNSF7OZGRmWQOFFrPWeqX5JA7HQPsRVURjJMeYgZWMpy4t1Tof
+          lF13u6OY6xV6A5kQZIISFj/dOYLT3+O7wME5SItL+YsNh6BToNU0xAZt71Z8JNdY
+          VJb2xSPMzn6bNXY8ioGzHlVxfEvzMqebV0KY7BTXR3y/Mh+v/RjXGmvZU6L/gnU7
+          8mTRPgekYKY8JX2CXTqgfuW6QSnJ+88bHHMhMP7nPwv+YkPcsvCPBSY08ykzFATw
+          SNoKP1/QFtERVUwrUXt3Cufz9huVysiy23dEyfAglgCCRWA+ZlaaXfieKkUWCJaE
+          Kw/2Jqz02HDc7uXkFLS1BMYjr3WjShg1a+ulYvrBhNtseRoZT833SStlS/jzZ8Bi
+          c1dt7UOiIZCGUIODfcZhO8l4mtjh034hdARLF0sUZhkVlosHPml5rlxh+qn8yJiJ
+          GJ7CUQtNCDBVGksVlwew/+XnesITxrDjUMu+2297at7wjBwCnO93zr1/wsx1e2Um
+          Xn+IfM6K/pbDar/y6uI9rHlyWu4iJ6cg7DAPJ2CCklw/YHJXhDHGwheO/qSrKtgz
+          PGHZoN9jcvvvWDLUGtJkEotMgdFpEA2XWR83H4fVFVc=
+          -----END CERTIFICATE-----
+    - path: /etc/ssl/certs/SAPNetCA_G2.pem
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          -----BEGIN CERTIFICATE-----
+          MIIGPTCCBCWgAwIBAgIKYQ4GNwAAAAAADDANBgkqhkiG9w0BAQsFADBOMQswCQYD
+          VQQGEwJERTERMA8GA1UEBwwIV2FsbGRvcmYxDzANBgNVBAoMBlNBUCBBRzEbMBkG
+          A1UEAwwSU0FQIEdsb2JhbCBSb290IENBMB4XDTE1MDMxNzA5MjQ1MVoXDTI1MDMx
+          NzA5MzQ1MVowRDELMAkGA1UEBhMCREUxETAPBgNVBAcMCFdhbGxkb3JmMQwwCgYD
+          VQQKDANTQVAxFDASBgNVBAMMC1NBUE5ldENBX0cyMIICIjANBgkqhkiG9w0BAQEF
+          AAOCAg8AMIICCgKCAgEAjuP7Hj/1nVWfsCr8M/JX90s88IhdTLaoekrxpLNJ1W27
+          ECUQogQF6HCu/RFD4uIoanH0oGItbmp2p8I0XVevHXnisxQGxBdkjz+a6ZyOcEVk
+          cEGTcXev1i0R+MxM8Y2WW/LGDKKkYOoVRvA5ChhTLtX2UXnBLcRdf2lMMvEHd/nn
+          KWEQ47ENC+uXd6UPxzE+JqVSVaVN+NNbXBJrI1ddNdEE3/++PSAmhF7BSeNWscs7
+          w0MoPwHAGMvMHe9pas1xD3RsRFQkV01XiJqqUbf1OTdYAoUoXo9orPPrO7FMfXjZ
+          RbzwzFtdKRlAFnKZOVf95MKlSo8WzhffKf7pQmuabGSLqSSXzIuCpxuPlNy7kwCX
+          j5m8U1xGN7L2vlalKEG27rCLx/n6ctXAaKmQo3FM+cHim3ko/mOy+9GDwGIgToX3
+          5SQPnmCSR19H3nYscT06ff5lgWfBzSQmBdv//rjYkk2ZeLnTMqDNXsgT7ac6LJlj
+          WXAdfdK2+gvHruf7jskio29hYRb2//ti5jD3NM6LLyovo1GOVl0uJ0NYLsmjDUAJ
+          dqqNzBocy/eV3L2Ky1L6DvtcQ1otmyvroqsL5JxziP0/gRTj/t170GC/aTxjUnhs
+          7vDebVOT5nffxFsZwmolzTIeOsvM4rAnMu5Gf4Mna/SsMi9w/oeXFFc/b1We1a0C
+          AwEAAaOCASUwggEhMAsGA1UdDwQEAwIBBjAdBgNVHQ4EFgQUOCSvjXUS/Dg/N4MQ
+          r5A8/BshWv8wHwYDVR0jBBgwFoAUg8dB/Q4mTynBuHmOhnrhv7XXagMwSwYDVR0f
+          BEQwQjBAoD6gPIY6aHR0cDovL2NkcC5wa2kuY28uc2FwLmNvbS9jZHAvU0FQJTIw
+          R2xvYmFsJTIwUm9vdCUyMENBLmNybDBWBggrBgEFBQcBAQRKMEgwRgYIKwYBBQUH
+          MAKGOmh0dHA6Ly9haWEucGtpLmNvLnNhcC5jb20vYWlhL1NBUCUyMEdsb2JhbCUy
+          MFJvb3QlMjBDQS5jcnQwGQYJKwYBBAGCNxQCBAweCgBTAHUAYgBDAEEwEgYDVR0T
+          AQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQsFAAOCAgEAGdBNALO509FQxcPhMCwE
+          /eymAe9f2u6hXq0hMlQAuuRbpnxr0+57lcw/1eVFsT4slceh7+CHGCTCVHK1ELAd
+          XQeibeQovsVx80BkugEG9PstCJpHnOAoWGjlZS2uWz89Y4O9nla+L9SCuK7tWI5Y
+          +QuVhyGCD6FDIUCMlVADOLQV8Ffcm458q5S6eGViVa8Y7PNpvMyFfuUTLcUIhrZv
+          eh4yjPSpz5uvQs7p/BJLXilEf3VsyXX5Q4ssibTS2aH2z7uF8gghfMvbLi7sS7oj
+          XBEylxyaegwOBLtlmcbII8PoUAEAGJzdZ4kFCYjqZBMgXK9754LMpvkXDTVzy4OP
+          emK5Il+t+B0VOV73T4yLamXG73qqt8QZndJ3ii7NGutv4SWhVYQ4s7MfjRwbFYlB
+          z/N5eH3veBx9lJbV6uXHuNX3liGS8pNVNKPycfwlaGEbD2qZE0aZRU8OetuH1kVp
+          jGqvWloPjj45iCGSCbG7FcY1gPVTEAreLjyINVH0pPve1HXcrnCV4PALT6HvoZoF
+          bCuBKVgkSSoGgmasxjjjVIfMiOhkevDya52E5m0WnM1LD3ZoZzavsDSYguBP6MOV
+          ViWNsVHocptphbEgdwvt3B75CDN4kf6MNZg2/t8bRhEQyK1FRy8NMeBnbRFnnEPe
+          7HJNBB1ZTjnrxJAgCQgNBIQ=
+          -----END CERTIFICATE-----
+    - path: /etc/sysctl.d/10-enable-icmp-redirects.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          net.ipv4.conf.all.accept_redirects=1
+    - path: /etc/sysctl.d/20-inotify-max-user.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          fs.inotify.max_user_instances=8192
+          fs.inotify.max_user_watches=524288
+    - path: /etc/kubernetes/certs/kubelet-clients-ca.pem
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+{{ .KubeletClientsCA | indent 10 }}
+    - path: /etc/kubernetes/bootstrap/kubeconfig
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          apiVersion: v1
+          kind: Config
+          clusters:
+            - name: local
+              cluster:
+                 certificate-authority-data: {{ .TLSCA | b64enc }}
+                 server: {{ .ApiserverURL }}
+          contexts:
+            - name: local
+              context:
+                cluster: local
+                user: local
+          current-context: local
+          users:
+            - name: local
+              user:
+                token: {{ .BootstrapToken }}
+    - path: /etc/kubernetes/kubelet/config
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          readOnlyPort: 0
+          clusterDomain: {{ .ClusterDomain }}
+          clusterDNS: [{{ .ClusterDNSAddress }}]
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/certs/kubelet-clients-ca.pem
+            anonymous:
+              enabled: true
+          rotateCertificates: true
+          nodeLeaseDurationSeconds: 20
+          cgroupDriver: systemd
+    - path: /etc/flatcar/update.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |-
+          REBOOT_STRATEGY="off"
+    - path: /etc/modules-load.d/br_netfilter.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: br_netfilter
+    - path: /etc/sysctl.d/30-br_netfilter.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.bridge.bridge-nf-call-iptables = 1
+`

--- a/swagger.yml
+++ b/swagger.yml
@@ -520,7 +520,7 @@ definitions:
         maxLength: 10000
       version:
         description: Kubernetes version
-        pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        pattern: '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
         type: string
       name:
         type: string


### PR DESCRIPTION
As this is from my local 1.27-rc branch, the semver regex was adjusted as well as the conditions in the helm chart, so that `1.27-rc... >= 1.27`.

- [ ] Test it
- [ ] Consider updating the CSI components