### PR TITLE
fix(etcd): pin etcdbrctl --endpoints to match transport

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -233,11 +233,13 @@ spec:
             {{- end }}
             - --garbage-collection-policy={{ .Values.backup.garbageCollectionPolicy }}
             {{- if .Values.secure.enabled }}
+            - --endpoints=https://127.0.0.1:2379
             - --cacert=/etc/kubernetes/certs/tls-etcd-ca.pem
             - --cert=/etc/kubernetes/certs/etcd-clients-backup.pem
             - --key=/etc/kubernetes/certs/etcd-clients-backup-key.pem
             - --insecure-transport=false
             {{- else }}
+            - --endpoints=http://127.0.0.1:2379
             - --insecure-transport=true
             {{- end }}
           image: "{{ include "etcdBackup.image" . }}"


### PR DESCRIPTION
etcd listens on the scheme picked by secure.enabled; etcdbrctl
expects --endpoints with the same scheme. Its default became http,
so without this the backup container can't reach an HTTPS etcd.