### PR TITLE
Add support for KVM

### DIFF
--- a/pkg/client/openstack/factory.go
+++ b/pkg/client/openstack/factory.go
@@ -231,7 +231,7 @@ func (f *factory) serviceClientsFor(authOptions *tokens.AuthOptions, logger log.
 	}
 
 	compute, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{})
-	compute.Microversion = "2.52" // 2.52 supports specifying server tags during create
+	compute.Microversion = "2.67" // 2.67 supports specifying volume_type when creating a server, which is required for KVM
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/client/openstack/kluster/client.go
+++ b/pkg/client/openstack/kluster/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
@@ -101,15 +102,26 @@ func (c *klusterClient) CreateNode(kluster *v1.Kluster, pool *models.NodePool, n
 	}
 
 	var server *servers.Server
+	useCinderBasedRootDisk := pool.CustomRootDiskSize > 0
+	volumeType := "vmware"
+	rootDiskSize := int(pool.CustomRootDiskSize)
+	if isKVMFlavour, err := regexp.MatchString(`^(hana|[cgm])_k_.*`, pool.Flavor); err == nil && isKVMFlavour {
+		useCinderBasedRootDisk = true
+		volumeType = "premium"
+		if rootDiskSize == 0 {
+			rootDiskSize = 64
+		}
+	}
 
-	if pool.CustomRootDiskSize > 0 {
+	if useCinderBasedRootDisk {
 		blockDevices := []bootfromvolume.BlockDevice{{
 			UUID:                imageID,
-			VolumeSize:          int(pool.CustomRootDiskSize),
+			VolumeSize:          rootDiskSize,
 			BootIndex:           0,
 			DeleteOnTermination: true,
 			SourceType:          "image",
 			DestinationType:     "volume",
+			VolumeType:          volumeType,
 		}}
 		createOpts = &bootfromvolume.CreateOptsExt{
 			CreateOptsBuilder: createOpts,


### PR DESCRIPTION
For kvm we need to always use cinder based root disks and use a dedicated volume_type.

The basic idea is to enforce cinder based root disks and set the volume type when any of our lvm flavours is used.