### PR TITLE
Sanitize volume type names to RFC 1123 for StorageClass names

### DIFF
--- a/charts/seed/templates/storageclasses.yaml
+++ b/charts/seed/templates/storageclasses.yaml
@@ -12,6 +12,9 @@
     false
   {{- end -}}
 {{- end -}}
+{{- define "seed.dns-name" -}}
+  {{- . | lower | regexReplaceAll "[^a-z0-9-]" "-" | trimSuffix "-" | trimPrefix "-" -}}
+{{- end -}}
 
 {{- if and (not .Values.seedKubeadm) (not .Values.seedVirtual) .Values.openstack -}}
 
@@ -32,7 +35,7 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: cinder-{{ $vt | lower }}
+  name: cinder-{{ include "seed.dns-name" $vt }}
 provisioner: {{ template "seed.storage-provisioner" $ }}
 allowVolumeExpansion: {{ template "seed.storage-expansion" $ }}
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
## Summary

- Adds a `seed.dns-name` Helm template helper that sanitizes arbitrary strings to RFC 1123 subdomain format
- Applies it to volume type names when generating StorageClass names
- Fixes deployment failures when Cinder volume types contain underscores, spaces, or other non-DNS characters (e.g. `standard_hdd` → `cinder-standard-hdd`)

Follows up on #1070.
