### PR TITLE
fix: use cluster name for POD_NAME

### DIFF
--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -62,10 +62,10 @@ data:
     initial-cluster: default=http://127.0.0.1:2380
 {{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
     initial-advertise-peer-urls:
-      kubernikus:
+      {{ include "fullname" . }}:
         - http://localhost:2380
     advertise-client-urls:
-      kubernikus:
+      {{ include "fullname" . }}:
         - {{ if .Values.secure.enabled }}https{{ else }}http{{ end }}://localhost:2379
 {{- end }}
 {{- end }}
@@ -334,7 +334,7 @@ spec:
 {{- if (semverCompare ">= 1.23-0" .Values.version.kubernetes) }}
             - name: POD_NAME
 {{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
-              value: "kubernikus"
+              value: {{ include "fullname" . }}
 {{- else }}
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Use cluster name for POD_NAME variable instead of generic "kubernikus" in >=1.34 clusters

POD_NAME is used by etcd-backup-restore to get `initial-advertise-peer-urls` and `advertise-client-urls`.

In gardener, etcd is running as sts, so static name could be used there, but in kubernikus we run etcd as a deployment