### PR TITLE
Set `csi-cinder-nodeplugin` priority to `system-node-critical`

### DIFF
--- a/charts/seed/templates/csi.yaml
+++ b/charts/seed/templates/csi.yaml
@@ -450,6 +450,7 @@ spec:
         - operator: Exists
       serviceAccount: csi-cinder-node-sa
       hostNetwork: true
+      priorityClassName: system-node-critical
       containers:
         - name: node-driver-registrar
           image: "{{ .Values.images.csiNodeDriver.repository }}:{{ .Values.images.csiNodeDriver.tag }}"

--- a/pkg/controller/ground/bootstrap/csi/manifest.go
+++ b/pkg/controller/ground/bootstrap/csi/manifest.go
@@ -358,6 +358,7 @@ spec:
         - operator: Exists
       serviceAccount: csi-cinder-node-sa
       hostNetwork: true
+      priorityClassName: system-node-critical
       containers:
         - name: node-driver-registrar
           image: "{{ .ImageNodeDriver }}"


### PR DESCRIPTION
Fixes https://github.com/sapcc/kubernikus/issues/825

In Gardener, we run the CSI node plugin with the `system-node-critical` PriorityClass:  https://github.com/gardener/gardener-extension-provider-openstack/blob/05711993d1f0fd0f8e7199c76dcbdfc4cb08e93b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml#L27C7-L27C46

