### PR TITLE
Change audit log config for pod/exec and pod/attach

### DIFF
--- a/charts/kube-master/templates/configmap.yaml
+++ b/charts/kube-master/templates/configmap.yaml
@@ -95,7 +95,7 @@ data:
       - group: ""
         resources: ["secrets", "serviceaccounts"]
       - group: ""
-        resources: ["pods/log"]
+        resources: ["pods/log", "pods/exec", "pods/attach"]
     - level: Request
       resources:
       - group: "rbac.authorization.k8s.io"


### PR DESCRIPTION
kubectl 1.30 switched to websockets instead of
SPDY, which changes exec from a POST to a GET request.