### PR TITLE
Add endpoint-updates-batch-period flag to controller manager

### DIFF
--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.1.8
+version: 2.1.9

--- a/charts/kube-master/templates/controller-manager.yaml
+++ b/charts/kube-master/templates/controller-manager.yaml
@@ -147,6 +147,9 @@ spec:
             - --use-service-account-credentials
             - --pv-recycler-pod-template-filepath-hostpath=/etc/kubernetes/config/pv-recycler-template
             - --pv-recycler-pod-template-filepath-nfs=/etc/kubernetes/config/pv-recycler-template
+{{- if .Values.controllerManager.endpointUpdatePeriod }}
+            - --endpoint-updates-batch-period={{ .Values.controllerManager.endpointUpdatePeriod }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/kube-master/values.yaml
+++ b/charts/kube-master/values.yaml
@@ -69,6 +69,8 @@ cloudControllerManager:
 
 controllerManager:
   replicaCount: 1
+  # addresses endpoint issue https://github.com/kubernetes/kubernetes/issues/117193
+  endpointUpdatePeriod: 3s
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
When pod readiness is changing states in very short succession we are missing the ready state and are loosing all active endpoints and they are not reconciled anymore. Raising the duration of controller-manager flag `--endpoint-updates-batch-period` should mitigate this issue.

Also see discussion at https://github.com/kubernetes/kubernetes/issues/117193