### PR TITLE
fix(etcd): mount Swift credentials as files for etcdbrctl

### DIFF
--- a/Dockerfile.kubernikus-binaries
+++ b/Dockerfile.kubernikus-binaries
@@ -1,7 +1,7 @@
 FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/golang:1.25-alpine3.21 as builder
 RUN apk add --no-cache make git curl bash gcc musl-dev
 WORKDIR /app
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
 COPY . .
 ENV GOARCH=amd64
 ARG VERSION

--- a/charts/kube-master/Chart.yaml
+++ b/charts/kube-master/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube-master
-version: 2.1.11
+version: 2.1.12

--- a/charts/kube-master/charts/etcd/Chart.yaml
+++ b/charts/kube-master/charts/etcd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: etcd
-version: 0.1.3
+version: 0.1.4

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -60,6 +60,14 @@ data:
   etcd.conf.yaml: |-
     name: kubernikus
     initial-cluster: default=http://127.0.0.1:2380
+{{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
+    initial-advertise-peer-urls:
+      kubernikus:
+        - http://localhost:2380
+    advertise-client-urls:
+      kubernikus:
+        - {{ if .Values.secure.enabled }}https{{ else }}http{{ end }}://localhost:2379
+{{- end }}
 {{- end }}
 ---
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
@@ -325,9 +333,13 @@ spec:
 {{- end }}
 {{- if (semverCompare ">= 1.23-0" .Values.version.kubernetes) }}
             - name: POD_NAME
+{{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
+              value: "kubernikus"
+{{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+{{- end }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -329,7 +329,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: POD_NAMESPACE
-              value: {{ include "fullname" . }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 {{- end }}
           volumeMounts:
             - mountPath: /var/lib/etcd

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -131,6 +131,22 @@ spec:
               path: secretAccessKey
 {{- end }}
 {{- end }}
+{{- if eq .Values.backup.storageProvider "Swift" }}
+        - name: swift-creds
+          secret:
+            secretName: {{ include "fullname" . }}
+            items:
+              - key: openstack-auth-url
+                path: authURL
+              - key: openstack-username
+                path: username
+              - key: openstack-password
+                path: password
+              - key: openstack-domain-name
+                path: domainName
+              - key: openstack-project-name
+                path: tenantName
+{{- end }}
 {{- if .Values.secure.enabled }}
         - name: certs-etcd
           secret:
@@ -282,6 +298,8 @@ spec:
 {{- else if eq .Values.backup.storageProvider "Swift" }}
             - name: STORAGE_CONTAINER
               value: {{ .Values.storageContainer }}
+            - name: OPENSTACK_APPLICATION_CREDENTIALS
+              value: /var/etcd/swift-creds
             - name: OS_AUTH_URL
               valueFrom:
                 secretKeyRef:
@@ -329,6 +347,11 @@ spec:
               mountPath: "/etc/aws/credentials"
               readOnly: true
 {{- end }}
+{{- end }}
+{{- if eq .Values.backup.storageProvider "Swift" }}
+            - name: swift-creds
+              mountPath: /var/etcd/swift-creds
+              readOnly: true
 {{- end }}
           resources:
 {{ toYaml .Values.backup.resources | indent 12 }}

--- a/charts/kube-master/charts/etcd/templates/secrets.yaml
+++ b/charts/kube-master/charts/etcd/templates/secrets.yaml
@@ -15,5 +15,6 @@ data:
   openstack-password: {{ required "missing openstack-password" .Values.openstack.password | b64enc }}
   openstack-domain-name: {{ required "missing openstack-domain-name" .Values.openstack.domainName | b64enc }}
   openstack-project-id: {{ required "missing openstack-project-id" .Values.openstack.projectID | b64enc }}
+  openstack-project-name: {{ required "missing openstack-project-name" .Values.openstack.projectName | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/kube-master/test-values.yaml
+++ b/charts/kube-master/test-values.yaml
@@ -30,6 +30,7 @@ etcd:
     password: xyz
     domainName: xyz.com
     projectID: xyz
+    projectName: xyz
   images:
     etcd:
       repository: abc

--- a/pkg/apis/kubernikus/v1/secret.go
+++ b/pkg/apis/kubernikus/v1/secret.go
@@ -69,6 +69,7 @@ type Openstack struct {
 	DomainName        string `json:"openstack-domain-name,omitempty"`
 	Password          string `json:"openstack-password"`
 	ProjectID         string `json:"openstack-project-id"`
+	ProjectName       string `json:"openstack-project-name,omitempty"`
 	ProjectDomainName string `json:"openstack-project-domain-name,omitempty"`
 	UserDomainID      string `json:"openstack-user-domain-id,omitempty"`
 	ProjectDomainID   string `json:"openstack-project-domain-id,omitempty"`

--- a/pkg/client/openstack/admin/client.go
+++ b/pkg/client/openstack/admin/client.go
@@ -42,6 +42,7 @@ type AdminClient interface {
 	GetUserRoles(projectID, userName, domainName string) ([]string, error)
 	GetDefaultServiceUserRoles() []string
 	GetDomainNameByProject(projectID string) (string, error)
+	GetProjectName(projectID string) (string, error)
 }
 
 type adminClient struct {
@@ -181,6 +182,16 @@ func (c *adminClient) GetDomainNameByProject(projectID string) (string, error) {
 	}
 
 	return domain.Name, nil
+}
+
+func (c *adminClient) GetProjectName(projectID string) (string, error) {
+
+	project, err := projects.Get(c.IdentityClient, projectID).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return project.Name, nil
 }
 
 func (c *adminClient) GetDefaultServiceUserRoles() []string {

--- a/pkg/client/openstack/admin/logging.go
+++ b/pkg/client/openstack/admin/logging.go
@@ -162,6 +162,19 @@ func (c LoggingClient) GetDomainNameByProject(projectID string) (domainName stri
 	return c.Client.GetDomainNameByProject(projectID)
 }
 
+func (c LoggingClient) GetProjectName(projectID string) (projectName string, err error) {
+	defer func(begin time.Time) {
+		c.Logger.Log(
+			"msg", "get project name by project id",
+			"project_id", projectID,
+			"took", time.Since(begin),
+			"v", 2,
+			"err", err,
+		)
+	}(time.Now())
+	return c.Client.GetProjectName(projectID)
+}
+
 func (c LoggingClient) GetDefaultServiceUserRoles() (roles []string) {
 	return c.Client.GetDefaultServiceUserRoles()
 }

--- a/pkg/cmd/env.go
+++ b/pkg/cmd/env.go
@@ -10,7 +10,7 @@ import (
 
 func PopulateFromEnv(obj interface{}) error {
 	s := reflect.ValueOf(obj)
-	if s.Kind() != reflect.Ptr {
+	if s.Kind() != reflect.Pointer {
 		return errors.New("not a pointer")
 	}
 	//Create a zero valued copy of the passed struct

--- a/pkg/controller/ground.go
+++ b/pkg/controller/ground.go
@@ -680,6 +680,12 @@ func (op *GroundControl) createKluster(kluster *v1.Kluster) error {
 		}
 		klusterSecret.ProjectDomainName = domainNameByProject
 
+		projectName, err := adminClient.GetProjectName(klusterSecret.ProjectID)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve project name: %s", err)
+		}
+		klusterSecret.ProjectName = projectName
+
 		userDomainID, err := adminClient.GetDomainID(klusterSecret.DomainName)
 		if err != nil {
 			return err

--- a/pkg/migration/22_kluster_secret_project_name.go
+++ b/pkg/migration/22_kluster_secret_project_name.go
@@ -1,0 +1,32 @@
+package migration
+
+import (
+	v1 "github.com/sapcc/kubernikus/pkg/apis/kubernikus/v1"
+	"github.com/sapcc/kubernikus/pkg/controller/config"
+	"github.com/sapcc/kubernikus/pkg/util"
+)
+
+// Backfill ProjectName on the kluster Secret for clusters created before
+// ground.go started populating it. Required by etcdbrctl's swift creds file.
+func KlusterSecretProjectName(rawKluster []byte, current *v1.Kluster, clients config.Clients, factories config.Factories) error {
+	if current.Spec.NoCloud {
+		return nil
+	}
+	secret, err := util.KlusterSecret(clients.Kubernetes, current)
+	if err != nil {
+		return err
+	}
+	if secret.ProjectName != "" {
+		return nil
+	}
+	adminClient, err := factories.Openstack.AdminClient()
+	if err != nil {
+		return err
+	}
+	projectName, err := adminClient.GetProjectName(secret.ProjectID)
+	if err != nil {
+		return err
+	}
+	secret.ProjectName = projectName
+	return util.UpdateKlusterSecret(clients.Kubernetes, current, secret)
+}

--- a/pkg/migration/register.go
+++ b/pkg/migration/register.go
@@ -28,6 +28,7 @@ func init() {
 		FixFlannelOnFlatcar,
 		KlusterSecretOpenStackIds,
 		Helm2to3,
+		KlusterSecretProjectName,
 		// <-- Insert new migrations at the end only!
 	}
 }

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -33,6 +33,7 @@ type openstackValues struct {
 	Password            string `yaml:"password,omitempty" json:"password,omitempty"`
 	DomainName          string `yaml:"domainName,omitempty" json:"domainName,omitempty"`
 	ProjectID           string `yaml:"projectID,omitempty" json:"projectID,omitempty"`
+	ProjectName         string `yaml:"projectName,omitempty" json:"projectName,omitempty"`
 	ProjectDomainName   string `yaml:"projectDomainName,omitempty" json:"projectDomainName,omitempty"`
 	Region              string `yaml:"region,omitempty" json:"region,omitempty"`
 	LbSubnetID          string `yaml:"lbSubnetID,omitempty" json:"lbSubnetID,omitempty"`
@@ -199,6 +200,7 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 				Password:          secret.Password,
 				DomainName:        secret.DomainName,
 				ProjectID:         secret.ProjectID,
+				ProjectName:       secret.ProjectName,
 				ProjectDomainName: secret.ProjectDomainName,
 			},
 			Version: versionValues{
@@ -229,6 +231,7 @@ func KlusterToHelmValues(kluster *v1.Kluster, secret *v1.Secret, kubernetesVersi
 			DomainName:          secret.DomainName,
 			Region:              secret.Region,
 			ProjectID:           kluster.Account(),
+			ProjectName:         secret.ProjectName,
 			ProjectDomainName:   secret.ProjectDomainName,
 			LbSubnetID:          kluster.Spec.Openstack.LBSubnetID,
 			LbFloatingNetworkID: kluster.Spec.Openstack.LBFloatingNetworkID,

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -164,7 +164,7 @@ func (v *Version) String() string {
 		if i > 0 {
 			buffer.WriteString(".")
 		}
-		buffer.WriteString(fmt.Sprintf("%d", comp))
+		fmt.Fprintf(&buffer, "%d", comp)
 	}
 	if v.preRelease != "" {
 		buffer.WriteString("-")


### PR DESCRIPTION
etcdbrctl v0.28+ unconditionally checks Swift credential file mtime before every snapshot; without OPENSTACK_APPLICATION_CREDENTIALS set, it refuses to upload. Mount the etcd Secret as files at /var/etcd/swift-creds with upstream-expected names (tenantName, authURL, ...).