### PR TITLE
Update golangci-lint in pipeline

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,7 +23,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.62.2
+        version: v1.64.8
     - name: Tests
       run: /bin/bash -c make gotest
     - name: Build e2e


### PR DESCRIPTION
Renovate PRs currently fail due to using an outdated go + golangci-lint version