### PR TITLE
Fix containerd config on existing nodes

### DIFF
--- a/charts/seed/templates/containerd-fix.yaml
+++ b/charts/seed/templates/containerd-fix.yaml
@@ -1,0 +1,44 @@
+{{- if semverCompare ">= 1.24-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: containerd-fix
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: containerd-fix
+  template:
+    metadata:
+      labels:
+        app: containerd-fix
+    spec:
+      tolerations:
+        - operator: Exists
+      hostPID: true
+      initContainers:
+        - name: init
+          image: keppel.global.cloud.sap/ccloud-dockerhub-mirror/library/alpine:latest
+          securityContext:
+            privileged: true
+          command:
+            - sh
+            - -c
+          args:
+            - |-
+              set -xe
+              FILE=/host/etc/containerd/config.toml
+              if [ -f "$FILE" ]; then
+                sed -i 's/\[plugins."containerd.runtime.v1.linux"\]/\[plugins."io.containerd.runtime.v1.linux"\]/g' $FILE
+              fi
+          volumeMounts:
+            - name: host
+              mountPath: "/host"
+      containers:
+        - name: pause
+          image: keppel.global.cloud.sap/ccloud-dockerhub-mirror/sapcc/pause-amd64:3.1
+      volumes:
+        - name: host
+          hostPath:
+            path: "/"
+{{- end }}


### PR DESCRIPTION
This PR is fixing containerd config on existing nodes and is rolled out via seed reconciliation. This _should_ also work for older Flatcar versions, as we use containerd version `1.6.x` since we enabled it in node templates.

I would like to have more testing and a bit of discussion before merging.

cc @defo89 