### PR TITLE
cluser typo fixed

### DIFF
--- a/pkg/api/client/operations/operations_client.go
+++ b/pkg/api/client/operations/operations_client.go
@@ -552,7 +552,7 @@ func (a *Client) ListClusters(params *ListClustersParams, authInfo runtime.Clien
 }
 
 /*
-ShowCluster shows the specified cluser
+ShowCluster shows the specified cluster
 */
 func (a *Client) ShowCluster(params *ShowClusterParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*ShowClusterOK, error) {
 	// TODO: Validate the params before sending
@@ -628,7 +628,7 @@ func (a *Client) TerminateCluster(params *TerminateClusterParams, authInfo runti
 }
 
 /*
-UpdateCluster updates the specified cluser
+UpdateCluster updates the specified cluster
 */
 func (a *Client) UpdateCluster(params *UpdateClusterParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateClusterOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/api/rest/operations/show_cluster.go
+++ b/pkg/api/rest/operations/show_cluster.go
@@ -34,7 +34,7 @@ func NewShowCluster(ctx *middleware.Context, handler ShowClusterHandler) *ShowCl
 /*
 	ShowCluster swagger:route GET /api/v1/clusters/{name} showCluster
 
-Show the specified cluser
+Show the specified cluster
 */
 type ShowCluster struct {
 	Context *middleware.Context

--- a/pkg/api/rest/operations/update_cluster.go
+++ b/pkg/api/rest/operations/update_cluster.go
@@ -34,7 +34,7 @@ func NewUpdateCluster(ctx *middleware.Context, handler UpdateClusterHandler) *Up
 /*
 	UpdateCluster swagger:route PUT /api/v1/clusters/{name} updateCluster
 
-Update the specified cluser
+Update the specified cluster
 */
 type UpdateCluster struct {
 	Context *middleware.Context

--- a/pkg/api/spec/embedded_spec.go
+++ b/pkg/api/spec/embedded_spec.go
@@ -92,7 +92,7 @@ func init() {
     },
     "/api/v1/clusters/{name}": {
       "get": {
-        "summary": "Show the specified cluser",
+        "summary": "Show the specified cluster",
         "operationId": "ShowCluster",
         "responses": {
           "200": {
@@ -107,7 +107,7 @@ func init() {
         }
       },
       "put": {
-        "summary": "Update the specified cluser",
+        "summary": "Update the specified cluster",
         "operationId": "UpdateCluster",
         "parameters": [
           {
@@ -1150,7 +1150,7 @@ func init() {
     },
     "/api/v1/clusters/{name}": {
       "get": {
-        "summary": "Show the specified cluser",
+        "summary": "Show the specified cluster",
         "operationId": "ShowCluster",
         "responses": {
           "200": {
@@ -1168,7 +1168,7 @@ func init() {
         }
       },
       "put": {
-        "summary": "Update the specified cluser",
+        "summary": "Update the specified cluster",
         "operationId": "UpdateCluster",
         "parameters": [
           {

--- a/swagger.yml
+++ b/swagger.yml
@@ -138,7 +138,7 @@ paths:
         in: path
     get:
       operationId: ShowCluster
-      summary: Show the specified cluser
+      summary: Show the specified cluster
       responses:
         '200':
           description: OK
@@ -156,7 +156,7 @@ paths:
           $ref: '#/responses/errorResponse'
     put:
       operationId: UpdateCluster
-      summary: Update the specified cluser
+      summary: Update the specified cluster
       responses:
         '200':
           description: OK
@@ -351,7 +351,7 @@ definitions:
           properties:
             name:
               type: string
-            publicKey: 
+            publicKey:
               type: string
 
       routers:
@@ -476,11 +476,11 @@ definitions:
         type: boolean
       dashboard:
         type: boolean
-        x-nullable: true 
+        x-nullable: true
         x-omitempty: false
       dex:
         type: boolean
-        x-nullable: true 
+        x-nullable: true
         x-omitempty: false
       serviceCIDR:
         description: CIDR Range for Services in the cluster. Can not be updated.
@@ -606,11 +606,11 @@ definitions:
         $ref: '#/definitions/NodePoolConfig'
   NodePoolConfig:
     type: object
-    x-nullable: true 
+    x-nullable: true
     properties:
       allowReboot:
         description: Allow automatic drain and reboot of nodes. Enables OS updates. Required by security policy.
-        x-nullable: true 
+        x-nullable: true
         x-omitempty: false
         type: boolean
       allowReplace:


### PR DESCRIPTION
`cluser` renamed to `cluster`