### PR TITLE
Only offer TLS 1.3 in kubelet server

### DIFF
--- a/charts/seed/templates/kubeadm.yaml
+++ b/charts/seed/templates/kubeadm.yaml
@@ -258,6 +258,7 @@ data:
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
     volumeStatsAggPeriod: 0s
+    tlsMinVersion: VersionTLS13
 kind: ConfigMap
 metadata:
   name: kubelet-config

--- a/pkg/api/handlers/get_cluster_bootstrap.go
+++ b/pkg/api/handlers/get_cluster_bootstrap.go
@@ -46,6 +46,7 @@ authentication:
     enabled: true
 rotateCertificates: true
 nodeLeaseDurationSeconds: 20
+tlsMinVersion: VersionTLS13
 featureGates:
 `))
 

--- a/pkg/templates/node_1.27.go
+++ b/pkg/templates/node_1.27.go
@@ -297,6 +297,7 @@ storage:
           rotateCertificates: true
           nodeLeaseDurationSeconds: 20
           cgroupDriver: systemd
+          tlsMinVersion: VersionTLS13
     - path: /etc/flatcar/update.conf
       filesystem: root
       mode: 0644


### PR DESCRIPTION
This config change limits kubelet server to only offer TLS 1.3 ciphers. Those are:

```
 x1302   TLS_AES_256_GCM_SHA384            ECDH 253   AESGCM      256      TLS_AES_256_GCM_SHA384                             
 x1303   TLS_CHACHA20_POLY1305_SHA256      ECDH 253   ChaCha20    256      TLS_CHACHA20_POLY1305_SHA256                       
 x1301   TLS_AES_128_GCM_SHA256            ECDH 253   AESGCM      128      TLS_AES_128_GCM_SHA256       
```

See attachment for detailed scan.

References:
https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
https://pkg.go.dev/crypto/tls#pkg-constants
https://nvd.nist.gov/vuln/detail/CVE-2016-2183

[testssl.txt](https://github.com/sapcc/kubernikus/files/14512332/testssl.txt)
