### PR TITLE
Disable Kubernetes 1.32 and 1.33 due to NodeAuthorizerWithSelector feature

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -8005,7 +8005,7 @@ imagesForVersion:
     scheduler:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
       tag: v1.32.6
-    supported: true
+    supported: false
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme
@@ -8089,7 +8089,7 @@ imagesForVersion:
     scheduler:
       repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
       tag: v1.33.2
-    supported: true
+    supported: false
     wormhole:
       repository: keppel.global.cloud.sap/ccloud/kubernikus
       tag: changeme


### PR DESCRIPTION
See: https://github.com/flannel-io/flannel/pull/2270.