### PR TITLE
Remove deprecated cloud provider flag

### DIFF
--- a/charts/kube-master/templates/api.yaml
+++ b/charts/kube-master/templates/api.yaml
@@ -213,7 +213,7 @@ spec:
             {{- if (semverCompare "< 1.20" .Values.version.kubernetes) }}
             - --cloud-config=/etc/kubernetes/cloudprovider/openstack.config
             - --cloud-provider=openstack
-            {{- else }}
+            {{- else if (semverCompare "< 1.33" .Values.version.kubernetes) }}
             - --cloud-provider=external
             {{- end }}
             {{- end }}


### PR DESCRIPTION
Flags got removed in 1.33, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#other-cleanup-or-flake-1