### PR TITLE
chore(etcd): add init container to validate safe_guard namespace

### DIFF
--- a/charts/kube-master/charts/etcd/Chart.yaml
+++ b/charts/kube-master/charts/etcd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: etcd
-version: 0.1.4
+version: 0.1.5

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -185,6 +185,7 @@ spec:
               - key: etcd-clients-backup-key.pem
                 path: etcd-clients-backup-key.pem
 {{- end }}
+{{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
       initContainers:
         - name: safe-guard-check
           image: "{{ include "etcd.image" . }}"
@@ -208,6 +209,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/etcd
               name: data
+{{- end }}
       containers:
         - name: etcd
           ports:

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -185,6 +185,29 @@ spec:
               - key: etcd-clients-backup-key.pem
                 path: etcd-clients-backup-key.pem
 {{- end }}
+      initContainers:
+        - name: safe-guard-check
+          image: "{{ include "etcd.image" . }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ -f /var/lib/etcd/safe_guard ]; then
+                STORED_NAMESPACE=$(cat /var/lib/etcd/safe_guard)
+                if [ "$STORED_NAMESPACE" != "$POD_NAMESPACE" ]; then
+                  echo "Namespace mismatch detected: stored=$STORED_NAMESPACE, current=$POD_NAMESPACE"
+                  echo "Removing safe_guard file due to namespace change"
+                  rm -f /var/lib/etcd/safe_guard
+                fi
+              fi
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /var/lib/etcd
+              name: data
       containers:
         - name: etcd
           ports:

--- a/charts/kube-master/charts/etcd/templates/deployment.yaml
+++ b/charts/kube-master/charts/etcd/templates/deployment.yaml
@@ -185,7 +185,6 @@ spec:
               - key: etcd-clients-backup-key.pem
                 path: etcd-clients-backup-key.pem
 {{- end }}
-{{- if (semverCompare ">= 1.34-0" .Values.version.kubernetes) }}
       initContainers:
         - name: safe-guard-check
           image: "{{ include "etcd.image" . }}"
@@ -209,7 +208,6 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/etcd
               name: data
-{{- end }}
       containers:
         - name: etcd
           ports:


### PR DESCRIPTION
Add an init container that checks if the etcd backup safe_guard file contains the same namespace as the current POD_NAMESPACE. If the namespace has changed (due to recent updates), the safe_guard file is removed to allow the backup restore sidecar to reinitialize.