### PR TITLE
Fix service user role reconciliation

### DIFF
--- a/pkg/controller/flight/reconciler.go
+++ b/pkg/controller/flight/reconciler.go
@@ -143,21 +143,20 @@ func (f *flightReconciler) EnsureServiceUserRoles() []string {
 	}
 
 	rolesToCreate := []string{}
-	if len(existingUserRoles) != len(wantedUserRoles) {
-		for _, wantedUserRole := range wantedUserRoles {
-			exists := false
-			for _, existingUserRole := range existingUserRoles {
-				if existingUserRole == wantedUserRole {
-					exists = true
-					break
-				}
-			}
-			if !exists {
-				rolesToCreate = append(rolesToCreate, wantedUserRole)
+	for _, wantedUserRole := range wantedUserRoles {
+		exists := false
+		for _, existingUserRole := range existingUserRoles {
+			if existingUserRole == wantedUserRole {
+				exists = true
+				break
 			}
 		}
-
-		err = f.AdminClient.AssignUserRoles(secret.Openstack.ProjectID, secret.Openstack.Username, secret.Openstack.DomainName, wantedUserRoles)
+		if !exists {
+			rolesToCreate = append(rolesToCreate, wantedUserRole)
+		}
+	}
+	if len(rolesToCreate) > 0 {
+		err = f.AdminClient.AssignUserRoles(secret.Openstack.ProjectID, secret.Openstack.Username, secret.Openstack.DomainName, rolesToCreate)
 		if err != nil {
 			f.Logger.Log("msg", "couldn't reconcile service user roles", "err", err)
 		}


### PR DESCRIPTION
The check if roles are actually missing was flawed and would constanly try to update a service user if it had any additional roles assigned besides the wanted ones.

Note: I did not test this change in a devstack. I just made sure it compiles