### PR TITLE
fix: revert etcd-backup-restore to 0.25.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -8316,7 +8316,7 @@ imagesForVersion:
       tag: v3.4.36
     etcdBackup:
       repository: keppel.global.cloud.sap/ccloud/etcdbrctl
-      tag: v0.41.2
+      tag: v0.25.1
     flannel:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/flannel/flannel
       tag: v0.26.3
@@ -8400,7 +8400,7 @@ imagesForVersion:
       tag: v3.4.36
     etcdBackup:
       repository: keppel.global.cloud.sap/ccloud/etcdbrctl
-      tag: v0.41.2
+      tag: v0.25.1
     flannel:
       repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/flannel/flannel
       tag: v0.26.3

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -62,10 +62,10 @@ data:
     initial-cluster: default=http://127.0.0.1:2380
 {{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
     initial-advertise-peer-urls:
-      kubernikus:
+      {{ include "fullname" . }}:
         - http://localhost:2380
     advertise-client-urls:
-      kubernikus:
+      {{ include "fullname" . }}:
         - {{ if .Values.secure.enabled }}https{{ else }}http{{ end }}://localhost:2379
 {{- end }}
 {{- end }}
@@ -334,7 +334,7 @@ spec:
 {{- if (semverCompare ">= 1.23-0" .Values.version.kubernetes) }}
             - name: POD_NAME
 {{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
-              value: "kubernikus"
+              value: {{ include "fullname" . }}
 {{- else }}
               valueFrom:
                 fieldRef:

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -341,9 +341,7 @@ spec:
                   fieldPath: metadata.name
 {{- end }}
             - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: {{ include "fullname" . }} # namespace -- release name -- is used for safe guard check in backup sidecar
 {{- end }}
           volumeMounts:
             - mountPath: /var/lib/etcd


### PR DESCRIPTION
* guard check currently contains release name as a namespace variabe
* pod namespace is used in newer etcd-backup-restore versions