### PR TITLE
Disable k8s 1.26 support

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -3309,7 +3309,7 @@ imagesForVersion:
     scheduler:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
       tag: v1.26.13
-    supported: true
+    supported: false
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme


### PR DESCRIPTION
k8s 1.26 is eol, this disables support.