### PR TITLE
Disable k8s 1.25 support

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2562,7 +2562,7 @@ imagesForVersion:
     scheduler:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
       tag: v1.25.15
-    supported: true
+    supported: false
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme


### PR DESCRIPTION
Kubernetes 1.25 is EOL on 2023-10-28.